### PR TITLE
Modify uncompressed model name

### DIFF
--- a/paddlehub/commands/download.py
+++ b/paddlehub/commands/download.py
@@ -60,9 +60,11 @@ class DownloadCommand(BaseCommand):
         else:
             search_result = default_hub_server.get_resource_url(
                 mod_name, resource_type="Module", version=mod_version)
+            self.args.type = "Module"
             if search_result == {}:
                 search_result = default_hub_server.get_resource_url(
                     mod_name, resource_type="Model", version=mod_version)
+                self.args.type = "Model"
         url = search_result.get('url', None)
         except_md5_value = search_result.get('md5', None)
         if not url:
@@ -98,8 +100,10 @@ class DownloadCommand(BaseCommand):
             result, tips, file = default_downloader.uncompress(
                 file=file,
                 dirname=self.args.output_path,
-                delete_file=True,
+                delete_file=False,
                 print_progress=True)
+            if self.args.type == "Model":
+                os.rename(file, "./" + mod_name)
             print(tips)
         return True
 

--- a/paddlehub/module/module.py
+++ b/paddlehub/module/module.py
@@ -192,7 +192,11 @@ class Module(object):
 
     def _init_with_module_file(self, module_dir):
         checker = ModuleChecker(module_dir)
-        checker.check()
+        if checker.check() == False:
+            print(
+                "ERROR! %s is  a model. The command is only for the module type but not the model type."
+                % module_dir)
+            sys.exit(0)
 
         self.helper = ModuleHelper(module_dir)
         with open(self.helper.module_desc_path(), "rb") as fi:


### PR DESCRIPTION
As user download a model and uncompress it, the uncompressed file name  doesn't suit the model. We modify the the uncompressed file name as the model name so as to the user can understand it.