### PR TITLE
Travis CI: Streamline and use flake8 to find Python syntax errors and…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,10 @@
 language: python
 
-python:
-  - "3.6"
+before_install: pip install flake8
 
-sudo: required
+before_script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 
-os:
-  - linux
-
-script:
-  - /bin/bash ./scripts/check_code_style.sh
+script: /bin/bash ./scripts/check_code_style.sh
 
 notifications:
   email:

--- a/paddlehub/dataset/base_cv_dataset.py
+++ b/paddlehub/dataset/base_cv_dataset.py
@@ -19,6 +19,8 @@ from __future__ import print_function
 
 import os
 
+import numpy as np
+
 import paddlehub as hub
 from paddlehub.common.downloader import default_downloader
 

--- a/paddlehub/reader/tokenization.py
+++ b/paddlehub/reader/tokenization.py
@@ -37,7 +37,7 @@ def convert_to_unicode(text):
     elif six.PY2:
         if isinstance(text, str):
             return text.decode("utf-8", "ignore")
-        elif isinstance(text, unicode):
+        elif isinstance(text, unicode):  # noqa
             return text
         else:
             raise ValueError("Unsupported string type: %s" % (type(text)))
@@ -60,7 +60,7 @@ def printable_text(text):
     elif six.PY2:
         if isinstance(text, str):
             return text
-        elif isinstance(text, unicode):
+        elif isinstance(text, unicode):  # noqa
             return text.encode("utf-8")
         else:
             raise ValueError("Unsupported string type: %s" % (type(text)))


### PR DESCRIPTION
… undefined names

The __sudo:__ tag is deprecated in Travis CI and __Linux__ and __Python 3.6__ are defaults.