### PR TITLE
解决MultiLabelClassifierTask中多标签输出结果中标签名顺序错误的问题（base on v1.7）

### DIFF
--- a/paddlehub/finetune/task/classifier_task.py
+++ b/paddlehub/finetune/task/classifier_task.py
@@ -335,7 +335,6 @@ class MultiLabelClassifierTask(ClassifierTask):
             config=config,
             hidden_units=hidden_units,
             metrics_choices=metrics_choices)
-        self.class_name = list(data_reader.label_map.keys())
 
     def _build_net(self):
         cls_feats = fluid.layers.dropout(
@@ -415,7 +414,8 @@ class MultiLabelClassifierTask(ClassifierTask):
                 # NOTE: for MultiLabelClassifierTask, the metrics will be used to evaluate all the label
                 #      and their mean value will also be reported.
                 for index, auc in enumerate(auc_list):
-                    scores["auc_" + self.class_name[index]] = auc_list[index][0]
+                    scores["auc_" + self._base_data_reader.dataset.
+                           label_list[index]] = auc_list[index][0]
             else:
                 raise ValueError("Not Support Metric: \"%s\"" % metric)
         return scores, avg_loss, run_speed
@@ -428,7 +428,6 @@ class MultiLabelClassifierTask(ClassifierTask):
 
     def _postprocessing(self, run_states):
         results = []
-        label_list = list(self._base_data_reader.label_map.keys())
         for batch_state in run_states:
             batch_result = batch_state.run_results
             for sample_id in range(len(batch_result[0])):
@@ -437,7 +436,9 @@ class MultiLabelClassifierTask(ClassifierTask):
                         self._base_data_reader.dataset.num_labels):
                     sample_category_prob = batch_result[category_id][sample_id]
                     sample_category_value = np.argmax(sample_category_prob)
-                    sample_result.append(
-                        {label_list[category_id]: sample_category_value})
+                    sample_result.append({
+                        self._base_data_reader.dataset.label_list[category_id]:
+                        sample_category_value
+                    })
                 results.append(sample_result)
         return results


### PR DESCRIPTION
**BUG说明：**
    `MultiLabelClassifierTask`的`predict`函数返回结果有误。期待的返回形式为`[{label_1:value_1},{label_2:value_2},...,{label_n:value_n}]`，实际为`[{label_x1:value_y1},{label_x2:value_y2},...,{label_xn:value_yn}]`，其中`xi!=yi`，即返回结果中的标签名称与实际该位置的标签不符。

**BUG复现**
1. 切换目录到PaddleHub/demo/multi_label_classification/
2. 运行run_classifier.sh得到finetune的toxic数据集多标签分类模型，该模型3epoch后auc可达98.28%。
3. 修改predict.py文件中，最后预测改为`data=[["Would you both shut up, you don't run wikipedia, especially a stupid kid"]]`，该句在训练数据集中，其标注的多分类标签为`"1,0,0,0,1,0"`，由toxic数据集的训练数据集的header可知其类别依次是`"toxic,severe_toxic,obscene,threat,insult,identity_hate"`。
4. 运行run_predict.sh，可得到步骤3中句子的预测结果为`[[{'severe_toxic': 1}, {'identity_hate': 0}, {'obscene': 0}, {'insult': 0}, {'threat': 1}, {'toxic': 0}]]`。
5. 通过分析我们可以看出。
    - 完全按预测结果来看，则该预测结果完全不准确，其预测该句子的标签为"severe_toxic"和"threat"，而实际标注标签为"toxic"和"insult"。
    - 而从另一方面看，预测结果和标注标签按位置一一比较的话，其各位置的标签值和标注的一致，但其对应的标签名不一致。

**问题分析：**
    返回结果中各标签的value顺序是与用来初始化`reader`的`dataset`中的`label_list`一致的，而返回结果中的表签名称的顺序不是。其问题在于`MultiLabelClassifierTask`重写`_postprocessing`函数时，其确定各位置标签名称时，使用的label_list的生成方法为`list(self._base_data_reader.label_map.keys())`，而显然字典的keys()不会保持标签顺序。

**问题解决：**
    直接使用`dataset`中的`label_list`，该变量中标签名的顺序与输出结果各值对应的标签顺序一致。另外，在评估函数中`_calculate_metrics`也应该改为以`label_list`中的标签顺序为准。

**PS**
    1. 该pull_request改自#732，将base由release/v1.6改为release/v1.7。
    2. 该bug和解决在v1.6验证