### PR TITLE
修复predict图片不能大于512的问题

### DIFF
--- a/modules/image/semantic_segmentation/deeplabv3p_resnet50_voc/module.py
+++ b/modules/image/semantic_segmentation/deeplabv3p_resnet50_voc/module.py
@@ -76,7 +76,7 @@ class DeepLabV3PResnet50(nn.Layer):
                                    backbone_channels, aspp_ratios,
                                    aspp_out_channels, align_corners)
         self.align_corners = align_corners
-        self.transforms = T.Compose([T.Padding(target_size=(512, 512)), T.Normalize()])
+        self.transforms = T.Compose([T.Normalize()])
 
         if pretrained is not None:
             model_dict = paddle.load(pretrained)

--- a/modules/image/semantic_segmentation/ocrnet_hrnetw18_voc/module.py
+++ b/modules/image/semantic_segmentation/ocrnet_hrnetw18_voc/module.py
@@ -69,7 +69,7 @@ class OCRNetHRNetW18(nn.Layer):
             ocr_mid_channels=ocr_mid_channels,
             ocr_key_channels=ocr_key_channels)
         self.align_corners = align_corners
-        self.transforms = T.Compose([T.Padding(target_size=(512, 512)), T.Normalize()])
+        self.transforms = T.Compose([T.Normalize()])
 
         if pretrained is not None:
             model_dict = paddle.load(pretrained)


### PR DESCRIPTION
将module里面的transform中对图片大小的限制去掉