### PR TITLE
Update utils.py

### DIFF
--- a/modules/image/text_recognition/chinese_ocr_db_crnn_server/utils.py
+++ b/modules/image/text_recognition/chinese_ocr_db_crnn_server/utils.py
@@ -172,6 +172,6 @@ def sorted_boxes(dt_boxes):
 
 def base64_to_cv2(b64str):
     data = base64.b64decode(b64str.encode('utf8'))
-    data = np.fromstring(data, np.uint8)
+    data = np.frombuffer(data, np.uint8)
     data = cv2.imdecode(data, cv2.IMREAD_COLOR)
     return data


### PR DESCRIPTION
The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead