### PR TITLE
Correcting the error in example of Chinese segmentation in README_ch.md and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ please add WeChat above and send "Hub" to the robot, the robot will invite you t
 <a name="QuickStart"></a>
 ## QuickStart
 
+### The installation of required components.
 ```python
 # install paddlepaddle with gpu
 # !pip install --upgrade paddlepaddle-gpu
@@ -132,8 +133,11 @@ please add WeChat above and send "Hub" to the robot, the robot will invite you t
 
 # install paddlehub
 !pip install --upgrade paddlehub
+```
 
+### The simplest cases of Chinese word segmentation.
 
+```python
 import paddlehub as hub
 
 lac = hub.Module(name="lac")
@@ -143,6 +147,15 @@ results = lac.cut(text=test_text, use_gpu=False, batch_size=1, return_tag=True)
 print(results)
 #{'word': ['今天', '是', '个', '好天气', '。'], 'tag': ['TIME', 'v', 'q', 'n', 'w']}
 ```
+### The simplest command of deploying lac service.
+</div>
+
+```python
+!hub serving start -m lac
+```
+
+More model description, please refer [Models List](https://www.paddlepaddle.org.cn/hublist)
+
 More API for transfer learning, please refer [Tutorial](https://paddlehub.readthedocs.io/en/release-v2.1/transfer_learning_index.html)
 
 <a name="License"></a>

--- a/README_ch.md
+++ b/README_ch.md
@@ -154,10 +154,16 @@ test_text = ["今天是个好天气。"]
 results = lac.cut(text=test_text, use_gpu=False, batch_size=1, return_tag=True)
 print(results)
 #{'word': ['今天', '是', '个', '好天气', '。'], 'tag': ['TIME', 'v', 'q', 'n', 'w']}
-
-# 一行代码启动serving 服务，更多模型搜索可参考 https://www.paddlepaddle.org.cn/hublist
-！hub serving start -m lac
 ```
+
+### 一行代码启动lac（词法分析）服务，
+</div>
+
+```python
+!hub serving start -m lac
+```
+
+ 更多模型介绍可以参考[模型搜索](https://www.paddlepaddle.org.cn/hublist)
 
  更多迁移学习能力可以参考[教程文档](https://paddlehub.readthedocs.io/zh_CN/release-v2.1/transfer_learning_index.html)
 

--- a/README_ch.md
+++ b/README_ch.md
@@ -139,13 +139,18 @@
 
 [【零基础linux安装并实现图像风格迁移】](./docs/docs_ch/get_start/linux_quickstart.md)
 
-### 极简中文分词案例  
+### 快速安装相关组件
 </div>
 
 ```python
 !pip install --upgrade paddlepaddle -i https://mirror.baidu.com/pypi/simple
 !pip install --upgrade paddlehub -i https://mirror.baidu.com/pypi/simple
+```
 
+### 极简中文分词案例  
+</div>
+
+```python
 import paddlehub as hub
 
 lac = hub.Module(name="lac")
@@ -156,14 +161,14 @@ print(results)
 #{'word': ['今天', '是', '个', '好天气', '。'], 'tag': ['TIME', 'v', 'q', 'n', 'w']}
 ```
 
-### 一行代码启动lac（词法分析）服务，
+### 一行代码部署lac（词法分析）模型
 </div>
 
 ```python
 !hub serving start -m lac
 ```
 
- 更多模型介绍可以参考[模型搜索](https://www.paddlepaddle.org.cn/hublist)
+ 欢迎用户通过[模型搜索](https://www.paddlepaddle.org.cn/hublist)发现更多实用的预训练模型！
 
  更多迁移学习能力可以参考[教程文档](https://paddlehub.readthedocs.io/zh_CN/release-v2.1/transfer_learning_index.html)
 


### PR DESCRIPTION
在原先的“极简中文分词案例”中，存在下述问题：
A、最后两句不属于案例本身，放在一起执行，启动LAC（词法分析）服务后程序不停止。
B、在最后1句中，“hub”前面的“！”有问题，应该修改为“!”。
C、倒数第2行注释“启动serving服务”不准确，应该是“启动lac（词法分析）服务”。
D、在倒数第2行注释中，“更多模型搜索可参考***”和前面注释不搭配。
针对上述问题，对这部分代码进行调整，经测试可以正常运行。