### PR TITLE
Matching mistaken between demo\text_classification\README.md and demo\text_classification\train.py

### DIFF
--- a/demo/sequence_labeling/README.md
+++ b/demo/sequence_labeling/README.md
@@ -91,6 +91,8 @@ train_dataset = hub.datasets.MSRA_NER(
     tokenizer=model.get_tokenizer(), max_seq_len=128, mode='train')
 dev_dataset = hub.datasets.MSRA_NER(
     tokenizer=model.get_tokenizer(), max_seq_len=128, mode='dev')
+test_dataset = hub.datasets.MSRA_NER(
+    tokenizer=model.get_tokenizer(), max_seq_len=128, mode='test')
 ```
 
 * `tokenizer`：表示该module所需用到的tokenizer，其将对输入文本完成切词，并转化成module运行所需模型输入格式。
@@ -106,7 +108,7 @@ dev_dataset = hub.datasets.MSRA_NER(
 
 ```python
 optimizer = paddle.optimizer.AdamW(learning_rate=5e-5, parameters=model.parameters())
-trainer = hub.Trainer(model, optimizer, checkpoint_dir='test_ernie_token_cls', use_gpu=False)
+trainer = hub.Trainer(model, optimizer, checkpoint_dir='test_ernie_token_cls', use_gpu=True)
 
 trainer.train(train_dataset, epochs=3, batch_size=32, eval_dataset=dev_dataset)
 

--- a/demo/text_classification/README.md
+++ b/demo/text_classification/README.md
@@ -80,6 +80,8 @@ train_dataset = hub.datasets.ChnSentiCorp(
     tokenizer=model.get_tokenizer(), max_seq_len=128, mode='train')
 dev_dataset = hub.datasets.ChnSentiCorp(
     tokenizer=model.get_tokenizer(), max_seq_len=128, mode='dev')
+test_dataset = hub.datasets.ChnSentiCorp(
+    tokenizer=model.get_tokenizer(), max_seq_len=128, mode='test')
 ```
 
 * `tokenizer`：表示该module所需用到的tokenizer，其将对输入文本完成切词，并转化成module运行所需模型输入格式。
@@ -95,7 +97,7 @@ dev_dataset = hub.datasets.ChnSentiCorp(
 
 ```python
 optimizer = paddle.optimizer.Adam(learning_rate=5e-5, parameters=model.parameters())
-trainer = hub.Trainer(model, optimizer, checkpoint_dir='test_ernie_text_cls')
+trainer = hub.Trainer(model, optimizer, checkpoint_dir='test_ernie_text_cls', use_gpu=True)
 
 trainer.train(train_dataset, epochs=3, batch_size=32, eval_dataset=dev_dataset)
 


### PR DESCRIPTION
文本分类示例的文件“README.md”和训练代码“train.py”存在两处不匹配：
A、GPU设置
文件“train.py”采用GPU训练，效果和用户体验都很好。
文档“README.md”在开始通过“export CUDA_VISIBLE_DEVICES=0”表示使用0号GPU卡，但是训练时却采用默认设置，其值为“use_gpu=False”，训练速度特别慢，用户体验不好。
因此，将trainer定义中的GPU设置修改为“use_gpu=True”。
B、测试集加载
文档“README.md”缺少加载测试集“test_dataset”的语句，使用trainer.evaluate进行模型评估时出错。
因此，添加加载测试集“test_dataset”的语句，如下：
test_dataset = hub.datasets.ChnSentiCorp(
tokenizer=model.get_tokenizer(), max_seq_len=128, mode='test')