### PR TITLE
Mismatching between data mode description and the corresponding code in demo\text_classification\README.md

### DIFF
--- a/demo/sequence_labeling/README.md
+++ b/demo/sequence_labeling/README.md
@@ -91,6 +91,8 @@ train_dataset = hub.datasets.MSRA_NER(
     tokenizer=model.get_tokenizer(), max_seq_len=128, mode='train')
 dev_dataset = hub.datasets.MSRA_NER(
     tokenizer=model.get_tokenizer(), max_seq_len=128, mode='dev')
+test_dataset = hub.datasets.MSRA_NER(
+    tokenizer=model.get_tokenizer(), max_seq_len=128, mode='test')
 ```
 
 * `tokenizer`：表示该module所需用到的tokenizer，其将对输入文本完成切词，并转化成module运行所需模型输入格式。
@@ -106,7 +108,7 @@ dev_dataset = hub.datasets.MSRA_NER(
 
 ```python
 optimizer = paddle.optimizer.AdamW(learning_rate=5e-5, parameters=model.parameters())
-trainer = hub.Trainer(model, optimizer, checkpoint_dir='test_ernie_token_cls', use_gpu=False)
+trainer = hub.Trainer(model, optimizer, checkpoint_dir='test_ernie_token_cls', use_gpu=True)
 
 trainer.train(train_dataset, epochs=3, batch_size=32, eval_dataset=dev_dataset)
 

--- a/demo/sequence_labeling/README.md
+++ b/demo/sequence_labeling/README.md
@@ -96,7 +96,7 @@ test_dataset = hub.datasets.MSRA_NER(
 ```
 
 * `tokenizer`：表示该module所需用到的tokenizer，其将对输入文本完成切词，并转化成module运行所需模型输入格式。
-* `mode`：选择数据模式，可选项有 `train`, `test`, `val`， 默认为`train`。
+* `mode`：选择数据模式，可选项有 `train`, `test`, `dev`， 默认为`train`。
 * `max_seq_len`：ERNIE/BERT模型使用的最大序列长度，若出现显存不足，请适当调低这一参数。
 
 预训练模型ERNIE对中文数据的处理是以字为单位，tokenizer作用为将原始输入文本转化成模型model可以接受的输入数据形式。 PaddleHub 2.0中的各种预训练模型已经内置了相应的tokenizer，可以通过`model.get_tokenizer`方法获取。

--- a/demo/text_classification/README.md
+++ b/demo/text_classification/README.md
@@ -80,6 +80,8 @@ train_dataset = hub.datasets.ChnSentiCorp(
     tokenizer=model.get_tokenizer(), max_seq_len=128, mode='train')
 dev_dataset = hub.datasets.ChnSentiCorp(
     tokenizer=model.get_tokenizer(), max_seq_len=128, mode='dev')
+test_dataset = hub.datasets.ChnSentiCorp(
+    tokenizer=model.get_tokenizer(), max_seq_len=128, mode='test')
 ```
 
 * `tokenizer`：表示该module所需用到的tokenizer，其将对输入文本完成切词，并转化成module运行所需模型输入格式。
@@ -95,7 +97,7 @@ dev_dataset = hub.datasets.ChnSentiCorp(
 
 ```python
 optimizer = paddle.optimizer.Adam(learning_rate=5e-5, parameters=model.parameters())
-trainer = hub.Trainer(model, optimizer, checkpoint_dir='test_ernie_text_cls')
+trainer = hub.Trainer(model, optimizer, checkpoint_dir='test_ernie_text_cls', use_gpu=True)
 
 trainer.train(train_dataset, epochs=3, batch_size=32, eval_dataset=dev_dataset)
 

--- a/demo/text_classification/README.md
+++ b/demo/text_classification/README.md
@@ -85,7 +85,7 @@ test_dataset = hub.datasets.ChnSentiCorp(
 ```
 
 * `tokenizer`：表示该module所需用到的tokenizer，其将对输入文本完成切词，并转化成module运行所需模型输入格式。
-* `mode`：选择数据模式，可选项有 `train`, `test`, `val`， 默认为`train`。
+* `mode`：选择数据模式，可选项有 `train`, `test`, `dev`， 默认为`train`。
 * `max_seq_len`：ERNIE/BERT模型使用的最大序列长度，若出现显存不足，请适当调低这一参数。
 
 预训练模型ERNIE对中文数据的处理是以字为单位，tokenizer作用为将原始输入文本转化成模型model可以接受的输入数据形式。 PaddleHub 2.0中的各种预训练模型已经内置了相应的tokenizer，可以通过`model.get_tokenizer`方法获取。


### PR DESCRIPTION
文本分类示例文件“README.md”在Step2下方的数据模式说明中，“mode”的可选项有“train, test, val”，分别对应训练集、测试集和验证集，和上方代码不符合，如下：
 
![image](https://user-images.githubusercontent.com/89008682/148539678-725d2675-7548-4800-a50e-90596a04cd4c.png)

因此，将Step2下方数据模式说明中的“val”修改为“dev”。