### PR TITLE
Mismatching between result prediction and the corresponding code in demo\sequence_labeling\README.md

### DIFF
--- a/demo/sequence_labeling/README.md
+++ b/demo/sequence_labeling/README.md
@@ -91,10 +91,12 @@ train_dataset = hub.datasets.MSRA_NER(
     tokenizer=model.get_tokenizer(), max_seq_len=128, mode='train')
 dev_dataset = hub.datasets.MSRA_NER(
     tokenizer=model.get_tokenizer(), max_seq_len=128, mode='dev')
+test_dataset = hub.datasets.MSRA_NER(
+    tokenizer=model.get_tokenizer(), max_seq_len=128, mode='test')
 ```
 
 * `tokenizer`：表示该module所需用到的tokenizer，其将对输入文本完成切词，并转化成module运行所需模型输入格式。
-* `mode`：选择数据模式，可选项有 `train`, `test`, `val`， 默认为`train`。
+* `mode`：选择数据模式，可选项有 `train`, `test`, `dev`， 默认为`train`。
 * `max_seq_len`：ERNIE/BERT模型使用的最大序列长度，若出现显存不足，请适当调低这一参数。
 
 预训练模型ERNIE对中文数据的处理是以字为单位，tokenizer作用为将原始输入文本转化成模型model可以接受的输入数据形式。 PaddleHub 2.0中的各种预训练模型已经内置了相应的tokenizer，可以通过`model.get_tokenizer`方法获取。
@@ -106,7 +108,7 @@ dev_dataset = hub.datasets.MSRA_NER(
 
 ```python
 optimizer = paddle.optimizer.AdamW(learning_rate=5e-5, parameters=model.parameters())
-trainer = hub.Trainer(model, optimizer, checkpoint_dir='test_ernie_token_cls', use_gpu=False)
+trainer = hub.Trainer(model, optimizer, checkpoint_dir='test_ernie_token_cls', use_gpu=True)
 
 trainer.train(train_dataset, epochs=3, batch_size=32, eval_dataset=dev_dataset)
 
@@ -181,7 +183,7 @@ model = hub.Module(
     label_map=label_map,
 )
 
-results = model.predict(data, max_seq_len=50, batch_size=1, use_gpu=False)
+results = model.predict(data, max_seq_len=128, batch_size=1, use_gpu=True)
 for idx, text in enumerate(text_a):
     print(f'Data: {text} \t Lable: {", ".join(results[idx][1:len(text)+1])}')
 ```


### PR DESCRIPTION
序列标注示例的文件“README.md”和推理代码“predict.py”存在两处不匹配：
A、GPU设置
文件“predict.py”采用GPU推理，文档“README.md”采用CPU推理，速度较慢，用户体验不好。
因此，将model.predict函数中的GPU设置修改为“use_gpu=True”。
B、最大序列长度
文件“predict.py”设置“max_seq_len = 128”，和模型训练时的相同。
文档“README.md”设置“max_seq_len = 50”，所给4个示例句子的长度分别是：70、44、53、34，在处理第1句和第3句时，返回的标注结果长度仅为50，小于句子实际长度，造成信息丢失。
因此，将model.predict函数中的最大序列长度设置修改为“max_seq_len=128”。