### PR TITLE
fix deeplabv3p_xception65_humanseg inference client bug

### DIFF
--- a/modules/image/semantic_segmentation/deeplabv3p_xception65_humanseg/README.md
+++ b/modules/image/semantic_segmentation/deeplabv3p_xception65_humanseg/README.md
@@ -131,34 +131,35 @@
 
   - 配置好服务端，以下数行代码即可实现发送预测请求，获取预测结果
 
-      ```python
-      import requests
-      import json
-      import cv2
-      import base64
-      import numpy as np
-
-
-      def cv2_to_base64(image):
-          data = cv2.imencode('.jpg', image)[1]
-          return base64.b64encode(data.tostring()).decode('utf8')
-
-
-      def base64_to_cv2(b64str):
-          data = base64.b64decode(b64str.encode('utf8'))
-          data = np.fromstring(data, np.uint8)
-          data = cv2.imdecode(data, cv2.IMREAD_COLOR)
-          return data
-
-      # 发送HTTP请求
-      data = {'images':[cv2_to_base64(cv2.imread("/PATH/TO/IMAGE"))]}
-      headers = {"Content-type": "application/json"}
-      url = "http://127.0.0.1:8866/predict/deeplabv3p_xception65_humanseg"
-      r = requests.post(url=url, headers=headers, # 保存图片
-      mask =cv2.cvtColor(base64_to_cv2(r.json()["results"][0]['data']), cv2.COLOR_BGR2GRAY)
-      rgba = np.concatenate((org_im, np.expand_dims(mask, axis=2)), axis=2)
-      cv2.imwrite("segment_human_server.png", rgba)
-      ```
+  - ```python
+    import requests
+    import json
+    import cv2
+    import base64
+    import numpy as np
+  
+  
+    def cv2_to_base64(image):
+        data = cv2.imencode('.jpg', image)[1]
+        return base64.b64encode(data.tostring()).decode('utf8')
+  
+  
+    def base64_to_cv2(b64str):
+        data = base64.b64decode(b64str.encode('utf8'))
+        data = np.fromstring(data, np.uint8)
+        data = cv2.imdecode(data, cv2.IMREAD_COLOR)
+        return data
+  
+    org_im = cv2.imread("/PATH/TO/IMAGE")
+    # 发送HTTP请求
+    data = {'images':[cv2_to_base64(org_im)]}
+    headers = {"Content-type": "application/json"}
+    url = "http://127.0.0.1:8866/predict/deeplabv3p_xception65_humanseg"
+    r = requests.post(url=url, headers=headers, data=json.dumps(data))# 保存图片
+    mask =cv2.cvtColor(base64_to_cv2(r.json()["results"][0]['data']), cv2.COLOR_BGR2GRAY)
+    rgba = np.concatenate((org_im, np.expand_dims(mask, axis=2)), axis=2)
+    cv2.imwrite("segment_human_server.png", rgba)
+    ```
 
 ## 五、更新历史
 

--- a/modules/image/semantic_segmentation/deeplabv3p_xception65_humanseg/README_en.md
+++ b/modules/image/semantic_segmentation/deeplabv3p_xception65_humanseg/README_en.md
@@ -128,34 +128,35 @@
 
   - With a configured server, use the following lines of code to send the prediction request and obtain the result
 
-    - ```python
-      import requests
-      import json
-      import cv2
-      import base64
-      import numpy as np
+  - ```python
+    import requests
+    import json
+    import cv2
+    import base64
+    import numpy as np
 
 
-      def cv2_to_base64(image):
-          data = cv2.imencode('.jpg', image)[1]
-          return base64.b64encode(data.tostring()).decode('utf8')
+    def cv2_to_base64(image):
+        data = cv2.imencode('.jpg', image)[1]
+        return base64.b64encode(data.tostring()).decode('utf8')
 
 
-      def base64_to_cv2(b64str):
-          data = base64.b64decode(b64str.encode('utf8'))
-          data = np.fromstring(data, np.uint8)
-          data = cv2.imdecode(data, cv2.IMREAD_COLOR)
-          return data
+    def base64_to_cv2(b64str):
+        data = base64.b64decode(b64str.encode('utf8'))
+        data = np.fromstring(data, np.uint8)
+        data = cv2.imdecode(data, cv2.IMREAD_COLOR)
+        return data
 
-      # Send an HTTP request
-      data = {'images':[cv2_to_base64(cv2.imread("/PATH/TO/IMAGE"))]}
-      headers = {"Content-type": "application/json"}
-      url = "http://127.0.0.1:8866/predict/deeplabv3p_xception65_humanseg"
-      r = requests.post(url=url, headers=headers,
-      mask =cv2.cvtColor(base64_to_cv2(r.json()["results"][0]['data']), cv2.COLOR_BGR2GRAY)
-      rgba = np.concatenate((org_im, np.expand_dims(mask, axis=2)), axis=2)
-      cv2.imwrite("segment_human_server.png", rgba)
-      ```
+    org_im = cv2.imread("/PATH/TO/IMAGE")
+    # Send an HTTP request
+    data = {'images':[cv2_to_base64(org_im)]}
+    headers = {"Content-type": "application/json"}
+    url = "http://127.0.0.1:8866/predict/deeplabv3p_xception65_humanseg"
+    r = requests.post(url=url, headers=headers, data=json.dumps(data))
+    mask =cv2.cvtColor(base64_to_cv2(r.json()["results"][0]['data']), cv2.COLOR_BGR2GRAY)
+    rgba = np.concatenate((org_im, np.expand_dims(mask, axis=2)), axis=2)
+    cv2.imwrite("segment_human_server.png", rgba)
+    ```
 ## V. Release Note
 
 - 1.0.0


### PR DESCRIPTION
fix deeplabv3p_xception65_humanseg inference client bug

复现步骤：
1、hub serving start -m deeplabv3p_xception65_humanseg
2、修改图片路劲后，使用下面代码进行预测正常预测
```
import requests
import json
import cv2
import base64
import numpy as np


def cv2_to_base64(image):
    data = cv2.imencode('.jpg', image)[1]
    return base64.b64encode(data.tostring()).decode('utf8')


def base64_to_cv2(b64str):
    data = base64.b64decode(b64str.encode('utf8'))
    data = np.fromstring(data, np.uint8)
    data = cv2.imdecode(data, cv2.IMREAD_COLOR)
    return data

org_im = cv2.imread("/PATH/TO/IMAGE")
# 发送HTTP请求
data = {'images':[cv2_to_base64(org_im)]}
headers = {"Content-type": "application/json"}
url = "http://127.0.0.1:8866/predict/deeplabv3p_xception65_humanseg"
r = requests.post(url=url, headers=headers, data=json.dumps(data))# 保存图片
mask =cv2.cvtColor(base64_to_cv2(r.json()["results"][0]['data']), cv2.COLOR_BGR2GRAY)
rgba = np.concatenate((org_im, np.expand_dims(mask, axis=2)), axis=2)
cv2.imwrite("segment_human_server.png", rgba)
```
3、原始预测代码如：
![a](https://user-images.githubusercontent.com/29157444/178642391-f88a4644-7bd1-4219-aff3-ab33e8beacb1.png)
