### PR TITLE
fix a bug of tokenize on win (int32 -> int64)

### DIFF
--- a/modules/image/text_to_image/disco_diffusion_clip_rn101/clip/clip/utils.py
+++ b/modules/image/text_to_image/disco_diffusion_clip_rn101/clip/clip/utils.py
@@ -62,7 +62,7 @@ def tokenize(texts: Union[str, List[str]], context_length: int = 77):
     for i, tokens in enumerate(all_tokens):
         if len(tokens) > context_length:
             raise RuntimeError(f"Input {texts[i]} is too long for context length {context_length}")
-        result[i, :len(tokens)] = paddle.Tensor(np.array(tokens), dtype='int64')
+        result[i, :len(tokens)] = paddle.to_tensor(np.array(tokens), dtype='int64')
 
     return result
 

--- a/modules/image/text_to_image/disco_diffusion_clip_rn101/clip/clip/utils.py
+++ b/modules/image/text_to_image/disco_diffusion_clip_rn101/clip/clip/utils.py
@@ -62,7 +62,7 @@ def tokenize(texts: Union[str, List[str]], context_length: int = 77):
     for i, tokens in enumerate(all_tokens):
         if len(tokens) > context_length:
             raise RuntimeError(f"Input {texts[i]} is too long for context length {context_length}")
-        result[i, :len(tokens)] = paddle.Tensor(np.array(tokens))
+        result[i, :len(tokens)] = paddle.Tensor(np.array(tokens), dtype='int64')
 
     return result
 

--- a/modules/image/text_to_image/disco_diffusion_clip_rn50/clip/clip/utils.py
+++ b/modules/image/text_to_image/disco_diffusion_clip_rn50/clip/clip/utils.py
@@ -62,7 +62,7 @@ def tokenize(texts: Union[str, List[str]], context_length: int = 77):
     for i, tokens in enumerate(all_tokens):
         if len(tokens) > context_length:
             raise RuntimeError(f"Input {texts[i]} is too long for context length {context_length}")
-        result[i, :len(tokens)] = paddle.Tensor(np.array(tokens), dtype='int64')
+        result[i, :len(tokens)] = paddle.to_tensor(np.array(tokens), dtype='int64')
 
     return result
 

--- a/modules/image/text_to_image/disco_diffusion_clip_rn50/clip/clip/utils.py
+++ b/modules/image/text_to_image/disco_diffusion_clip_rn50/clip/clip/utils.py
@@ -62,7 +62,7 @@ def tokenize(texts: Union[str, List[str]], context_length: int = 77):
     for i, tokens in enumerate(all_tokens):
         if len(tokens) > context_length:
             raise RuntimeError(f"Input {texts[i]} is too long for context length {context_length}")
-        result[i, :len(tokens)] = paddle.Tensor(np.array(tokens))
+        result[i, :len(tokens)] = paddle.Tensor(np.array(tokens), dtype='int64')
 
     return result
 

--- a/modules/image/text_to_image/disco_diffusion_clip_vitb32/clip/clip/utils.py
+++ b/modules/image/text_to_image/disco_diffusion_clip_vitb32/clip/clip/utils.py
@@ -62,7 +62,7 @@ def tokenize(texts: Union[str, List[str]], context_length: int = 77):
     for i, tokens in enumerate(all_tokens):
         if len(tokens) > context_length:
             raise RuntimeError(f"Input {texts[i]} is too long for context length {context_length}")
-        result[i, :len(tokens)] = paddle.Tensor(np.array(tokens), dtype='int64')
+        result[i, :len(tokens)] = paddle.to_tensor(np.array(tokens), dtype='int64')
 
     return result
 

--- a/modules/image/text_to_image/disco_diffusion_clip_vitb32/clip/clip/utils.py
+++ b/modules/image/text_to_image/disco_diffusion_clip_vitb32/clip/clip/utils.py
@@ -62,7 +62,7 @@ def tokenize(texts: Union[str, List[str]], context_length: int = 77):
     for i, tokens in enumerate(all_tokens):
         if len(tokens) > context_length:
             raise RuntimeError(f"Input {texts[i]} is too long for context length {context_length}")
-        result[i, :len(tokens)] = paddle.Tensor(np.array(tokens))
+        result[i, :len(tokens)] = paddle.Tensor(np.array(tokens), dtype='int64')
 
     return result
 

--- a/modules/image/text_to_image/disco_diffusion_cnclip_vitb16/cn_clip/clip/utils.py
+++ b/modules/image/text_to_image/disco_diffusion_cnclip_vitb16/cn_clip/clip/utils.py
@@ -46,7 +46,7 @@ def tokenize(texts: Union[str, List[str]], context_length: int = 64):
 
     for i, tokens in enumerate(all_tokens):
         assert len(tokens) <= context_length
-        result[i, :len(tokens)] = paddle.to_tensor(tokens)
+        result[i, :len(tokens)] = paddle.to_tensor(tokens, dtype='int64')
 
     return result
 

--- a/modules/image/text_to_image/disco_diffusion_ernievil_base/vit_b_16x/ernievil2/utils/utils.py
+++ b/modules/image/text_to_image/disco_diffusion_ernievil_base/vit_b_16x/ernievil2/utils/utils.py
@@ -49,7 +49,7 @@ def tokenize(texts: Union[str, List[str]], context_length: int = 64):
 
     for i, tokens in enumerate(all_tokens):
         assert len(tokens) <= context_length
-        result[i, :len(tokens)] = paddle.to_tensor(tokens)
+        result[i, :len(tokens)] = paddle.to_tensor(tokens, dtype='int64')
 
     return result
 

--- a/modules/image/text_to_image/stable_diffusion/clip/clip/utils.py
+++ b/modules/image/text_to_image/stable_diffusion/clip/clip/utils.py
@@ -59,7 +59,7 @@ def tokenize(texts: Union[str, List[str]], context_length: int = 77):
     for i, tokens in enumerate(all_tokens):
         if len(tokens) > context_length:
             raise RuntimeError(f"Input {texts[i]} is too long for context length {context_length}")
-        result[i, :len(tokens)] = paddle.Tensor(np.array(tokens))
+        result[i, :len(tokens)] = paddle.Tensor(np.array(tokens), dtype='int64')
 
     return result
 

--- a/modules/image/text_to_image/stable_diffusion/clip/clip/utils.py
+++ b/modules/image/text_to_image/stable_diffusion/clip/clip/utils.py
@@ -59,7 +59,7 @@ def tokenize(texts: Union[str, List[str]], context_length: int = 77):
     for i, tokens in enumerate(all_tokens):
         if len(tokens) > context_length:
             raise RuntimeError(f"Input {texts[i]} is too long for context length {context_length}")
-        result[i, :len(tokens)] = paddle.Tensor(np.array(tokens), dtype='int64')
+        result[i, :len(tokens)] = paddle.to_tensor(np.array(tokens), dtype='int64')
 
     return result
 


### PR DESCRIPTION
* win numpy 默认整数类型为 int32，如果没有指定类型的话，模型会报错
* AIStudio：https://aistudio.baidu.com/aistudio/projectdetail/4559030