### PR TITLE
add environment version filter for module download

### DIFF
--- a/paddlehub/server/server_source.py
+++ b/paddlehub/server/server_source.py
@@ -12,16 +12,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import json
-import requests
 from typing import List
+
+import requests
 
 import paddlehub
 from paddlehub.utils import platform
+from paddlehub.utils.utils import convert_version
+from paddlehub.utils.utils import Version
 
 
 class ServerConnectionError(Exception):
+
     def __init__(self, url: str):
         self.url = url
 
@@ -76,26 +79,28 @@ class ServerSource(object):
 
         result = self.request(path='search', params=params)
         if result['status'] == 0 and len(result['data']) > 0:
-            return result['data']
+            results = []
+            for module_info in result['data']:
+                should_skip = False
+                if module_info['paddle_version']:
+                    paddle_version_intervals = convert_version(module_info['paddle_version'])
+                    for module_paddle_version in paddle_version_intervals:
+                        if not Version(params['paddle_version']).match(module_paddle_version):
+                            should_skip = True
+                if module_info['hub_version']:
+                    hub_version_intervals = convert_version(module_info['hub_version'])
+                    for module_hub_version in hub_version_intervals:
+                        if not Version(params['hub_version']).match(module_hub_version):
+                            should_skip = True
+                if should_skip:
+                    continue
+                results.append(module_info)
+            if results:
+                return results
         return None
 
     def get_module_compat_info(self, name: str) -> dict:
         '''Get the version compatibility information of the model.'''
-
-        def _convert_version(version: str) -> List:
-            result = []
-            # from [1.5.4, 2.0.0] -> 1.5.4,2.0.0
-            version = version.replace(' ', '')[1:-1]
-            version = version.split(',')
-            if version[0] != '-1.0.0':
-                result.append('>={}'.format(version[0]))
-
-            if len(version) > 1:
-                if version[1] != '99.0.0':
-                    result.append('<={}'.format(version[1]))
-
-            return result
-
         params = {'name': name}
         result = self.request(path='info', params=params)
         if result['status'] == 0 and len(result['data']) > 0:
@@ -103,8 +108,8 @@ class ServerSource(object):
             for _info in result['data']['info']:
                 infos[_info['version']] = {
                     'url': _info['url'],
-                    'paddle_version': _convert_version(_info['paddle_version']),
-                    'hub_version': _convert_version(_info['hub_version'])
+                    'paddle_version': convert_version(_info['paddle_version']),
+                    'hub_version': convert_version(_info['hub_version'])
                 }
             return infos
 

--- a/paddlehub/utils/utils.py
+++ b/paddlehub/utils/utils.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import base64
 import contextlib
 import hashlib
@@ -25,7 +24,8 @@ import tempfile
 import time
 import traceback
 import types
-from typing import Generator, List
+from typing import Generator
+from typing import List
 from urllib.parse import urlparse
 
 import cv2
@@ -410,14 +410,13 @@ def extract_melspectrogram(y,
         logger.error('Failed to import librosa. Please check that librosa and numba are correctly installed.')
         raise
 
-    s = librosa.stft(
-        y,
-        n_fft=window_size,
-        hop_length=hop_size,
-        win_length=window_size,
-        window=window,
-        center=center,
-        pad_mode=pad_mode)
+    s = librosa.stft(y,
+                     n_fft=window_size,
+                     hop_length=hop_size,
+                     win_length=window_size,
+                     window=window,
+                     center=center,
+                     pad_mode=pad_mode)
 
     power = np.abs(s)**2
     melW = librosa.filters.mel(sr=sample_rate, n_fft=window_size, n_mels=mel_bins, fmin=fmin, fmax=fmax)
@@ -425,3 +424,23 @@ def extract_melspectrogram(y,
     db = librosa.power_to_db(mel, ref=ref, amin=amin, top_db=None)
     db = db.transpose()
     return db
+
+
+def convert_version(version: str) -> List:
+    '''
+    Convert version string in modules dataset such as [1.5.4, 2.0.0] to >=1.5.4 and <=2.0.0
+    '''
+    result = []
+    # from [1.5.4, 2.0.0] -> 1.5.4,2.0.0
+    version = version.replace(' ', '')[1:-1]
+    version = version.split(',')
+    # Although -1.0.0 represents no least version limited,
+    # we should also consider when users write another minus number
+    if not version[0].startswith('-'):
+        result.append('>={}'.format(version[0]))
+
+    if len(version) > 1:
+        if version[1] != '99.0.0':
+            result.append('<={}'.format(version[1]))
+
+    return result


### PR DESCRIPTION
1. Hub server的服务器端加入了对客户端paddle和paddlehub版本的判定过滤。客户端也加入代码在hub 2.3.1之后来实现对服务器返回结果的再次判定。

# 测试效果：
paddle 版本：2.3.2    hub版本： 2.2.0

1. xception71_imagenet（版本限制 paddle  <=2.1.0 , paddlehub <= 2.2.0 ）: 
下载失败，提示用户版本兼容信息
![image](https://user-images.githubusercontent.com/22424850/201509631-22775700-b5c1-46a9-9ca2-bbee7d41a4b9.png)

2. yolov3_darknet53_coco2017 (版本限制 paddle >=1.6.2, paddlehub >=1.6.0)
正常下载
<img width="801" alt="image" src="https://user-images.githubusercontent.com/22424850/201509673-beac8c28-ab23-4e80-b957-95fb04588007.png">  

将paddle版本降低至2.1.0以下
3. xception71_imagenet（版本限制 paddle  <=2.1.0 , paddlehub <= 2.2.0） :
正常下载
<img width="902" alt="image" src="https://user-images.githubusercontent.com/22424850/201509905-12d36e40-df6f-4f2d-b620-c5f0c4ebf000.png">






