### PR TITLE
bump paddlehub to v2.3.1

### DIFF
--- a/paddlehub/__init__.py
+++ b/paddlehub/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '2.3.0'
+__version__ = '2.3.1'
 
 import paddle
 from packaging.version import Version


### PR DESCRIPTION
1. bump paddlehub to v2.3.1. 

# ChangeLog:
### 【1、框架和模块代码升级】
 - hub install新增模块对于环境版本兼容性的判定 [PR2145](https://github.com/PaddlePaddle/PaddleHub/pull/2145)
 - hub serving新增对于模块gradio app的支持 [PR2146](https://github.com/PaddlePaddle/PaddleHub/pull/2146)

### 【2、问题修复】
 - 修复RunModule的save_inference_model的报错问题 [PR2143](https://github.com/PaddlePaddle/PaddleHub/pull/2143)