### PR TITLE
Set prefered multiprocessing startup method

### DIFF
--- a/paddlehub/commands/utils.py
+++ b/paddlehub/commands/utils.py
@@ -12,9 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from typing import Any
 from collections import defaultdict
+from typing import Any
 
 
 def _CommandDict():
@@ -66,9 +65,11 @@ def execute():
     import sys
     import multiprocessing
     try:
-        multiprocessing.set_start_method('fork') # In paddlehub, functions like gradio app need multiprocess supported, and 'fork' is our prefered start method.
+        multiprocessing.set_start_method(
+            'fork'
+        )  # In paddlehub, functions like gradio app need multiprocess supported, and 'fork' is our prefered start method.
     except Exception:
-        pass # If can not set 'fork', maintain the default start method
+        pass  # If can not set 'fork', maintain the default start method
     com = _commands
     for idx, _argv in enumerate(['hub'] + sys.argv[1:]):
         if _argv not in com:

--- a/paddlehub/commands/utils.py
+++ b/paddlehub/commands/utils.py
@@ -64,6 +64,11 @@ def execute():
          status(int) : Result of the command execution. 0 for a success and 1 for a failure.
     '''
     import sys
+    import multiprocessing
+    try:
+        multiprocessing.set_start_method('fork') # In paddlehub, functions like gradio app need multiprocess supported, and 'fork' is our prefered start method.
+    except Exception:
+        pass # If can not set 'fork', maintain the default start method
     com = _commands
     for idx, _argv in enumerate(['hub'] + sys.argv[1:]):
         if _argv not in com:


### PR DESCRIPTION
1. 有的环境下首选的多进程启动方式为spawn，这种方式下多进程启动gradio app会有问题，因此我们设置为首选fork的启动方式。