### PR TITLE
添加设置 timeout 参数逻辑

### DIFF
--- a/paddlehub/commands/serving.py
+++ b/paddlehub/commands/serving.py
@@ -176,7 +176,7 @@ class ServingCommand:
                 log.logger.error("Port %s is occupied, please change it." % port)
                 return False
             self.preinstall_modules()
-            options = {"bind": "0.0.0.0:%s" % port, "workers": self.args.workers}
+            options = {"bind": "0.0.0.0:%s" % port, "workers": self.args.workers, "timeout": self.args.timeout}
             self.dump_pid_file()
             StandaloneApplication(app.create_app(init_flag=False, configs=self.modules_info), options).run()
         else:
@@ -282,6 +282,8 @@ class ServingCommand:
         str += "\tUse gpu for predicting if specifies the parameter.\n"
         str += "--gpu\n"
         str += "\tSpecify the GPU devices to use.\n"
+        str += "--timeout/-t\n"
+        str += "\tSet timeout time with multiprocess.\n"
         print(str)
 
     def parse_args(self):
@@ -301,8 +303,10 @@ class ServingCommand:
                 self.args.use_gpu = self.args_config.get('use_gpu', False)
                 if self.args.use_multiprocess:
                     self.args.workers = self.args_config.get('workers', number_of_workers())
+                    self.args.timeout = self.args_config.get('timeout', 300)
                 else:
                     self.args.workers = self.args_config.get('workers', None)
+                    self.args.timeout = self.args_config.get('timeout', None)
             else:
                 raise RuntimeError("{} not exists.".format(self.args.config))
                 exit(1)
@@ -339,6 +343,8 @@ class ServingCommand:
         self.parser.add_argument("--use_singleprocess", action="store_true", default=False)
         self.parser.add_argument("--modules_info", "-mi", default={}, type=json.loads)
         self.parser.add_argument("--workers", "-w", nargs="?", default=number_of_workers())
+        self.parser.add_argument("--timeout", "-t", nargs="?", default=300)
+
         try:
             self.args = self.parser.parse_args()
         except:


### PR DESCRIPTION
在使用 PaddleHub 搭建 OCR 服务的时候发现一个问题,在开启"use_multiprocess"的情况下,由于采用了"Gunicorn",其默认超时时间比较短,在进行多张图片识别的时候服务器经常报超时错误([CRITICAL] WORKER TIMEOUT)
所以添加了设置"timeout"参数的功能,
1. 可以通过命令行 --timeout 或者 -t 赋值,默认为300秒,当值为0就表示禁用超时设置.如: 
hub serving start -m ocr_system --use_multiprocess --workers --timeout 0

2. 也可以在"config.json "中添加
 {
    "modules_info": {
        "ocr_system": {
            "init_args": {
                "version": "1.0.0",
                "use_gpu": false
            },
            "predict_args": {
            }
        }
    },
    "port": 8868,
    "use_multiprocess": true,
    "workers": 2,
    "timeout": 0
}