### PR TITLE
Solve DPO pin-memory problem by hacking HybridParallelOptimizer

### DIFF
--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -49,9 +49,6 @@ try:
 except:
     core = None
 from paddle.distributed import fleet
-from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer.hybrid_parallel_optimizer import (
-    HybridParallelOptimizer,
-)
 from paddle.distributed.fleet.meta_parallel.sharding.group_sharded_optimizer_stage2 import (
     GroupShardedOptimizerStage2,
 )
@@ -146,6 +143,7 @@ from .trainer_callback import (
     TrainerControl,
     TrainerState,
 )
+from .trainer_utils import CustomHybridParallelOptimizer as HybridParallelOptimizer
 from .trainer_utils import (  # set_hyrbid_parallel_seed,
     EvalLoopOutput,
     EvalPrediction,

--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -49,6 +49,9 @@ try:
 except:
     core = None
 from paddle.distributed import fleet
+from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer.hybrid_parallel_optimizer import (
+    HybridParallelOptimizer,
+)
 from paddle.distributed.fleet.meta_parallel.sharding.group_sharded_optimizer_stage2 import (
     GroupShardedOptimizerStage2,
 )
@@ -143,7 +146,6 @@ from .trainer_callback import (
     TrainerControl,
     TrainerState,
 )
-from .trainer_utils import CustomHybridParallelOptimizer as HybridParallelOptimizer
 from .trainer_utils import (  # set_hyrbid_parallel_seed,
     EvalLoopOutput,
     EvalPrediction,
@@ -155,6 +157,7 @@ from .trainer_utils import (  # set_hyrbid_parallel_seed,
     ShardingOption,
     TrainerMemoryTracker,
     TrainOutput,
+    _insert_sync,
     download_recovery_ckpt_from_pdc,
     find_batch_size,
     get_last_checkpoint,
@@ -2393,6 +2396,9 @@ class Trainer:
                     and "enable_stage1_broadcast_overlap" in self.args.sharding_parallel_config
                 ):
                     self.optimizer._set_broadcast_overlap(True, model)
+
+        # To solve DPO pin-memory problem, temporarily modify the _insert_sync method.
+        self.optimizer._insert_sync = types.MethodType(_insert_sync, self.optimizer)
 
         return model
 

--- a/paddleformers/trainer/trainer_utils.py
+++ b/paddleformers/trainer/trainer_utils.py
@@ -36,6 +36,9 @@ import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
+from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer.hybrid_parallel_optimizer import (
+    HybridParallelOptimizer,
+)
 from paddle.distributed.fleet.meta_parallel import get_rng_state_tracker
 from paddle.io import IterableDataset
 from paddle.optimizer.lr import LambdaDecay
@@ -1252,3 +1255,34 @@ def download_recovery_ckpt_from_pdc(recovery_checkpoint_path, timeout):
         raise RuntimeError(
             f"{PDC_DOWNLOAD_ERROR}; Error occurred when trying to download checkpoint from PDC, recovery_checkpoint_path: {recovery_checkpoint_path}, timeout: {timeout}; error details: {PDCErrorMessageMap[result]}"
         )
+
+
+class CustomHybridParallelOptimizer(HybridParallelOptimizer):
+    """
+    Custom optimizer class inherited from HybridParallelOptimizer
+    Override _insert_sync method to solve DPO pin-memory problem
+    """
+
+    def _insert_sync(self, sync_var, src, mp_group, sync_mode):
+        # Get device type where the sync_var is located
+        original_device = "pin_memory" if str(sync_var.place) == "Place(gpu_pinned)" else "cuda"
+
+        # If the sync_var is on pin memory, first move it to CUDA
+        if original_device == "pin_memory":
+            sync_var = sync_var.cuda()
+
+        if sync_mode == "broadcast":
+            paddle.distributed.broadcast(sync_var, src=src, group=mp_group, sync_op=True)
+        else:
+            paddle.distributed.all_reduce(sync_var, group=mp_group, sync_op=True)
+            sync_var.multiply_(
+                paddle.full(
+                    shape=[],
+                    dtype=sync_var.dtype,
+                    fill_value=(1.0 / mp_group.nranks),
+                )
+            )
+
+        # Move it back to pin memory
+        if original_device == "pin_memory":
+            sync_var = paddle.to_tensor(sync_var.numpy(), place=paddle.CUDAPinnedPlace())

--- a/paddleformers/trainer/trainer_utils.py
+++ b/paddleformers/trainer/trainer_utils.py
@@ -36,9 +36,6 @@ import numpy as np
 import paddle
 import paddle.distributed as dist
 from paddle.distributed import fleet
-from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer.hybrid_parallel_optimizer import (
-    HybridParallelOptimizer,
-)
 from paddle.distributed.fleet.meta_parallel import get_rng_state_tracker
 from paddle.io import IterableDataset
 from paddle.optimizer.lr import LambdaDecay
@@ -51,6 +48,7 @@ from ..utils.fault_tolerance import PDC_DOWNLOAD_ERROR
 from ..utils.import_utils import is_paddle_cuda_available, is_psutil_available
 from ..utils.log import logger
 from ..utils.pdc_sdk import PDCErrorCode, PDCErrorMessageMap, pdc_tool
+from ..utils.tools import get_env_device
 from .utils.helper import distributed_file
 
 __all__ = [
@@ -1257,32 +1255,29 @@ def download_recovery_ckpt_from_pdc(recovery_checkpoint_path, timeout):
         )
 
 
-class CustomHybridParallelOptimizer(HybridParallelOptimizer):
-    """
-    Custom optimizer class inherited from HybridParallelOptimizer
-    Override _insert_sync method to solve DPO pin-memory problem
-    """
+def _insert_sync(self, sync_var, src, mp_group, sync_mode):
+    # Get device type where the sync_var is located
+    original_device = "pin_memory" if str(sync_var.place) == "Place(gpu_pinned)" else "Other"
 
-    def _insert_sync(self, sync_var, src, mp_group, sync_mode):
-        # Get device type where the sync_var is located
-        original_device = "pin_memory" if str(sync_var.place) == "Place(gpu_pinned)" else "cuda"
-
-        # If the sync_var is on pin memory, first move it to CUDA
-        if original_device == "pin_memory":
+    # If the sync_var is on pin memory, first move it to CUDA or other decives
+    if original_device == "pin_memory":
+        if get_env_device() == "gpu":
             sync_var = sync_var.cuda()
-
-        if sync_mode == "broadcast":
-            paddle.distributed.broadcast(sync_var, src=src, group=mp_group, sync_op=True)
         else:
-            paddle.distributed.all_reduce(sync_var, group=mp_group, sync_op=True)
-            sync_var.multiply_(
-                paddle.full(
-                    shape=[],
-                    dtype=sync_var.dtype,
-                    fill_value=(1.0 / mp_group.nranks),
-                )
-            )
+            sync_var = sync_var.to(get_env_device())
 
-        # Move it back to pin memory
-        if original_device == "pin_memory":
-            sync_var = paddle.to_tensor(sync_var.numpy(), place=paddle.CUDAPinnedPlace())
+    if sync_mode == "broadcast":
+        paddle.distributed.broadcast(sync_var, src=src, group=mp_group, sync_op=True)
+    else:
+        paddle.distributed.all_reduce(sync_var, group=mp_group, sync_op=True)
+        sync_var.multiply_(
+            paddle.full(
+                shape=[],
+                dtype=sync_var.dtype,
+                fill_value=(1.0 / mp_group.nranks),
+            )
+        )
+
+    # Move it back to pin memory
+    if original_device == "pin_memory":
+        sync_var = paddle.to_tensor(sync_var, place=paddle.CUDAPinnedPlace())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 blobfile
 colorlog
-seqeval
+scikit-learn
 multiprocess<=0.70.12.2
 datasets >= 2.0.0
 tqdm


### PR DESCRIPTION
### PR types
Function optimization

### PR changes
APIs

### Description
solve DPO pin-memory problem by hacking HybridParallelOptimizer.
To ensure the proper functioning of the broadcast operation, if the tensor that needs to be synchronized is stored in pin-memory, move it to CUDA first. After the synchronization is completed, move it back to pin-memory.
