### PR TITLE
[BugFix] fix lazy_import error of importlib.machinery

### DIFF
--- a/paddleformers/utils/lazy_import.py
+++ b/paddleformers/utils/lazy_import.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import importlib
+import importlib.machinery
 import importlib.util
 import os
 from itertools import chain


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
fix lazy_import error of importlib.machinery when use `python -c "..."`

<img width="2424" height="174" alt="image" src="https://github.com/user-attachments/assets/00c40f2c-d762-47ca-bee3-9311a681c09d" />

