### PR TITLE
[Fix Bug]Fix LM Head dimension mismatch issue

### DIFF
--- a/paddleformers/nn/criterion/loss_utils.py
+++ b/paddleformers/nn/criterion/loss_utils.py
@@ -55,7 +55,7 @@ def calc_lm_head_logits(
         hidden_states,
         weight,
         bias=bias,
-        transpose_y=config.get("tie_word_embeddings", False),
+        transpose_y=True,
         tensor_parallel_degree=config.tensor_parallel_degree,
         tensor_parallel_output=tensor_parallel_output,
         fuse_linear=config.get("fuse_linear", False),

--- a/paddleformers/nn/lm_head.py
+++ b/paddleformers/nn/lm_head.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import paddle
 import paddle.nn as nn
 
 from ..generation.configuration_utils import PretrainedConfig
 from ..utils.log import logger
 from .criterion.loss_utils import calc_lm_head_logits
-from .linear import Linear
 
 __all__ = ["LMHead"]
 
@@ -41,22 +41,27 @@ class LMHead(nn.Layer):
                     vocab_size,
                     config.tensor_parallel_degree,
                 )
-        self.lm_head = Linear.create(
-            in_features=vocab_size,
-            out_features=config.hidden_size,
-            weight_attr=nn.initializer.XavierNormal(1.0),
-            has_bias=self.use_bias,
-            linear_type="default",
-        )
 
-        self.weight = self.lm_head.weight
-        self.bias = self.lm_head.bias
+        self.weight = self.create_parameter(
+            shape=[vocab_size, config.hidden_size],
+            dtype=paddle.get_default_dtype(),
+            default_initializer=nn.initializer.XavierNormal(1.0),
+        )
 
         # setting distributed attr for tensor parallel
         self._set_distributed_attr(self.weight)
+
         if self.use_bias:
+            self.bias = self.create_parameter(
+                shape=[vocab_size],
+                dtype=paddle.get_default_dtype(),
+                default_initializer=nn.initializer.Constant(0.0),
+            )
+
             # setting distributed attr for tensor parallel
             self._set_distributed_attr(self.bias)
+        else:
+            self.bias = None
 
     def _set_distributed_attr(self, param):
         param.is_distributed = self.vocab_parallel

--- a/paddleformers/nn/lm_head.py
+++ b/paddleformers/nn/lm_head.py
@@ -12,25 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle
 import paddle.nn as nn
 
 from ..generation.configuration_utils import PretrainedConfig
 from ..utils.log import logger
 from .criterion.loss_utils import calc_lm_head_logits
+from .linear import Linear
 
 __all__ = ["LMHead"]
 
 
 class LMHead(nn.Layer):
     def __init__(self, config: PretrainedConfig):
-        """
-        transpose_y (bool): Whether to transpose the lm_head weight matrix before matrix multiplication.
-        """
         super().__init__()
         self.config = config
         self.use_bias = config.get("lm_head_bias", False)
-        self.transpose_y = config.get("tie_word_embeddings", False)
         self.vocab_parallel = False
 
         # apply vocab tensor parallel
@@ -45,35 +41,27 @@ class LMHead(nn.Layer):
                     vocab_size,
                     config.tensor_parallel_degree,
                 )
-        self.lm_head_shape = (
-            [config.hidden_size, vocab_size] if not self.transpose_y else [vocab_size, config.hidden_size]
+        self.lm_head = Linear.create(
+            in_features=vocab_size,
+            out_features=config.hidden_size,
+            weight_attr=nn.initializer.XavierNormal(1.0),
+            has_bias=self.use_bias,
+            linear_type="default",
         )
 
-        self.weight = self.create_parameter(
-            shape=self.lm_head_shape,
-            dtype=paddle.get_default_dtype(),
-            default_initializer=nn.initializer.XavierNormal(1.0),
-        )
+        self.weight = self.lm_head.weight
+        self.bias = self.lm_head.bias
 
         # setting distributed attr for tensor parallel
-        self.weight.is_distributed = self.vocab_parallel
-
-        if self.weight.is_distributed:
-            self.weight.split_axis = 0 if self.transpose_y else 1
-
+        self._set_distributed_attr(self.weight)
         if self.use_bias:
-            self.bias = self.create_parameter(
-                shape=[vocab_size],
-                dtype=paddle.get_default_dtype(),
-                attr=paddle.ParamAttr(initializer=paddle.nn.initializer.constant.Constant(0.0)),
-            )
-
             # setting distributed attr for tensor parallel
-            self.bias.is_distributed = self.vocab_parallel
-            if self.bias.is_distributed:
-                self.bias.split_axis = 0
-        else:
-            self.bias = None
+            self._set_distributed_attr(self.bias)
+
+    def _set_distributed_attr(self, param):
+        param.is_distributed = self.vocab_parallel
+        if param.is_distributed:
+            param.split_axis = 0
 
     def forward(self, hidden_states, tensor_parallel_output=None):
         """Project hidden states to vocabulary logits.
@@ -114,5 +102,4 @@ class LMHead(nn.Layer):
         )
 
     def extra_repr(self):
-        hidden_size, vocab_size = self.lm_head_shape if not self.transpose_y else self.lm_head_shape[::-1]
-        return f"hidden_size={hidden_size}, vocab_size={vocab_size}, dtype={self.weight.dtype}, vocab_parallel={self.vocab_parallel}"
+        return f"hidden_size={self.weight.shape[1]}, vocab_size={self.weight.shape[0]}, dtype={self.weight.dtype}, vocab_parallel={self.vocab_parallel}"

--- a/paddleformers/nn/lm_head.py
+++ b/paddleformers/nn/lm_head.py
@@ -55,7 +55,7 @@ class LMHead(nn.Layer):
             self.bias = self.create_parameter(
                 shape=[vocab_size],
                 dtype=paddle.get_default_dtype(),
-                default_initializer=nn.initializer.Constant(0.0),
+                attr=paddle.ParamAttr(initializer=paddle.nn.initializer.constant.Constant(0.0)),
             )
 
             # setting distributed attr for tensor parallel

--- a/paddleformers/transformers/ernie4_5/modeling.py
+++ b/paddleformers/transformers/ernie4_5/modeling.py
@@ -439,7 +439,7 @@ class Ernie4_5PretrainedModel(PretrainedModel):
 
         def make_base_actions():
             actions = {
-                "lm_head.weight": partial(fn, is_column=not config.tie_word_embeddings),
+                "lm_head.weight": partial(fn, is_column=False),
                 "embed_tokens.weight": partial(fn, is_column=False),
             }
             for layer_idx in range(config.num_hidden_layers):

--- a/paddleformers/transformers/ernie4_5_moe/modeling.py
+++ b/paddleformers/transformers/ernie4_5_moe/modeling.py
@@ -503,7 +503,7 @@ class Ernie4_5_MoePretrainedModel(PretrainedModel):
 
         def make_base_actions():
             actions = {
-                "lm_head.weight": partial(fn, is_column=not config.tie_word_embeddings),
+                "lm_head.weight": partial(fn, is_column=False),
                 "embed_tokens.weight": partial(fn, is_column=False),
             }
             for layer_idx in range(config.num_hidden_layers):

--- a/paddleformers/transformers/glm4_moe/modeling.py
+++ b/paddleformers/transformers/glm4_moe/modeling.py
@@ -589,7 +589,7 @@ class Glm4MoePreTrainedModel(PretrainedModel):
     config: Glm4MoeConfig
     config_class = Glm4MoeConfig
     base_model_prefix = "model"
-    transpose_weight_keys = ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj", "lm_head"]
+    transpose_weight_keys = ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"]
 
     @classmethod
     def _get_tensor_parallel_mappings(cls, config: Glm4MoeConfig, is_split=True):
@@ -634,7 +634,7 @@ class Glm4MoePreTrainedModel(PretrainedModel):
 
         def make_base_actions():
             actions = {
-                "lm_head.weight": partial(fn, is_column=not config.tie_word_embeddings),
+                "lm_head.weight": partial(fn, is_column=False),
                 "model.embed_tokens.weight": partial(fn, is_column=False),
             }
             for layer_idx in range(config.num_hidden_layers):

--- a/paddleformers/transformers/gpt_oss/modeling.py
+++ b/paddleformers/transformers/gpt_oss/modeling.py
@@ -650,7 +650,7 @@ class GptOssPreTrainedModel(PretrainedModel):
     config_class = GptOssConfig
     base_model_prefix = "model"
     keys_to_ignore_on_load_unexpected = [r"self_attn.rotary_emb.inv_freq"]
-    transpose_weight_keys = ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj", "lm_head"]
+    transpose_weight_keys = ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"]
 
     @classmethod
     def _get_tensor_parallel_mappings(cls, config: GptOssConfig, is_split=True):
@@ -667,7 +667,7 @@ class GptOssPreTrainedModel(PretrainedModel):
             final_actions = {}
 
             base_actions = {
-                "lm_head.weight": partial(fn, is_column=True),
+                "lm_head.weight": partial(fn, is_column=False),
                 # Row Linear
                 "embed_tokens.weight": partial(fn, is_column=False),
                 "layers.0.self_attn.o_proj.weight": partial(fn, is_column=False),

--- a/paddleformers/transformers/qwen2/modeling.py
+++ b/paddleformers/transformers/qwen2/modeling.py
@@ -348,7 +348,7 @@ class Qwen2PretrainedModel(PretrainedModel):
     config_class = Qwen2Config
     base_model_prefix = "model"
     _keys_to_ignore_on_load_unexpected = [r"self_attn.rotary_emb.inv_freq"]
-    transpose_weight_keys = ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj", "lm_head"]
+    transpose_weight_keys = ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"]
 
     @classmethod
     def _get_tensor_parallel_mappings(cls, config: Qwen2Config, is_split=True):
@@ -380,7 +380,7 @@ class Qwen2PretrainedModel(PretrainedModel):
 
         def make_base_actions():
             actions = {
-                "lm_head.weight": partial(fn, is_column=not config.tie_word_embeddings),
+                "lm_head.weight": partial(fn, is_column=False),
                 "embed_tokens.weight": partial(fn, is_column=False),
             }
             for layer_idx in range(config.num_hidden_layers):

--- a/paddleformers/transformers/qwen2_moe/modeling.py
+++ b/paddleformers/transformers/qwen2_moe/modeling.py
@@ -388,7 +388,6 @@ class Qwen2MoePretrainedModel(PretrainedModel):
         "down_proj",
         "gate",
         "shared_expert_gate",
-        "lm_head",
     ]
 
     @classmethod
@@ -433,7 +432,7 @@ class Qwen2MoePretrainedModel(PretrainedModel):
 
         def make_base_actions():
             actions = {
-                "lm_head.weight": partial(fn, is_column=not config.tie_word_embeddings),
+                "lm_head.weight": partial(fn, is_column=False),
                 "embed_tokens.weight": partial(fn, is_column=False),
             }
             for layer_idx in range(config.num_hidden_layers):

--- a/paddleformers/transformers/qwen3/modeling.py
+++ b/paddleformers/transformers/qwen3/modeling.py
@@ -247,7 +247,7 @@ class Qwen3PretrainedModel(PretrainedModel):
     config_class = Qwen3Config
     base_model_prefix = "model"
     _keys_to_ignore_on_load_unexpected = [r"self_attn.rotary_emb.inv_freq"]
-    transpose_weight_keys = ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj", "lm_head"]
+    transpose_weight_keys = ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"]
 
     @classmethod
     def _get_tensor_parallel_mappings(cls, config: Qwen3Config, is_split=True):
@@ -279,7 +279,7 @@ class Qwen3PretrainedModel(PretrainedModel):
 
         def make_base_actions():
             actions = {
-                "lm_head.weight": partial(fn, is_column=not config.tie_word_embeddings),
+                "lm_head.weight": partial(fn, is_column=False),
                 "embed_tokens.weight": partial(fn, is_column=False),
             }
             for layer_idx in range(config.num_hidden_layers):

--- a/paddleformers/transformers/qwen3_moe/modeling.py
+++ b/paddleformers/transformers/qwen3_moe/modeling.py
@@ -273,7 +273,6 @@ class Qwen3MoePretrainedModel(PretrainedModel):
         "up_proj",
         "down_proj",
         "gate",
-        "lm_head",
     ]
 
     @classmethod
@@ -311,7 +310,7 @@ class Qwen3MoePretrainedModel(PretrainedModel):
 
         def make_base_actions():
             actions = {
-                "lm_head.weight": partial(fn, is_column=not config.tie_word_embeddings),
+                "lm_head.weight": partial(fn, is_column=False),
                 "embed_tokens.weight": partial(fn, is_column=False),
             }
             for layer_idx in range(config.num_hidden_layers):

--- a/tests/nn/test_lm_head.py
+++ b/tests/nn/test_lm_head.py
@@ -27,11 +27,10 @@ class TestLMHead(unittest.TestCase):
         lm_head = LMHead(config)
 
         # Check weight shape and attributes
-        self.assertEqual(lm_head.weight.shape, [config.hidden_size, config.vocab_size])
+        self.assertEqual(lm_head.weight.shape, [config.vocab_size, config.hidden_size])
         self.assertFalse(lm_head.weight.is_distributed)
         self.assertIsNone(lm_head.bias)
         self.assertFalse(lm_head.vocab_parallel)
-        self.assertFalse(lm_head.transpose_y)
 
     def test_initialization_with_tie_word_embeddings(self):
         # Test initialization with tied embeddings
@@ -40,7 +39,6 @@ class TestLMHead(unittest.TestCase):
         lm_head = LMHead(config)
 
         self.assertEqual(lm_head.weight.shape, [config.vocab_size, config.hidden_size])
-        self.assertTrue(lm_head.transpose_y)
 
     def test_forward_normal(self):
         # Test normal forward pass


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
修复"tie_word_embeddings=True"时加载lm_head.weight维度不匹配问题
### Description
<!-- Describe what this PR does -->
1. LMHead改[vocab_size, hidden_size]形式初始化
2. 修改Qwen2/3、GLM4、GPT-OSS、ERNIE4.5模型LM HeadTP切分逻辑