### PR TITLE
Resolving the Save-Load Discontinuity Caused by Non-Contiguous Tensors

### DIFF
--- a/paddleformers/transformers/conversion_utils.py
+++ b/paddleformers/transformers/conversion_utils.py
@@ -745,7 +745,7 @@ def get_tensor_parallel_split_func(tensor_parallel_degree, tensor_parallel_rank,
             return None
         if transpose:
             if isinstance(x, paddle.Tensor):
-                x = paddle.transpose(x, [1, 0])
+                x = paddle.transpose(x, [1, 0]).contiguous()
             else:
                 x = np.transpose(x, [1, 0])
         if is_old_qkv:
@@ -1252,7 +1252,7 @@ class ConversionMixin:
                     continue
                 for trans_key in transpose_weight_keys:
                     if re.search(f"\.{trans_key}\.weight$", key) or re.fullmatch(f"^{trans_key}\.weight$", key):
-                        state_dict[key] = state_dict.pop(key).transpose([-1, -2])
+                        state_dict[key] = state_dict.pop(key).transpose([-1, -2]).contiguous()
         return state_dict
 
     @classmethod

--- a/paddleformers/transformers/model_utils.py
+++ b/paddleformers/transformers/model_utils.py
@@ -397,7 +397,7 @@ def _load_part_state_dict(
 
     def _transpose_hf_weight(key, weight):
         if _is_need_transpose(key):
-            return weight.transpose([-1, -2])
+            return weight.transpose([-1, -2]).contiguous()
         return weight
 
     part_state_dict = {}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
- 解决contiguous造成的save load 不接续问题
load时对部分weight进行transpose造成Non-Contiguous
导致在PipelineParallel init时，调用broadcast_sharding_parameters对parma.contiguous(), 造成参数错位