### PR TITLE
Feat(validation): Add error logging for unsupported config in pp

### DIFF
--- a/paddleformers/nn/pp_model.py
+++ b/paddleformers/nn/pp_model.py
@@ -510,6 +510,12 @@ class GeneralModelForCausalLMPipe(PipelinePretrainedModel, PipelineLayer):
     _norm_cls = "rms_norm"
 
     def __init__(self, config: PretrainedConfig, **kwargs):
+        if config.sliding_window is not None and "sliding_attention" in config.layer_types:
+            logger.error(
+                "Pipeline Parallelism (PP) does not support sliding window attention. "
+                "To prevent issues during training, please set use_sliding_window=False."
+            )
+
         # dynamic inherit DecoderLayer
         if self._decoder_layer_cls is None:
             raise ValueError("_decoder_layer_cls must be set before init.")


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
PP并行时不支持sliding winodw传入，补充ERROR日志。

TODO：修复pp_model模块的attention mask传入逻辑，支持sliding attention