### PR TITLE
[Fix] TP-SP时, sharding stage1 or dp采用callback方法, 其他情况采用hook方法同步sp的梯度

### DIFF
--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -145,6 +145,7 @@ from .trainer_callback import (
     DefaultFlowCallback,
     PrinterCallback,
     ProgressCallback,
+    SPGradSyncCallback,
     TrainerCallback,
     TrainerControl,
     TrainerState,
@@ -2262,9 +2263,15 @@ class Trainer:
                 model, self.optimizer = decorated
 
         if self.args.tensor_parallel_degree > 1 and self.args.sequence_parallel:
-            register_sequence_parallel_allreduce_hooks(
-                model, self.args.gradient_accumulation_steps, self.args.fuse_sequence_parallel_allreduce
-            )
+            # use callback for sp grad sync in case of unexpected behaviour (except sharding stage 2&3)
+            if ShardingOption.SHARD_GRAD_OP in self.args.sharding or ShardingOption.FULL_SHARD in self.args.sharding:
+                # stage 2 or stage 3
+                register_sequence_parallel_allreduce_hooks(
+                    model, self.args.gradient_accumulation_steps, self.args.fuse_sequence_parallel_allreduce
+                )
+            else:
+                # stage 1 or dp
+                self.add_callback(SPGradSyncCallback(model))
 
         if self.args.world_size == 1:
             if self.args.amp_master_grad:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
TP-SP时, sharding stage1 or dp采用callback方法, 其他情况采用hook方法同步sp的梯度。
注意：hook方法进行sp同步梯度在两种特殊情况下会存在BUG：
- 情况1：当梯度累计数值动态发生变化时，注册的backward的hook里面的acc值无法修改，进而导致梯度reduce sum错误。
- 情况2：当部分算子的反向被重复多次调用，此时同样也会导致梯度reduce sum错误。