### PR TITLE
fix fused_head_and_loss_fn  bug

### DIFF
--- a/paddleformers/nn/lm_head.py
+++ b/paddleformers/nn/lm_head.py
@@ -93,7 +93,7 @@ class LMHead(nn.Layer):
                 hidden_states,
                 self.weight,
                 self.bias,
-                self.config.tie_word_embeddings,
+                True,
             )
 
         return calc_lm_head_logits(

--- a/tests/nn/test_lm_head.py
+++ b/tests/nn/test_lm_head.py
@@ -60,7 +60,7 @@ class TestLMHead(unittest.TestCase):
         self.assertEqual(output[0].shape, test_input.shape)
         self.assertEqual(output[1].shape, lm_head.weight.shape)
         self.assertIs(output[2], lm_head.bias)
-        self.assertEqual(output[3], config.tie_word_embeddings)
+        self.assertEqual(output[3], True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
修复开启use_fused_head_and_loss_fn后转置参数传递错误的问题 from #2648 
