### PR TITLE
raise error in LMHead when vocab_size cannot divide by tp degree

### DIFF
--- a/paddleformers/nn/lm_head.py
+++ b/paddleformers/nn/lm_head.py
@@ -16,7 +16,6 @@ import paddle
 import paddle.nn as nn
 
 from ..generation.configuration_utils import PretrainedConfig
-from ..utils.log import logger
 from .criterion.loss_utils import calc_lm_head_logits
 
 __all__ = ["LMHead"]
@@ -30,17 +29,17 @@ class LMHead(nn.Layer):
         self.vocab_parallel = False
 
         # apply vocab tensor parallel
+        if config.vocab_size % config.tensor_parallel_degree != 0:
+            raise ValueError(
+                f"lm_head can not activate vocab parallelism "
+                f"(vocab_size={config.vocab_size} % tp_degree={config.tensor_parallel_degree} != 0)."
+            )
+
         if config.tensor_parallel_degree > 1 and config.vocab_size % config.tensor_parallel_degree == 0:
             vocab_size = config.vocab_size // config.tensor_parallel_degree
             self.vocab_parallel = True
         else:
             vocab_size = config.vocab_size
-            if config.tensor_parallel_degree > 1:
-                logger.warning_once(
-                    "lm_head vocab parallelism is disabled (vocab_size=%d %% tp_degree=%d != 0).",
-                    vocab_size,
-                    config.tensor_parallel_degree,
-                )
 
         self.weight = self.create_parameter(
             shape=[vocab_size, config.hidden_size],


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
LMHead 中vocab size 不能被tp degree整除时，直接抛异常