### PR TITLE
【Pretrain】fix pipe parallel bug when Pretrain

### DIFF
--- a/paddleformers/nn/pp_model.py
+++ b/paddleformers/nn/pp_model.py
@@ -71,7 +71,9 @@ def parse_args(args, mtp_enable=False):
                 hidden_states, attention_mask, nbatch_pack_offset = args
                 position_ids = None
             else:
-                hidden_states, attention_mask, position_ids = args
+                hidden_states, position_ids, position_embeddings = args
+                attention_mask = None
+                nbatch_pack_offset = None
         elif len(args) == 2:
             if mtp_enable:
                 hidden_states, nbatch_pack_offset = args
@@ -487,13 +489,12 @@ def make_decoder_layer_pipe(decoder_layer):
 class CriterionLayerPipe(CriterionLayer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.return_tuple = False  # loss_func only return loss, no loss_sum
 
     def forward(self, logits, labels):
         if isinstance(labels, tuple) and "sft" in self.loss_type:
             labels, loss_mask = labels
-            loss, loss_sum = super().forward(logits, labels)
-        else:
-            loss = super().forward(logits, labels)
+        loss = super().forward(logits, labels)
         return loss
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
pcard-67164
1.预训练没有传递attention_mask，但是有position_ids， position_embeding pp_model 解析arg 的时候错位
2.loss_fun CriterionLayer 返回了tuple 导致pp 报错，将pp 下默认设置为self.return_tuple=false