### PR TITLE
fix model save for moe_sharding

### DIFF
--- a/paddleformers/trainer/training_args.py
+++ b/paddleformers/trainer/training_args.py
@@ -2357,6 +2357,8 @@ class TrainingArguments:
                 name.append(self._format_name("pp", self.pipeline_parallel_rank, self.pipeline_parallel_degree))
             if self.use_expert_parallel and self.expert_parallel_degree <= 1:
                 name.append(self._format_name("moe", self.data_parallel_rank, self.data_parallel_degree))
+            if self.use_expert_parallel and self.expert_parallel_degree > 1:
+                name.append(self._format_name("moe_sharding", self.expert_parallel_rank, self.expert_parallel_degree))
             return "_".join(name)
 
         else:


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
修复moe_sharding并行策略下，模型保存因缺少moe rank导致相同文件名覆盖问题

相关PR：
paddlenlp dev：https://github.com/PaddlePaddle/PaddleNLP/pull/11162
paddlenlp fleety0421: https://github.com/PaddlePaddle/PaddleNLP/pull/11155
paddleformers dev: https://github.com/PaddlePaddle/PaddleFormers/pull/2846
paddleformers fleety1103: https://github.com/PaddlePaddle/PaddleFormers/pull/2847