### PR TITLE
Fix(DPO): Resolve DPO training loss diff in Pipeline Parallelism mode

### DIFF
--- a/examples/alignment/dpo/dpo_argument.py
+++ b/examples/alignment/dpo/dpo_argument.py
@@ -111,7 +111,8 @@ class DPOConfig:
     reference_free: bool = field(default=False, metadata={"help": "No reference model."})
     lora: bool = field(default=False, metadata={"help": "Use LoRA model."})
     offset_alpha: float = field(default=0.0, metadata={"help": "offset alpha"})
-    normalize_logps: bool = field(default=True, metadata={"help": "normalize logps"})
+    normalize_logps: bool = field(default=False, metadata={"help": "normalize logps"})
+    ignore_eos_token: bool = field(default=False, metadata={"help": "ignore eos token"})
 
 
 @dataclass

--- a/examples/alignment/dpo/run_dpo.py
+++ b/examples/alignment/dpo/run_dpo.py
@@ -15,11 +15,6 @@
 """ Training DPO """
 
 import os
-
-os.environ["NVIDIA_TF32_OVERRIDE"] = "0"
-os.environ["NCCL_ALGO"] = "Tree"
-os.environ["FLAGS_embedding_deterministic"] = "1"
-os.environ["FLAGS_cudnn_deterministic"] = "1"
 import sys
 from functools import partial
 

--- a/examples/alignment/dpo/run_dpo.py
+++ b/examples/alignment/dpo/run_dpo.py
@@ -15,6 +15,11 @@
 """ Training DPO """
 
 import os
+
+os.environ["NVIDIA_TF32_OVERRIDE"] = "0"
+os.environ["NCCL_ALGO"] = "Tree"
+os.environ["FLAGS_embedding_deterministic"] = "1"
+os.environ["FLAGS_cudnn_deterministic"] = "1"
 import sys
 from functools import partial
 
@@ -295,7 +300,7 @@ def main():
             use_sparse_head_and_loss_fn=model_config.use_sparse_head_and_loss_fn,
             use_fused_head_and_loss_fn=model_config.use_fused_head_and_loss_fn,
         ),
-        ignore_eos_token=True,
+        ignore_eos_token=dpo_config.ignore_eos_token,
         model_with_dpo_criterion=model_args.model_with_dpo_criterion,
     )
 

--- a/paddleformers/cli/hparams/finetuning_args.py
+++ b/paddleformers/cli/hparams/finetuning_args.py
@@ -263,7 +263,7 @@ class DPOTrainingArguments(TrainingArguments):
     )
     # base
     normalize_logps: bool = field(
-        default=True,
+        default=False,
         metadata={"help": "Apply logprobs normalization."},
     )
     label_smoothing: float = field(
@@ -273,6 +273,10 @@ class DPOTrainingArguments(TrainingArguments):
     dpo_benchmark: bool = field(
         default=False,
         metadata={"help": "Whether to run benchmark by autotuner. True for from_scratch."},
+    )
+    ignore_eos_token: bool = field(
+        default=False,
+        metadata={"help": "Ignore EOS token during training."},
     )
     # reference model
     ref_model_update_steps: int = field(

--- a/paddleformers/cli/train/dpo/dpo_argument.py
+++ b/paddleformers/cli/train/dpo/dpo_argument.py
@@ -103,7 +103,8 @@ class DPOConfig:
     reference_free: bool = field(default=False, metadata={"help": "No reference model."})
     lora: bool = field(default=False, metadata={"help": "Use LoRA model."})
     offset_alpha: float = field(default=0.0, metadata={"help": "offset alpha"})
-    normalize_logps: bool = field(default=True, metadata={"help": "normalize logps"})
+    normalize_logps: bool = field(default=False, metadata={"help": "normalize logps"})
+    ignore_eos_token: bool = field(default=False, metadata={"help": "ignore eos token"})
 
 
 @dataclass

--- a/paddleformers/cli/train/dpo/workflow.py
+++ b/paddleformers/cli/train/dpo/workflow.py
@@ -116,6 +116,7 @@ def run_dpo(
         offset_alpha=training_args.offset_alpha,
         simpo_gamma=training_args.simpo_gamma,
         normalize_logps=training_args.normalize_logps,
+        ignore_eos_token=training_args.ignore_eos_token,
         label_smoothing=training_args.label_smoothing,
         loss_type=training_args.loss_type,
         pref_loss_ratio=training_args.pref_loss_ratio,
@@ -305,7 +306,7 @@ def run_dpo(
             use_sparse_head_and_loss_fn=model_config.use_sparse_head_and_loss_fn,
             use_fused_head_and_loss_fn=model_config.use_fused_head_and_loss_fn,
         ),
-        ignore_eos_token=True,
+        ignore_eos_token=dpo_config.ignore_eos_token,
         model_with_dpo_criterion=model_args.model_with_dpo_criterion,
     )
 

--- a/paddleformers/nn/criterion/dpo_loss.py
+++ b/paddleformers/nn/criterion/dpo_loss.py
@@ -33,9 +33,15 @@ from .loss_utils import subbatch
 def dpo_preprocess_inputs(self, logits, labels):
     hidden_states, lm_head_weight, lm_head_bias, transpose_y = None, None, None, None
 
-    if isinstance(logits, tuple):
-        hidden_states, lm_head_weight, lm_head_bias, transpose_y = logits  # unpack logits when using fused head loss
-        logits = None
+    def unpack_logits(obj):
+        if isinstance(obj, tuple):
+            if len(obj) == 1:
+                return unpack_logits(obj[0])
+            elif len(obj) == 4:
+                return None, *obj  # unpack logits when using fused head loss
+        return obj, None, None, None, None
+
+    logits, hidden_states, lm_head_weight, lm_head_bias, transpose_y = unpack_logits(logits)
     return logits, labels, hidden_states, lm_head_weight, lm_head_bias, transpose_y
 
 

--- a/paddleformers/nn/criterion/kto_loss.py
+++ b/paddleformers/nn/criterion/kto_loss.py
@@ -36,9 +36,15 @@ from .loss_utils import subbatch
 def kto_preprocess_inputs(self, logits, labels):
     hidden_states, lm_head_weight, lm_head_bias, transpose_y = None, None, None, None
 
-    if isinstance(logits, tuple):
-        hidden_states, lm_head_weight, lm_head_bias, transpose_y = logits  # unpack logits when using fused head loss
-        logits = None
+    def unpack_logits(obj):
+        if isinstance(obj, tuple):
+            if len(obj) == 1:
+                return unpack_logits(obj[0])
+            elif len(obj) == 4:
+                return None, *obj  # unpack logits when using fused head loss
+        return obj, None, None, None, None
+
+    logits, hidden_states, lm_head_weight, lm_head_bias, transpose_y = unpack_logits(logits)
     return logits, labels, hidden_states, lm_head_weight, lm_head_bias, transpose_y
 
 

--- a/paddleformers/nn/criterion/sft_loss.py
+++ b/paddleformers/nn/criterion/sft_loss.py
@@ -29,10 +29,15 @@ from .loss_utils import calc_lm_head_logits, subbatch
 def sft_preprocess_inputs(self, logits, labels):
     hidden_states, lm_head_weight, lm_head_bias, transpose_y = None, None, None, None
 
-    if isinstance(logits, tuple):
-        hidden_states, lm_head_weight, lm_head_bias, transpose_y = logits  # unpack logits when using fused head loss
-        logits = None
+    def unpack_logits(obj):
+        if isinstance(obj, tuple):
+            if len(obj) == 1:
+                return unpack_logits(obj[0])
+            elif len(obj) == 4:
+                return None, *obj  # unpack logits when using fused head loss
+        return obj, None, None, None, None
 
+    logits, hidden_states, lm_head_weight, lm_head_bias, transpose_y = unpack_logits(logits)
     return logits, labels, hidden_states, lm_head_weight, lm_head_bias, transpose_y
 
 

--- a/paddleformers/nn/pp_model.py
+++ b/paddleformers/nn/pp_model.py
@@ -37,7 +37,7 @@ from .moe.utils import _parse_moe_group
 from .norm import LayerNorm, RMSNorm
 
 
-def parse_args(args, mtp_enable=False):
+def parse_args(args, mtp_enable=False, is_embed=False):
     """
     Parses input arguments and converts them into model-ready format.
     Processes different input argument patterns into standardized hidden states,
@@ -50,6 +50,9 @@ def parse_args(args, mtp_enable=False):
             - Tuple containing 1 element: (hidden_states)
             - Single tensor: hidden_states
             If rope_embeddings are provided, they should be included in the tuple.
+        mtp_enable (bool): Flag for Multi-Token Prediction.
+        is_embed (bool): Flag to indicate if processing is for EmbeddingPipe,
+                                  affects 3-argument tuple parsing.
     Returns:
         Tuple[paddle.Tensor, Optional[paddle.Tensor], Optional[paddle.Tensor]]:
             Returns a tuple containing:
@@ -70,6 +73,8 @@ def parse_args(args, mtp_enable=False):
             if mtp_enable:
                 hidden_states, attention_mask, nbatch_pack_offset = args
                 position_ids = None
+            elif is_embed:
+                hidden_states, attention_mask, position_ids = args
             else:
                 hidden_states, position_ids, position_embeddings = args
                 attention_mask = None
@@ -257,7 +262,9 @@ class EmbeddingPipe(nn.Layer):
         num_nextn_predict_layers = self.config.get("num_nextn_predict_layers", 0)
         enable_mtp_magic_send = self.config.get("enable_mtp_magic_send", False)
 
-        input_ids, attention_mask, position_ids, _, nbatch_pack_offset = parse_args(args, num_nextn_predict_layers > 0)
+        input_ids, attention_mask, position_ids, _, nbatch_pack_offset = parse_args(
+            args, num_nextn_predict_layers > 0, is_embed=True
+        )
         input_ids.stop_gradient = True
         emb = self.embed_tokens(input_ids).astype(self.embed_tokens.weight.dtype)
         if position_ids is None and not self.config.fuse_rope:

--- a/paddleformers/transformers/dpo_criterion.py
+++ b/paddleformers/transformers/dpo_criterion.py
@@ -268,6 +268,12 @@ class DPOCriterion(nn.Layer):
             rejected_response_length = response_indexs[:, 3] - response_indexs[:, 2]
             chosen_logps /= chosen_response_length.astype("float32")
             rejected_logps /= rejected_response_length.astype("float32")
+        elif self.dpo_config.normalize_logps:
+            avg_response_length = (response_indexs[:, 3] - response_indexs[:, 1]) / 2
+            chosen_response_length = response_indexs[:, 2] - response_indexs[:, 1]
+            rejected_response_length = response_indexs[:, 3] - response_indexs[:, 2]
+            chosen_logps *= avg_response_length / chosen_response_length.astype("float32")
+            rejected_logps *= avg_response_length / rejected_response_length.astype("float32")
         return chosen_logps, rejected_logps, sft_loss * self.dpo_config.sft_loss_ratio
 
     def forward(

--- a/paddleformers/trl/dpo_auto_trainer.py
+++ b/paddleformers/trl/dpo_auto_trainer.py
@@ -1121,7 +1121,7 @@ def prepare_pipeline_dpo_inputs_func(inputs):
         first_stage_keys = [
             "input_ids",
             "attn_mask_start_row_indices",
-            "attn_mask_startend_row_indice",
+            "attn_mask_startend_row_indices",
             "position_ids",
         ]
 

--- a/paddleformers/trl/dpo_trainer.py
+++ b/paddleformers/trl/dpo_trainer.py
@@ -17,9 +17,9 @@ import paddle
 import paddle.nn.functional as F
 from paddle.distributed import fleet
 
+from ..nn.criterion import CriterionLayer
 from ..peft.lora.lora_model import AVAILABLE_LAYERS
 from ..trainer import Trainer
-from ..transformers.dpo_criterion import DPOCriterion
 from ..transformers.model_utils import unwrap_model
 from ..utils import infohub
 
@@ -65,10 +65,8 @@ class DPOTrainer(Trainer):
             self.dpo_config = dpo_config
         if not model_with_dpo_criterion:
             if dpo_criterion is None:
-                self.dpo_criterion = DPOCriterion(
-                    self.model.config, dpo_config=dpo_config, ignore_eos_token=ignore_eos_token
-                )
-            elif isinstance(dpo_criterion, DPOCriterion):
+                self.dpo_criterion = CriterionLayer(self.model.config, ignore_eos_token=ignore_eos_token)
+            elif isinstance(dpo_criterion, CriterionLayer):
                 self.dpo_criterion = dpo_criterion
             else:
                 raise ValueError("dpo_criterion should be None or DPOCriterion. Got {}".format(type(dpo_criterion)))
@@ -538,7 +536,7 @@ def prepare_pipeline_dpo_inputs_func(inputs):
         first_stage_keys = [
             "input_ids",
             "attn_mask_start_row_indices",
-            "attn_mask_startend_row_indice",
+            "attn_mask_startend_row_indices",
             "position_ids",
         ]
 

--- a/scripts/regression/test_dpo.py
+++ b/scripts/regression/test_dpo.py
@@ -143,7 +143,7 @@ class DPOTrainTest(unittest.TestCase):
                 dop_full_reusme_f.write(dop_full_reusme_output)
         self.dpotrain_tester.assert_result(reusme_p.returncode, reusme_p.stdout)
 
-        EXCEPTED_LOSS = 0.691044
+        EXCEPTED_LOSS = 0.691177
         self.dpotrain_tester.assert_loss(reusme_p.stdout, EXCEPTED_LOSS)
 
         # test model generate
@@ -182,7 +182,7 @@ class DPOTrainTest(unittest.TestCase):
         self.dpotrain_tester.assert_result(training_p.returncode, training_p.stdout)
 
         # test training loss
-        EXCEPTED_LOSS = 0.692095
+        EXCEPTED_LOSS = 0.691972
         self.dpotrain_tester.assert_loss(training_p.stdout, EXCEPTED_LOSS)
 
         # test model resume
@@ -244,7 +244,7 @@ class DPOTrainTest(unittest.TestCase):
         self.dpotrain_tester.assert_result(training_p.returncode, training_p.stdout)
 
         # test training loss
-        EXCEPTED_LOSS = 0.692381
+        EXCEPTED_LOSS = 0.692186
         self.dpotrain_tester.assert_loss(training_p.stdout, EXCEPTED_LOSS)
         # test model resume
         reusme_p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
@@ -295,7 +295,7 @@ class DPOTrainTest(unittest.TestCase):
         self.dpotrain_tester.assert_result(training_p.returncode, training_p.stdout)
 
         # test training loss
-        EXCEPTED_LOSS = 0.692254
+        EXCEPTED_LOSS = 0.692127
         self.dpotrain_tester.assert_loss(training_p.stdout, EXCEPTED_LOSS)
 
         # test model resume

--- a/scripts/regression/test_dpo.py
+++ b/scripts/regression/test_dpo.py
@@ -196,7 +196,7 @@ class DPOTrainTest(unittest.TestCase):
                 dop_lora_reusme_f.write(dop_lora_reusme_output)
         self.dpotrain_tester.assert_result(reusme_p.returncode, reusme_p.stdout)
 
-        EXCEPTED_LOSS = 0.691209
+        EXCEPTED_LOSS = 0.690903
         self.dpotrain_tester.assert_loss(reusme_p.stdout, EXCEPTED_LOSS)
 
         # test lora  merge
@@ -257,7 +257,7 @@ class DPOTrainTest(unittest.TestCase):
                 dop_full_tp_pp_reusme_f.write(dop_full_tp_pp_reusme_output)
         self.dpotrain_tester.assert_result(reusme_p.returncode, reusme_p.stdout)
 
-        EXCEPTED_LOSS = 0.691568
+        EXCEPTED_LOSS = 0.691346
         self.dpotrain_tester.assert_loss(reusme_p.stdout, EXCEPTED_LOSS)
 
         # test model generate
@@ -309,7 +309,7 @@ class DPOTrainTest(unittest.TestCase):
                 dop_lora_tp_pp_reusme_f.write(dop_lora_tp_pp_reusme_output)
         self.dpotrain_tester.assert_result(reusme_p.returncode, reusme_p.stdout)
 
-        EXCEPTED_LOSS = 0.691406
+        EXCEPTED_LOSS = 0.691126
         self.dpotrain_tester.assert_loss(reusme_p.stdout, EXCEPTED_LOSS)
 
         # test lora  merge

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,6 +2,8 @@ parameterized
 sentencepiece
 regex
 torch>=2.1
+torchvision
+av
 fast_dataindex
 sacremoses
 pydantic

--- a/tests/transformers/test_hf_image_processor.py
+++ b/tests/transformers/test_hf_image_processor.py
@@ -61,6 +61,7 @@ class TestHFMultiSourceImageProcessor(unittest.TestCase):
     #     )
     #     self.preprocess(image_processor)
 
+    @skip_for_none_ce_case
     def test_model_scope(self):
         image_processor = AutoImageProcessor.from_pretrained("Qwen/Qwen2.5-VL-3B-Instruct", download_hub="modelscope")
         self.preprocess(image_processor)

--- a/tests/transformers/test_hf_processor.py
+++ b/tests/transformers/test_hf_processor.py
@@ -147,6 +147,7 @@ class TestHFMultiSourceProcessor(unittest.TestCase):
     #     self.preprocess_image(processor)
     #     self.preprocess_video(processor)
 
+    @skip_for_none_ce_case
     def test_model_scope(self):
         processor = AutoProcessor.from_pretrained("Qwen/Qwen2.5-VL-3B-Instruct", download_hub="modelscope")
         self.preprocess_image(processor)

--- a/tests/transformers/test_hf_video_processor.py
+++ b/tests/transformers/test_hf_video_processor.py
@@ -67,6 +67,7 @@ class TestHFMultiSourceVideoProcessor(unittest.TestCase):
     #     )
     #     self.preprocess(video_processor)
 
+    @skip_for_none_ce_case
     def test_model_scope(self):
         video_processor = AutoVideoProcessor.from_pretrained("Qwen/Qwen2.5-VL-3B-Instruct", download_hub="modelscope")
         self.preprocess(video_processor)


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
1. 修复DPO训练PP与非PP情况下Loss不一致问题

> 修复前DPO Loss(2卡PP=2[绿线]&单卡[蓝线])：

<img width="2324" height="1396" alt="train_loss (2)" src="https://github.com/user-attachments/assets/169e293b-e851-40ea-924c-2d9e614df2ff" />

> 修复后DPO Loss(2卡PP=2[绿线]&单卡[蓝线])：

<img width="2324" height="1396" alt="train_loss (1)" src="https://github.com/user-attachments/assets/60bfe697-db6d-46ff-a3dd-3971248e714a" />

2. 替换非PP情况的DPO Criterion实现

> 替换前后DPO Loss(单卡)：

<img width="2324" height="1396" alt="train_loss (3)" src="https://github.com/user-attachments/assets/df7f362f-9689-4273-aa16-f705530c0a18" />
