### PR TITLE
fix export tokenizer.json bug

### DIFF
--- a/paddleformers/cli/export/export.py
+++ b/paddleformers/cli/export/export.py
@@ -137,6 +137,7 @@ def run_export(args: Optional[dict[str, Any]] = None) -> None:
                 "tokenizer.model",
                 "tokenizer_config.json",
                 "special_tokens_map.json",
+                "tokenizer.json",
                 # "config.json",
             ]
 


### PR DESCRIPTION
改动：
export脚本的copy_file_list增加tokenizer.json，现在导出的文件夹包含原模型的tokenizer.json。