### PR TITLE
【gpt-oss】fix gpt-oss recompute error

### DIFF
--- a/paddleformers/nn/pp_model.py
+++ b/paddleformers/nn/pp_model.py
@@ -434,10 +434,6 @@ def make_decoder_layer_pipe(decoder_layer):
             attn_mask_startend_row_indices = None
             assert len(tgt_mask.shape) == 4, f"Attention mask should be 4D tensor, but got {tgt_mask.shape}."
 
-        position_ids_decoder = None
-        if position_ids is not None:
-            position_ids_decoder = position_ids[:, :max_seq_len]
-
         if position_embeddings is not None:
             position_embeddings = position_embeddings[..., :max_seq_len, :]
             tuple_position_embeddings = (position_embeddings[0], position_embeddings[1])
@@ -452,7 +448,6 @@ def make_decoder_layer_pipe(decoder_layer):
                 hidden_states,
                 attention_mask=tgt_mask,
                 attn_mask_startend_row_indices=attn_mask_startend_row_indices,
-                position_ids=position_ids_decoder,
                 position_embeddings=tuple_position_embeddings,
                 use_reentrant=self.config.recompute_use_reentrant,
             )
@@ -462,7 +457,6 @@ def make_decoder_layer_pipe(decoder_layer):
                 hidden_states=hidden_states,
                 attention_mask=tgt_mask,
                 attn_mask_startend_row_indices=attn_mask_startend_row_indices,
-                position_ids=position_ids_decoder,
                 position_embeddings=tuple_position_embeddings,
             )
 

--- a/paddleformers/trainer/training_args.py
+++ b/paddleformers/trainer/training_args.py
@@ -302,6 +302,8 @@ class TrainingArguments:
         recompute (`bool`, *optional*, defaults to `False`):
             Recompute the forward pass to calculate gradients. Used for saving memory.
             Only support for networks with transformer blocks.
+        recompute_use_reentrant(`bool`, *optional*, defaults to `True`):
+            Recompute_use_reentrant = True: use PyLayer implementation of recompute, otherwise : use hook implementation of recompute.
         refined_recompute (`str`, *optional*, defaults to `""`):
             The refined recompute parameter is designed to optimize the balance between GPU memory usage and computational speed.
             An example configuration could be: `attention_column_ln:-1,attention_row_ln:-1,flash_attn:-1,mlp_column_ln:5,mlp_row_ln:-1`.
@@ -810,6 +812,10 @@ class TrainingArguments:
             "help": "Recompute the forward pass to calculate gradients. Used for saving memory. "
             "Only support for networks with transformer blocks."
         },
+    )
+    recompute_use_reentrant: bool = field(
+        default=True,
+        metadata={"help": "recompute_use_reentrant"},
     )
     refined_recompute: str = field(
         default="",

--- a/paddleformers/trainer/training_args.py
+++ b/paddleformers/trainer/training_args.py
@@ -302,8 +302,6 @@ class TrainingArguments:
         recompute (`bool`, *optional*, defaults to `False`):
             Recompute the forward pass to calculate gradients. Used for saving memory.
             Only support for networks with transformer blocks.
-        recompute_use_reentrant(`bool`, *optional*, defaults to `True`):
-            Recompute_use_reentrant = True: use PyLayer implementation of recompute, otherwise : use hook implementation of recompute.
         refined_recompute (`str`, *optional*, defaults to `""`):
             The refined recompute parameter is designed to optimize the balance between GPU memory usage and computational speed.
             An example configuration could be: `attention_column_ln:-1,attention_row_ln:-1,flash_attn:-1,mlp_column_ln:5,mlp_row_ln:-1`.
@@ -812,10 +810,6 @@ class TrainingArguments:
             "help": "Recompute the forward pass to calculate gradients. Used for saving memory. "
             "Only support for networks with transformer blocks."
         },
-    )
-    recompute_use_reentrant: bool = field(
-        default=True,
-        metadata={"help": "recompute_use_reentrant"},
     )
     refined_recompute: str = field(
         default="",

--- a/paddleformers/transformers/configuration_utils.py
+++ b/paddleformers/transformers/configuration_utils.py
@@ -272,7 +272,7 @@ class LlmMetaConfig:
             "full",
             "Recompute granularity, Choose among ['full', 'core_attn', 'full_attn']",
         ),
-        ("recompute_use_reentrant", bool, False, "recompute_use_reentrant"),
+        ("recompute_use_reentrant", bool, True, "recompute_use_reentrant"),
         # refined_recompute attributes
         (
             "refined_recompute",

--- a/paddleformers/transformers/gpt_oss/modeling.py
+++ b/paddleformers/transformers/gpt_oss/modeling.py
@@ -748,12 +748,12 @@ class GptOssModel(GptOssPreTrainedModel):
             position_ids,
             attention_mask,
             output_attentions,
-            # output_router_logits,
+            output_router_logits,
             past_key_value,
             use_cache,
             position_embeddings,
             attn_mask_startend_row_indices,
-            # use_reentrant=self.config.recompute_use_reentrant,
+            use_reentrant=self.config.recompute_use_reentrant,
         )
 
         return hidden_states


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what this PR does -->
pcard-67164
recompute_use_reentrant 默认为false时，会使用框架的_recompute_without_reentrant 方法，该方法反向梯度计算有误
