### PR TITLE
glm 4.5 air开启lora时, 绕过gate的被冻结梯度防止hang-2

### DIFF
--- a/paddleformers/trainer/trainer_callback.py
+++ b/paddleformers/trainer/trainer_callback.py
@@ -833,11 +833,14 @@ class MoEGateSpGradSyncCallBack(TrainerCallback):
             hcg = fleet.get_hybrid_communicate_group()
             pg = hcg.get_model_parallel_group().process_group
             for param in model.parameters():
-                if getattr(param, "is_gate", False):
-                    if hasattr(param, "main_grad"):
-                        pg.allreduce(param.main_grad).wait()
-                    else:
-                        pg.allreduce(param.grad).wait()
+                if not getattr(param, "is_gate", False):
+                    continue
+                grad = getattr(param, "main_grad", None)
+                if grad is None:
+                    grad = getattr(param, "grad", None)
+                if grad is None:
+                    continue
+                pg.allreduce(grad).wait()
 
             logger.info("MoEGate grad allreduced done")
 


### PR DESCRIPTION
修复glm ep+sp+开启lora时，router 因为没有梯度而hang