### PR TITLE
[AutoParallel]  Refactor qwen3 model in intermediate api

### DIFF
--- a/paddleformers/transformers/configuration_utils.py
+++ b/paddleformers/transformers/configuration_utils.py
@@ -537,6 +537,9 @@ class PretrainedConfig:
             Whether the model's input and output word embeddings should be tied. Note that this is only relevant if the
             model has a output word embedding layer.
 
+        run_single_model (`bool`, *optional*, defaults to `False`):
+            Whether to run the model in single card mode. When enabled, all parallel degree configurations will be disabled.
+
         dtype (`str`, *optional*):
             The `dtype` of the weights. This attribute can be used to initialize the model to a non-default `dtype`
             (which is normally `float32`) and thus allow for optimal storage allocation. For example, if the saved
@@ -600,6 +603,13 @@ class PretrainedConfig:
         self.output_attentions = kwargs.pop("output_attentions", False)
         self.use_cache = kwargs.pop("use_cache", False)
         self.tie_word_embeddings = kwargs.pop("tie_word_embeddings", True)
+
+        # for run model in single card mode
+        self.run_single_model = kwargs.pop("run_single_model", False)
+        if self.run_single_model:
+            self.tensor_parallel_degree = 1
+            self.sep_parallel_degree = 1
+            self.context_parallel_degree = 1
 
         # for transformers fuse
         self.fuse_linear = kwargs.pop("fuse_linear", False)

--- a/paddleformers/transformers/qwen3/auto_dist_config.py
+++ b/paddleformers/transformers/qwen3/auto_dist_config.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle.distributed as dist
+
+
+def get_dist_config(model, prefix="model."):
+    if prefix != "":
+        assert prefix.endswith(".")
+    config = {
+        "mp_config": {
+            "parallelize_plan": {
+                f"{prefix}model.embed_tokens": dist.RowWiseParallel(),
+                f"{prefix}model.layers.*.self_attn.q_proj": dist.ColWiseParallel(),
+                f"{prefix}model.layers.*.self_attn.k_proj": dist.ColWiseParallel(),
+                f"{prefix}model.layers.*.self_attn.v_proj": dist.ColWiseParallel(),
+                f"{prefix}model.layers.*.self_attn.o_proj": dist.RowWiseParallel(),
+                f"{prefix}model.layers.*.mlp.gate_proj": dist.ColWiseParallel(),
+                f"{prefix}model.layers.*.mlp.up_proj": dist.ColWiseParallel(),
+                f"{prefix}model.layers.*.mlp.down_proj": dist.RowWiseParallel(),
+                f"{prefix}lm_head.weight": dist.RowWiseParallel(),
+            }
+        },
+    }
+
+    return config

--- a/paddleformers/transformers/qwen3/modeling.py
+++ b/paddleformers/transformers/qwen3/modeling.py
@@ -297,8 +297,6 @@ class Qwen3PretrainedModel(PretrainedModel):
     @classmethod
     def _get_tensor_parallel_mappings(cls, config: Qwen3Config, is_split=True):
         """Generate tensor parallel mappings for model conversion."""
-        if config.run_single_model:
-            return {}
         from ..conversion_utils import split_or_merge_func
 
         fn = split_or_merge_func(

--- a/paddleformers/transformers/qwen3/modeling.py
+++ b/paddleformers/transformers/qwen3/modeling.py
@@ -48,6 +48,7 @@ from ..model_outputs import (
     TokenClassifierOutput,
 )
 from ..model_utils import PretrainedModel, register_base_model
+from .auto_dist_config import get_dist_config
 from .configuration import Qwen3Config
 
 
@@ -296,6 +297,8 @@ class Qwen3PretrainedModel(PretrainedModel):
     @classmethod
     def _get_tensor_parallel_mappings(cls, config: Qwen3Config, is_split=True):
         """Generate tensor parallel mappings for model conversion."""
+        if config.run_single_model:
+            return {}
         from ..conversion_utils import split_or_merge_func
 
         fn = split_or_merge_func(
@@ -713,6 +716,10 @@ class Qwen3ForCausalLM(Qwen3PretrainedModel):
             hidden_states=outputs.hidden_states,
             attentions=outputs.attentions,
         )
+
+    def auto_dist_config(self, prefix=""):
+        assert self.config.run_single_model, "Use `get_dist_config` only in single card mode."
+        return get_dist_config(self, prefix)
 
 
 class Qwen3ForSequenceClassification(Qwen3PretrainedModel):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->
在重构 trainer （ https://github.com/PaddlePaddle/PaddleFormers/pull/2801 ）的基础上对 llama 3.1 模型组网接口进行优化
组网统一使用 modeling.py，移除 modeling_network.py 和 modeling_auto.py
该 PR 逻辑如下：

1. 用户在脚本中开启中层api动半时：

> enable_auto_parallel true
> use_intermediate_api true

2. 在 PretrainedConfig 中引入开关 run_single_model，当跑中层api动半时，该开关会被设为开启，并会关闭其他并行配置(将 sharding_parallel_degree、tensor_parallel_degree、sep_parallel_degree、context_parallel_degree 设为1)，通过 run_single_model 对 modeling 组网进行 hack，让 modeling.py 在运行时是在单卡代码模式下，避免跑到动手通信的地方

3.  在 pretrain 文件中，当检测到 开启中层api 时，会将 run_single_model 设为 True，并关闭其他并行配置

4. 在 modeling.py 添加中层api配置。新增文件 auto_dist_config.py，这是中层 api 的配置文件，记录每层在不同并行下的切分状态。给 Qwen3ForCausalLM 添加函数 auto_dist_config ，这个函数会在 trainer 初始化时去读取这个配置，并初始化中层api的环境
