### PR TITLE
Cherry-pick GLM4Moe: fix qk_norm (#2998) 

### DIFF
--- a/paddleformers/transformers/glm4_moe/modeling.py
+++ b/paddleformers/transformers/glm4_moe/modeling.py
@@ -192,14 +192,14 @@ class Glm4MoeAttention(nn.Layer):
             self.q_norm = GeneralNorm.create(
                 config=config,
                 norm_type="rms_norm",
-                hidden_size=config.hidden_size,
+                hidden_size=self.head_dim,
                 norm_eps=config.rms_norm_eps,
                 input_is_parallel=self.tensor_parallel,
             )
             self.k_norm = GeneralNorm.create(
                 config=config,
                 norm_type="rms_norm",
-                hidden_size=config.hidden_size,
+                hidden_size=self.head_dim,
                 norm_eps=config.rms_norm_eps,
                 input_is_parallel=self.tensor_parallel,
             )


### PR DESCRIPTION
Cherry-pick pr https://github.com/PaddlePaddle/PaddleFormers/pull/2998
改动：
修复qk_norm传参错误的问题