### PR TITLE
Fix(image_processor): Remove download code in image processor

### DIFF
--- a/paddleformers/transformers/auto/image_processing.py
+++ b/paddleformers/transformers/auto/image_processing.py
@@ -256,14 +256,9 @@ class AutoImageProcessor(hf.AutoImageProcessor):
         # Load the image processor config
         try:
             # Main path for all transformers models and local TimmWrapper checkpoints
-            if download_hub == DownloadSource.HUGGINGFACE:
-                config_dict, _ = ImageProcessingMixin.get_image_processor_dict(
-                    pretrained_model_name_or_path, image_processor_filename=image_processor_filename, **kwargs
-                )
-            else:
-                config_dict, _ = PaddleImageProcessingMixin.get_image_processor_dict(
-                    pretrained_model_name_or_path, image_processor_filename=image_processor_filename, **kwargs
-                )
+            config_dict, _ = PaddleImageProcessingMixin.get_image_processor_dict(
+                pretrained_model_name_or_path, image_processor_filename=image_processor_filename, **kwargs
+            )
         except Exception as initial_exception:
             # Fallback path for Hub TimmWrapper checkpoints. Timm models' image processing is saved in `config.json`
             # instead of `preprocessor_config.json`. Because this is an Auto class and we don't have any information

--- a/paddleformers/transformers/image_processing_utils.py
+++ b/paddleformers/transformers/image_processing_utils.py
@@ -32,7 +32,7 @@ from transformers.image_processing_utils import (
 from transformers.image_processing_utils import get_size_dict  # noqa: F401
 from transformers.utils import PROCESSOR_NAME
 
-from ..utils.download import DownloadSource, resolve_file_path
+from ..utils.download import resolve_file_path
 from ..utils.log import logger
 from .feature_extraction_utils import BatchFeature
 
@@ -186,13 +186,6 @@ class PaddleImageProcessingMixin:
         if download_hub is None:
             download_hub = os.environ.get("DOWNLOAD_SOURCE", "huggingface")
         logger.info(f"Using download source: {download_hub}")
-
-        # If downloaded from hf, use the native hf from pretrained
-        if download_hub == DownloadSource.HUGGINGFACE:
-            return super().get_image_processor_dict(
-                pretrained_model_name_or_path,
-                **kwargs,
-            )
 
         cache_dir = kwargs.pop("cache_dir", None)
         subfolder = kwargs.pop("subfolder", "")


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
修复Processor保存本地路径时，无法正常加载(`download_hub="huggingface"`)