### PR TITLE
fix/update ernie4_5 apply_fused_rope

### DIFF
--- a/paddleformers/transformers/ernie4_5/modeling.py
+++ b/paddleformers/transformers/ernie4_5/modeling.py
@@ -108,7 +108,7 @@ def apply_fused_rope(query_states, key_states, rope_theta):
             None,
             rotary_emb_base=rope_theta,
         )
-    return query_states, key_states
+    return query_states.transpose(1, 2), key_states.transpose(1, 2)
 
 
 class Ernie4_5RotaryEmbedding(nn.Layer):


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Models

### Description
ernie4_5组网中apply_fused_rope的维度返回时没有transpose，导致形状错误。
apply_fused_rope返回时加上了transpose，最终返回的形状为[b h l d]