### PR TITLE
[Llama3] Fix fc when lm_head not exists

### DIFF
--- a/paddleformers/transformers/llama/modeling.py
+++ b/paddleformers/transformers/llama/modeling.py
@@ -438,11 +438,11 @@ class LlamaPretrainedModel(PretrainedModel):
                 for PROJECTOR_NAME in ["gate_proj", "up_proj", "down_proj"]
             ]
         )
-
-        if config.tie_word_embeddings:
-            aoa_statements.append("model.embed_tokens.weight -> lm_head.weight")
-        else:
-            aoa_statements.append("lm_head.weight -> lm_head.weight")
+        if cls != cls.base_model_class:
+            if config.tie_word_embeddings:
+                aoa_statements.append("model.embed_tokens.weight -> lm_head.weight")
+            else:
+                aoa_statements.append("lm_head.weight -> lm_head.weight")
 
         return {"aoa_statements": aoa_statements}
 
@@ -471,7 +471,7 @@ class LlamaPretrainedModel(PretrainedModel):
             ]
         )
 
-        if not config.tie_word_embeddings:
+        if not config.tie_word_embeddings and cls != cls.base_model_class:
             aoa_statements.append("lm_head.weight -> lm_head.weight")
 
         return {"aoa_statements": aoa_statements}

--- a/tests/transformers/llama/test_modeling.py
+++ b/tests/transformers/llama/test_modeling.py
@@ -447,15 +447,15 @@ class Llama3ModelIntegrationTest(ModelTesterPretrainedMixin, unittest.TestCase):
         with paddle.no_grad():
             output = model(input_ids, attention_mask=attention_mask)[0]
 
-        expected_shape = [1, 11, 64]
+        expected_shape = [1, 11, 512]
         self.assertEqual(output.shape, expected_shape)
 
         expected_slice = paddle.to_tensor(
             [
                 [
-                    [0.01802453, -0.42128855, 0.45844582],
-                    [-0.12787277, 0.00660499, 0.83033413],
-                    [0.44403678, 0.26123494, 1.36080980],
+                    [1.33794415, -0.19816241, -1.59525776],
+                    [1.69990170, -0.31080112, -1.62164509],
+                    [1.70097589, -0.30771524, -1.16779113],
                 ]
             ],
             dtype=output.dtype,
@@ -476,14 +476,14 @@ class Llama3ModelIntegrationTest(ModelTesterPretrainedMixin, unittest.TestCase):
         with paddle.no_grad():
             output = model(input_ids, attention_mask=attention_mask)[0]
 
-        expected_shape = [1, 11, 64]
+        expected_shape = [1, 11, 512]
         self.assertEqual(output.shape, expected_shape)
         expected_slice = paddle.to_tensor(
             [
                 [
-                    [0.01802453, -0.42128855, 0.45844582],
-                    [-0.12787277, 0.00660499, 0.83033413],
-                    [0.44403678, 0.26123494, 1.36080980],
+                    [1.33794415, -0.19816241, -1.59525776],
+                    [1.69990170, -0.31080112, -1.62164509],
+                    [1.70097589, -0.30771524, -1.16779113],
                 ]
             ],
             dtype=output.dtype,


### PR DESCRIPTION
- 修复当 lm_head 不存在时 aoa 规则仍尝试保存 lm_head weight
- 更新 tiny-random-llama3 权重