### PR TITLE
Fix: enable GQA in scaled dot-product attention

### DIFF
--- a/paddleformers/nn/attention/sdpa_attention.py
+++ b/paddleformers/nn/attention/sdpa_attention.py
@@ -48,7 +48,14 @@ def sdpa_attention_forward(
 
     if sink is None:
         attn_output = nn.functional.scaled_dot_product_attention(
-            query, key, value, attention_mask, dropout, is_causal=is_causal, training=module.training
+            query,
+            key,
+            value,
+            attention_mask,
+            dropout,
+            is_causal=is_causal,
+            training=module.training,
+            enable_gqa=True,
         )
     else:
         attn_output = sink_attention_forward(

--- a/paddleformers/transformers/ernie4_5_moe_vl/model/fusion_ops/common_fusion_ops.py
+++ b/paddleformers/transformers/ernie4_5_moe_vl/model/fusion_ops/common_fusion_ops.py
@@ -93,11 +93,7 @@ def _fusion_flash_attention(
             attention_mask = _gen_from_sparse_attn_mask_indices(attn_mask_start_row_indices, q.dtype)
             if rr_flash_attn is None:
                 out = F.scaled_dot_product_attention(
-                    q,
-                    k,
-                    v,
-                    attn_mask=attention_mask,
-                    is_causal=False,
+                    q, k, v, attn_mask=attention_mask, is_causal=False, enable_gqa=True
                 )
             else:
                 out = rr_flash_attn(
@@ -107,6 +103,7 @@ def _fusion_flash_attention(
                     v,
                     attn_mask=attention_mask,
                     is_causal=False,
+                    enable_gqa=True,
                 )
         weights = None
     else:
@@ -117,6 +114,7 @@ def _fusion_flash_attention(
                 v,
                 attn_mask=attention_mask,
                 is_causal=attention_mask is None and q.shape[1] != 1,
+                enable_gqa=True,
             )
             weights = None
         else:
@@ -127,6 +125,7 @@ def _fusion_flash_attention(
                 v,
                 attn_mask=attention_mask,
                 is_causal=attention_mask is None and q.shape[1] != 1,
+                enable_gqa=True,
             )
             weights = None
 

--- a/paddleformers/transformers/qwen/modeling.py
+++ b/paddleformers/transformers/qwen/modeling.py
@@ -259,6 +259,7 @@ class QWenAttention(nn.Layer):
                     attn_mask=attention_mask,
                     is_causal=attention_mask is None,
                     enable=skip_recompute,
+                    enable_gqa=True,
                 )
                 attn_weights = None
 

--- a/paddleformers/transformers/qwen/modeling_auto.py
+++ b/paddleformers/transformers/qwen/modeling_auto.py
@@ -174,11 +174,7 @@ class QWenAttentionAuto(nn.Layer):
                 )
             else:
                 attn_output = F.scaled_dot_product_attention(
-                    query,
-                    key,
-                    value,
-                    attn_mask=attention_mask,
-                    is_causal=attention_mask is None,
+                    query, key, value, attn_mask=attention_mask, is_causal=attention_mask is None, enable_gqa=True
                 )
                 attn_weights = None
             return attn_output, attn_weights

--- a/paddleformers/transformers/qwen/modeling_network.py
+++ b/paddleformers/transformers/qwen/modeling_network.py
@@ -151,11 +151,7 @@ class QWenAttentionNet(nn.Layer):
                 )
             else:
                 attn_output = F.scaled_dot_product_attention(
-                    query,
-                    key,
-                    value,
-                    attn_mask=attention_mask,
-                    is_causal=attention_mask is None,
+                    query, key, value, attn_mask=attention_mask, is_causal=attention_mask is None, enable_gqa=True
                 )
                 attn_weights = None
             return attn_output, attn_weights

--- a/tests/transformers/test_ring_flash_attention.py
+++ b/tests/transformers/test_ring_flash_attention.py
@@ -17,7 +17,7 @@ import unittest
 
 import numpy as np
 import paddle
-from paddle.nn.functional.flash_attention import scaled_dot_product_attention
+from paddle.nn.functional import scaled_dot_product_attention
 
 from paddleformers.transformers.ring_flash_attention import (
     RingFlashAttention,
@@ -84,7 +84,9 @@ class TestRingFlashAttention(unittest.TestCase):
             local_out = RingFlashAttention.apply(
                 local_query, local_key, local_value, self.group, is_causal=is_causal, attn_mask=local_attn_mask
             )
-            ref_out = scaled_dot_product_attention(query, key, value, is_causal=is_causal, attn_mask=attn_mask)
+            ref_out = scaled_dot_product_attention(
+                query, key, value, is_causal=is_causal, attn_mask=attn_mask, enable_gqa=True
+            )
 
         local_out.backward()
         ref_out.backward()


### PR DESCRIPTION
在 paddle.nn.F.sdpa 调用中传入 `enable_gqa=True` 以适配 https://github.com/PaddlePaddle/Paddle/pull/76446 更新
