### PR TITLE
[加载模型]修复fused +pp开启时,因key(q /kv)不在同一safetensor时被跳过并随机初始化的bug

### DIFF
--- a/paddleformers/transformers/model_utils.py
+++ b/paddleformers/transformers/model_utils.py
@@ -2418,6 +2418,23 @@ class PretrainedModel(Layer, GenerationMixin, ConversionMixin):
                 origin_expected_keys = [k.replace("quant_weight", "weight") for k in expected_keys]
                 expected_keys_set = set(expected_keys + origin_expected_keys)
 
+            # Add original (pre-fuse) keys so that shards containing q/k/v or gate/up are not skipped
+            try:
+                fuse_actions, _ = cls.get_fuse_or_split_param_convert_actions(
+                    config, loaded_keys, is_fuse=True, ignore_error=True
+                )
+                logger.info(
+                    f"Getting fuse_actions for determine expected keys set succeed, "
+                    f"number of fuse actions: {len(fuse_actions)}"
+                )
+            except Exception as e:
+                logger.warning(f"get_fuse_or_split_param_convert_actions failed when building expected_keys_set: {e}")
+                fuse_actions = {}
+            for keys in fuse_actions.keys():
+                fused_key = keys[-1]
+                if fused_key in expected_keys_set:
+                    expected_keys_set.update(keys[:-1])
+
             if key_mapping is not None:
                 # Determine the precise set of original checkpoint keys that are actually needed for the current file.
                 # This set will be used to identify which sharded checkpoint files are relevant and must be loaded.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
- Description:
      - 修复开启 fuse_qkv/fuse_mlp 且使用 sharded safetensors、Pipeline 并行时，分片过滤仅按融合后键名匹配，导致含原始 q/k/v 或 gate/up 权重的分片被误跳过，权重随机初始化的问题。
      - 在分片跳过前，将需要的融合后键对应的原始键加入 expected_keys_set，确保包含 q/k/v 或 gate/up 的分片不会被过滤；未开启 fuse 时行为不变，依旧按文件过滤，避免全量扫描所有分片

### Description
<!-- Describe what this PR does -->
