### PR TITLE
Cherry-Pick from #3093: 修复开启lora时recompute报错pp_model 

### DIFF
--- a/paddleformers/nn/pp_model.py
+++ b/paddleformers/nn/pp_model.py
@@ -319,6 +319,7 @@ class EmbeddingPipe(nn.Layer):
 
             ret = (emb,)
 
+        ret[0].stop_gradient = False  # 开启lora 防止recompute pylayer因base weight输入没有gradient而报错
         if attention_mask is not None:
             if attention_mask.dtype != paddle.int32:
                 if len(attention_mask.shape) == 2:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
https://github.com/PaddlePaddle/PaddleFormers/pull/3093
开启pp+lora 时，如果走pylayer的recompute，需要输入有梯度，直接在pp_model这里把embedding后面的gradient打开即可，应该不会影响其他模式
