### PR TITLE
Feat(VL Training)Support Qwen2.5-VL training and freeze MLLM modules

### DIFF
--- a/docs/zh/datasets_format_zh.md
+++ b/docs/zh/datasets_format_zh.md
@@ -8,11 +8,11 @@
 
 ### 1.1. 在线数据流
 
-#### 1.1.1. erniekit格式
+#### 1.1.1. erniekit 格式
 
 使用 `erniekit` 格式需要在 `train(/eval)_dataset_type` 处指定为 `erniekit`
 
-erniekit格式：每条数据都是一个字典，包含以下字段：
+erniekit 格式：每条数据都是一个字典，包含以下字段：
 
 - `text` : `str, List(str)`
 
@@ -30,11 +30,11 @@ wget https://paddleformers.bj.bcebos.com/datasets/pt_data.tar.gz
 mkdir -p data/pt && tar -xf pt_data.tar.gz -C data/pt/
 ```
 
-#### 1.1.2. messages格式
+#### 1.1.2. messages 格式
 
 使用 `messages` 格式需要在 `train(/eval)_dataset_type` 处指定为 `messages`
 
-messages格式：每条数据都是一个字典，包含以下字段：
+messages 格式：每条数据都是一个字典，包含以下字段：
 
 - `messages` : `List(Dict）`
 
@@ -49,7 +49,7 @@ messages格式：每条数据都是一个字典，包含以下字段：
 
 我们也可以选择使用离线的比特预训练数据流，更节省内存。
 
-为了方便测试，我们也提供了[离线预训练demo数据集](https://paddleformers.bj.bcebos.com/datasets/pretrain_offline_data.tar.gz)可以直接使用：
+为了方便测试，我们也提供了[离线预训练 demo 数据集](https://paddleformers.bj.bcebos.com/datasets/pretrain_offline_data.tar.gz)可以直接使用：
 
 ```shell
 wget https://paddleformers.bj.bcebos.com/datasets/pretrain_offline_data.tar.gz
@@ -60,7 +60,7 @@ tar -xf pretrain_offline_data.tar.gz -C data/pre-training/
 
 下载一个文本数据集，例如 https://modelscope.cn/datasets/BazingaLyn/mini_pretrain_dataset
 
-格式需为jsonl，每行格式例如BazingaLyn/mini_pretrain_dataset/pretrain_hq_v7.jsonl：
+格式需为 jsonl，每行格式例如 BazingaLyn/mini_pretrain_dataset/pretrain_hq_v7.jsonl：
 ```text
 {"text": "番茄炒蛋\n材料：\n鸡蛋3个、番茄1个、油、盐、糖、水淀粉\n做法：..."}
 {"text": "请描述一下如何正确规划个人理财。正确规划个人理财需要以下几个步骤..."}
@@ -82,35 +82,35 @@ python -u examples/tools/create_pretraining_data.py \
 ```
 
 - 参数说明
- 
+
 | 参数名              | 类型        | 说明                 |
 |--------------------|----------- |-----------------|
 | `--model_name_or_path`     | string     | 模型路径  |
 | `--data_format`    | string     | 支持的文件格式，当前只支持 JSON |
-| `--input_path`     | string     | 输入的json文件的路径  |
-| `--append_eos`     | store_true | 是否在document的结尾添加eos token  |
+| `--input_path`     | string     | 输入的 json 文件的路径  |
+| `--append_eos`     | store_true | 是否在 document 的结尾添加 eos token  |
 | `--output_prefix`  | str        | 输出文件的前缀    |
 | `--workers`        | int        | 运行的进程数     |
 | `--log_interval`   | int        | 打印日志间隔   |
-| `--data_impl`      | str        | 制作的数据集类型，默认为mmap，也可以选择lazy |
+| `--data_impl`      | str        | 制作的数据集类型，默认为 mmap，也可以选择 lazy |
 
-## 2. SFT数据流
+## 2. SFT 数据流
 
-### erniekit格式
+### erniekit 格式
 
 使用 `erniekit` 格式需要在 `train(/eval)_dataset_type` 处指定为 `erniekit`
 
-SFT数据流中，每条数据都是一个字典，包含以下字段：
+SFT 数据流中，每条数据都是一个字典，包含以下字段：
 
 - `src` : `str, List(str)`, 模型的输入指令（instruction）、提示（prompt），模型应该执行的任务。
 - `tgt` : `str, List(str)`, 模型的输出。
 - `system(optional)` : 系统配置
 - `label(optional)`: Training flag (1=参与训练, 0=不参与训练)
-- `is_system(optional)` : 标志src的第一条数据是否是system
+- `is_system(optional)` : 标志 src 的第一条数据是否是 system
 
 Notes:
 * `src` 和 `tgt` 为支持多轮对话的列表（List）对象
-* 每个训练样本均为JSON格式，多个样本以换行符分隔
+* 每个训练样本均为 JSON 格式，多个样本以换行符分隔
 
 样例数据：
 ```json
@@ -136,13 +136,13 @@ mkdir -p data/sft && tar -xf alpaca_demo.gz -C data/sft/ --strip-components=1
 ```
 
 
-### messages格式
+### messages 格式
 
 使用 `messages` 格式需要在 `train(/eval)_dataset_type` 处指定为 `messages`
 
-SFT数据流中，每条数据都是一个字典，包含以下字段：
+SFT 数据流中，每条数据都是一个字典，包含以下字段：
 
-- `messages` : `List(Dict)`, 每个字典包含 `role`、`content`、`tool_calls(optional)` 三种key。
+- `messages` : `List(Dict)`, 每个字典包含 `role`、`content`、`tool_calls(optional)` 三种 key。
     - `role` 的值可以选择 `system`, `user`, `assistant` 或 `tool(optional)`。
     - `content`为具体的对话内容。
     - `tool_calls(optional)` 为申请工具调用。
@@ -150,7 +150,7 @@ SFT数据流中，每条数据都是一个字典，包含以下字段：
 - `label(optional)`: Training flag (1=参与训练, 0=不参与训练)
 
 Notes:
-* 每个训练样本均为JSON格式，多个样本以换行符分隔
+* 每个训练样本均为 JSON 格式，多个样本以换行符分隔
 
 样例数据：
 
@@ -166,9 +166,9 @@ Notes:
 ]
 ```
 
-- 注意：在 `examples/data/sft_think-train.jsonl` 和 `examples/data/sft_think-eval.jsonl` 中提供的demo数据集来自由nvidia发布的 [OpenCodeReasoning数据集](https://huggingface.co/datasets/nvidia/OpenCodeReasoning)。该数据集需要遵循 Creative Commons Attribution 4.0 International License (CC BY 4.0) 协议。
+- 注意：在 `examples/data/sft_think-train.jsonl` 和 `examples/data/sft_think-eval.jsonl` 中提供的 demo 数据集来自由 nvidia 发布的 [OpenCodeReasoning 数据集](https://huggingface.co/datasets/nvidia/OpenCodeReasoning)。该数据集需要遵循 Creative Commons Attribution 4.0 International License (CC BY 4.0) 协议。
 
-用于function call训练的demo数据：
+用于 function call 训练的 demo 数据：
 
 ```json
 [
@@ -194,23 +194,23 @@ wget https://paddleformers.bj.bcebos.com/datasets/sft_function_call_demo.tar.gz
 mkdir -p data/sft && tar -zxf sft_function_call_demo.tar.gz -C data/sft/
 ```
 
-## 3. DPO数据流
+## 3. DPO 数据流
 
-### erniekit格式
+### erniekit 格式
 
 使用 `erniekit` 格式需要在 `train(/eval)_dataset_type` 处指定为 `erniekit`
 
-DPO数据流中，每条数据都是一个字典，包含以下字段：
+DPO 数据流中，每条数据都是一个字典，包含以下字段：
 
 - `system(optional)`: 系统配置
 - `src` : `str, List(str)`, 用户对话内容
-- `tgt` : `str, List(str)`, 系统回复内容（比src少一个）
+- `tgt` : `str, List(str)`, 系统回复内容（比 src 少一个）
 - `response` : `str, List(str)`, 包含 chosen 和 rejected 回复。
 - `sort` : `List(int)`, sort 值用于区分 response 中 chosen 和 rejected（sort 值小的是 rejected，sort 值大的是 chosen）。
-- `is_system(optional)` : 标志src的第一条数据是否是system
+- `is_system(optional)` : 标志 src 的第一条数据是否是 system
 
 Notes:
-* 每个训练样本均为JSON格式，多个样本以换行符分隔
+* 每个训练样本均为 JSON 格式，多个样本以换行符分隔
 
 样例数据：
 
@@ -249,7 +249,7 @@ mkdir -p data/dpo && tar -zxf ultrafeedback_binarized.tar.gz -C data/dpo/ --stri
 
 使用 `messages` 格式需要在 `train(/eval)_dataset_type` 处指定为 `messages`
 
-DPO数据流中，每条数据都是一个字典，包含以下字段：
+DPO 数据流中，每条数据都是一个字典，包含以下字段：
 - `messages` : `List(dict)`, 对话历史列表。
   - 普通轮次：包含 `role` (`"user"` 或 `"assistant"`) 和 `content` (`str`) 字段。
   - 偏好/非偏好轮次（用于偏好学习）：包含以下两个关键字段，用于表示对同一用户查询的不同系统回复的偏好排序。
@@ -258,7 +258,7 @@ DPO数据流中，每条数据都是一个字典，包含以下字段：
 - `tools` : `List(dict)`, 对话中可能用到的工具（函数）的定义列表。
 - `label` : `List(int)`, 用于区分 `preferred_output` 和 `non_preferred_output` 的排序标签。其中 0 对应 `non_preferred_output` (rejected)， 1 对应 `preferred_output` (chosen)。
 
-详细的数据格式可见[function call说明](https://github.com/PaddlePaddle/PaddleFormers/blob/develop/examples/best_practices/function_call.md)
+详细的数据格式可见[function call 说明](https://github.com/PaddlePaddle/PaddleFormers/blob/develop/examples/best_practices/function_call.md)
 
 样例数据
 ```json
@@ -329,13 +329,13 @@ wget https://paddleformers.bj.bcebos.com/datasets/dpo_function_call_1k.tar.gz
 mkdir -p data/dpo_fc && tar -zxf dpo_function_call_1k.tar.gz -C data/dpo_fc/
 ```
 
-## 4. 多模 SFT数据流
+## 4. 多模 SFT 数据流
 
-### erniekit格式
+### erniekit 格式
 
 使用 `erniekit` 格式需要在 `train(/eval)_dataset_type` 处指定为 `erniekit`
 
-SFT数据流中，每条数据都是一个字典，包含以下字段：
+SFT 数据流中，每条数据都是一个字典，包含以下字段：
 
 * `text_info`: 纯文本的列表，每个元素包含一个 `text` 和一个 `tag`
   * `text`: 来自使用者的问题或系统回复的文字内容
@@ -397,18 +397,18 @@ SFT数据流中，每条数据都是一个字典，包含以下字段：
 }
 ```
 
-为了方便测试，我们也提供了用于快速训练的demo数据，请根据您的需要下载[数据](https://paddleformers.bj.bcebos.com/datasets/DoclingMatix.tar.gz)，并将其解压缩到`tests/fixtures/dummy/sft-vl/`：
+为了方便测试，我们也提供了用于快速训练的 demo 数据，请根据您的需要下载[数据](https://paddleformers.bj.bcebos.com/datasets/DoclingMatix.tar.gz)，并将其解压缩到`tests/fixtures/dummy/sft-vl/`：
 
 ```shell
 wget https://paddleformers.bj.bcebos.com/datasets/DoclingMatix.tar.gz
-tar -xf DoclingMatix.tar.gz -C tests/fixtures/dummy/sft-vl/ --strip-components=1
+tar -xf DoclingMatix.tar.gz -C tests/fixtures/dummy/sft-vl/
 ```
 
-### messages格式
+### messages 格式
 
 使用 `messages` 格式需要在 `train(/eval)_dataset_type` 处指定为 `messages`
 
-多模messages格式需要在纯文messages格式的基础上加上`images`、`videos`、`audios`几个key，用于传入多模态资源的`url`或者`path`，同时在`messages`中插入`<image>`、`<video>`、`<audio>`标签来表述插入多模态数据的位置：
+多模 messages 格式需要在纯文 messages 格式的基础上加上`images`、`videos`、`audios`几个 key，用于传入多模态资源的`url`或者`path`，同时在`messages`中插入`<image>`、`<video>`、`<audio>`标签来表述插入多模态数据的位置：
 
 纯文：
 ```json

--- a/examples/config/sft-vl/full_tp.yaml
+++ b/examples/config/sft-vl/full_tp.yaml
@@ -32,7 +32,7 @@ save_steps: 100
 save_strategy: steps
 logging_steps: 1
 gradient_accumulation_steps: 4
-logging_dir: ./vdl_log_test
+logging_dir: ./vdl_log
 output_dir: ./checkpoints/qwen2.5-vl-sft-full-tp
 disable_tqdm: true
 eval_accumulation_steps: 16

--- a/examples/config/sft-vl/full_tp.yaml
+++ b/examples/config/sft-vl/full_tp.yaml
@@ -5,14 +5,14 @@ train_dataset_path: ./tests/fixtures/dummy/sft-vl/train.jsonl
 train_dataset_prob: "1.0"
 eval_dataset_path: ./tests/fixtures/dummy/sft-vl/train.jsonl
 eval_dataset_prob: "1.0"
-max_seq_len: 8192
-packing: false
+max_seq_len: 32768
+packing: true
 mix_strategy: concat
 template_backend: custom
 template: qwen2_vl
 
 ### model
-model_name_or_path: Qwen2.5-VL-3B-Instruct
+model_name_or_path: Qwen/Qwen2.5-VL-3B-Instruct
 attn_impl: flashmask
 
 ### finetuning
@@ -32,8 +32,8 @@ save_steps: 100
 save_strategy: steps
 logging_steps: 1
 gradient_accumulation_steps: 4
-logging_dir: ./vdl_log
-output_dir: ./checkpoints/qwen2.5-vl-sft-full
+logging_dir: ./vdl_log_test
+output_dir: ./checkpoints/qwen2.5-vl-sft-full-tp
 disable_tqdm: true
 eval_accumulation_steps: 16
 
@@ -42,9 +42,10 @@ warmup_steps: 20
 learning_rate: 1.0e-5
 
 # performance
-tensor_parallel_degree: 1
+tensor_parallel_degree: 2
 pipeline_parallel_degree: 1
-sharding: stage2
+sequence_parallel: true
+sharding: stage1
 recompute: true
 bf16: true
 fp16_opt_level: O2

--- a/examples/config/sft-vl/lora.yaml
+++ b/examples/config/sft-vl/lora.yaml
@@ -6,7 +6,7 @@ train_dataset_prob: "1.0"
 eval_dataset_path: ./tests/fixtures/dummy/sft-vl/train.jsonl
 eval_dataset_prob: "1.0"
 max_seq_len: 8192
-packing: true
+packing: false
 mix_strategy: concat
 template_backend: custom
 template: qwen2_vl
@@ -14,11 +14,13 @@ template: qwen2_vl
 ### model
 model_name_or_path: Qwen2.5-VL-3B-Instruct
 attn_impl: flashmask
+lora: true
+lora_rank: 8
 
 ### finetuning
 # base
 stage: VL-SFT
-fine_tuning: full
+fine_tuning: lora
 seed: 23
 do_train: true
 do_eval: true
@@ -33,22 +35,22 @@ save_strategy: steps
 logging_steps: 1
 gradient_accumulation_steps: 4
 logging_dir: ./vdl_log
-output_dir: ./checkpoints/Qwen2.5-VL-sft-full-tp-pp
+output_dir: ./checkpoints/qwen2.5-vl-sft-lora
 disable_tqdm: true
 eval_accumulation_steps: 16
 
 # train
 warmup_steps: 20
-learning_rate: 1.0e-5
+learning_rate: 1.0e-4
 
 # performance
-tensor_parallel_degree: 2
-pipeline_parallel_degree: 2
-sequence_parallel: true
-sharding: stage1
+tensor_parallel_degree: 1
+pipeline_parallel_degree: 1
+sharding: stage2
 recompute: true
 bf16: true
 fp16_opt_level: O2
 unified_checkpoint: false
 save_checkpoint_format: "flex_checkpoint"
 load_checkpoint_format: "flex_checkpoint"
+freeze_config: freeze_vision freeze_aligner

--- a/examples/config/sft-vl/lora_tp.yaml
+++ b/examples/config/sft-vl/lora_tp.yaml
@@ -5,8 +5,8 @@ train_dataset_path: ./tests/fixtures/dummy/sft-vl/train.jsonl
 train_dataset_prob: "1.0"
 eval_dataset_path: ./tests/fixtures/dummy/sft-vl/train.jsonl
 eval_dataset_prob: "1.0"
-max_seq_len: 8192
-packing: false
+max_seq_len: 32768
+packing: true
 mix_strategy: concat
 template_backend: custom
 template: qwen2_vl
@@ -14,11 +14,13 @@ template: qwen2_vl
 ### model
 model_name_or_path: Qwen2.5-VL-3B-Instruct
 attn_impl: flashmask
+lora: true
+lora_rank: 8
 
 ### finetuning
 # base
 stage: VL-SFT
-fine_tuning: full
+fine_tuning: lora
 seed: 23
 do_train: true
 do_eval: true
@@ -33,17 +35,18 @@ save_strategy: steps
 logging_steps: 1
 gradient_accumulation_steps: 4
 logging_dir: ./vdl_log
-output_dir: ./checkpoints/qwen2.5-vl-sft-full
+output_dir: ./checkpoints/qwem2.5-vl-sft-lora-tp
 disable_tqdm: true
 eval_accumulation_steps: 16
 
 # train
 warmup_steps: 20
-learning_rate: 1.0e-5
+learning_rate: 1.0e-4
 
 # performance
-tensor_parallel_degree: 1
+tensor_parallel_degree: 2
 pipeline_parallel_degree: 1
+sequence_parallel: true
 sharding: stage2
 recompute: true
 bf16: true

--- a/paddleformers/cli/hparams/finetuning_args.py
+++ b/paddleformers/cli/hparams/finetuning_args.py
@@ -120,7 +120,7 @@ class PreTrainingArguments(TrainingArguments):
         metadata={
             "help": (
                 "Some additional config for freeze params, we provide some option to config it."
-                "following config is support: freeze_vision,freeze_lm"
+                "following config is support: freeze_vision | freeze_llm | freeze_aligner"
             )
         },
     )

--- a/paddleformers/cli/train/sft/workflow.py
+++ b/paddleformers/cli/train/sft/workflow.py
@@ -62,6 +62,10 @@ from paddleformers.transformers import (
 from paddleformers.transformers.configuration_utils import LlmMetaConfig
 from paddleformers.trl import SFTTrainer
 from paddleformers.trl.llm_utils import compute_metrics, get_lora_target_modules
+from paddleformers.trl.mllm_utils import (
+    freeze_model_parameters,
+    get_multimodel_lora_target_modules,
+)
 from paddleformers.utils.log import logger
 
 # Fine-tune Environment Variables to support sharding stage1 overlap optimization.
@@ -260,6 +264,13 @@ def run_sft(
     model_config.seq_length = data_args.max_seq_len
     model_config.max_sequence_length = data_args.max_seq_len
     model_config._attn_implementation = model_args.attn_impl
+
+    # Sync arguments to MLLM sub_config
+    if getattr(model_config, "text_config", None) is not None:
+        model_config.text_config.max_sequence_length = data_args.max_seq_len
+    if getattr(model_config, "vision_config", None) is not None:
+        model_config.vision_config._attn_implementation = model_args.attn_impl
+
     logger.info(f"Final model config: {model_config}")
     logger.info("Creating model")
 
@@ -379,6 +390,10 @@ def run_sft(
             sub_dataset_type=data_args.eval_dataset_type,
             **dataset_config,
         )
+
+    # Freeze model based on training args (Supports for MLLM Full training)
+    if not model_args.lora and getattr(training_args, "freeze_config", ""):
+        freeze_model_parameters(model, training_args.freeze_config)
 
     model = create_peft_model(model_args, training_args, dtype, model)
 
@@ -528,6 +543,11 @@ def create_peft_model(model_args, training_args, dtype, model):
             ), "Currently not support enabling sharding_stage1_overlap in lora mode."
         if model_args.lora_path is None:
             target_modules = get_lora_target_modules(model)
+
+            # Freeze model based on training args (Supports for MLLM LoRA training)
+            if getattr(training_args, "freeze_config", ""):
+                target_modules = get_multimodel_lora_target_modules(model, target_modules, training_args.freeze_config)
+
             lora_config = LoRAConfig(
                 target_modules=target_modules,
                 r=model_args.lora_rank,

--- a/paddleformers/transformers/qwen2_5_vl/modeling.py
+++ b/paddleformers/transformers/qwen2_5_vl/modeling.py
@@ -334,7 +334,7 @@ class Qwen2_5_VLPretrainedModel(PretrainedModel):
             ]
         }
 
-        # visual model
+        # vision model
         aoa_config["aoa_statements"] += (
             [
                 f"visual.blocks.$LAYER_ID.attn.{x}.weight^T -> {visual_prefix}blocks.$LAYER_ID.attn.{x}.weight"
@@ -919,9 +919,9 @@ class Qwen2_5_VLAttention(nn.Layer):
         key_states = self.k_proj(hidden_states)
         value_states = self.v_proj(hidden_states)
 
-        query_states = query_states.view(bsz, q_len, -1, self.head_dim).transpose(1, 2)
-        key_states = key_states.view(bsz, q_len, -1, self.head_dim).transpose(1, 2)
-        value_states = value_states.view(bsz, q_len, -1, self.head_dim).transpose(1, 2)
+        query_states = query_states.reshape(bsz, q_len, -1, self.head_dim).transpose(1, 2)
+        key_states = key_states.reshape(bsz, q_len, -1, self.head_dim).transpose(1, 2)
+        value_states = value_states.reshape(bsz, q_len, -1, self.head_dim).transpose(1, 2)
 
         cos, sin = position_embeddings
         query_states, key_states = apply_multimodal_rotary_pos_emb(
@@ -948,7 +948,6 @@ class Qwen2_5_VLAttention(nn.Layer):
 
         if self.config.sequence_parallel:
             attn_output = attn_output.reshape([-1, attn_output.shape[-1]])
-        attn_output = attn_output.reshape([bsz, q_len, -1]).contiguous()
         attn_output = self.o_proj(attn_output)
         if not output_attentions:
             attn_weights = None
@@ -1817,7 +1816,7 @@ class Qwen2_5_VLForConditionalGeneration(Qwen2_5_VLPretrainedModel):
 
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
         slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
-        logits = self.lm_head(hidden_states[:, slice_indices, :])
+        logits = self.lm_head(hidden_states[..., slice_indices, :])
 
         loss = None
         if labels is not None:

--- a/paddleformers/trl/__init__.py
+++ b/paddleformers/trl/__init__.py
@@ -39,6 +39,10 @@ import_structure = {
         "get_eos_token_id",
         "set_triton_cache",
     ],
+    "mllm_utils": [
+        "freeze_model_parameters",
+        "get_multimodel_lora_target_modules",
+    ],
     "model_config": ["ModelConfig"],
     "quant_config": ["QuantConfig"],
     "sft_auto_trainer": ["SFTAutoTrainer"],

--- a/paddleformers/trl/llm_utils.py
+++ b/paddleformers/trl/llm_utils.py
@@ -155,6 +155,25 @@ def get_lora_target_modules(model):
             ".*w2.*",
             ".*w3.*",
         ]
+    elif model.config.model_type == "qwen2_5_vl":
+        target_modules = [
+            # llm
+            "model.language_model.*q_proj.*",
+            "model.language_model.*k_proj.*",
+            "model.language_model.*v_proj.*",
+            "model.language_model.*o_proj.*",
+            "model.language_model.*gate_proj.*",
+            "model.language_model.*up_proj.*",
+            "model.language_model.*down_proj.*",
+            # vision
+            "model.visual.*attn.qkv.*",
+            "model.visual.*attn.proj.*",
+            "model.visual.*gate_proj.*",
+            "model.visual.*up_proj.*",
+            "model.visual.*down_proj.*",
+            # alinger
+            "model.visual.merger.mlp\.[02].*",
+        ]
     elif model.config.model_type == "qwen2_moe":
         target_modules = [
             ".*qkv_proj.*",

--- a/paddleformers/trl/mllm_utils.py
+++ b/paddleformers/trl/mllm_utils.py
@@ -1,0 +1,201 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Union
+
+from paddleformers.utils.log import logger
+
+_MULTIMODEL_KEY_REGISTRY: Dict[str, MultiModelKeys] = {}
+_ALL_MODULES = ["vision", "aligner", "llm"]
+
+
+class MLLMModelMapping:
+    qwen2_5_vl = "qwen2_5_vl"
+
+    ernie4_5_moe_vl = "ernie4_5_moe_vl"
+
+
+@dataclass
+class ModelKeys:
+    model_dtype: str
+
+    embedding: Optional[str] = None
+    module_list: Optional[str] = None
+    lm_head: Optional[str] = None
+
+    q_proj: Optional[str] = None
+    k_proj: Optional[str] = None
+    v_proj: Optional[str] = None
+    o_proj: Optional[str] = None
+    mlp: Optional[str] = None
+
+
+@dataclass
+class MultiModelKeys(ModelKeys):
+    llm: Union[str, List[str]] = field(default_factory=list)
+    aligner: Union[str, List[str]] = field(default_factory=list)
+    vision: Union[str, List[str]] = field(default_factory=list)
+
+    def __post_init__(self):
+        for key in ["llm", "aligner", "vision"]:
+            v = getattr(self, key)
+            if isinstance(v, str):
+                setattr(self, key, [v])
+            elif v is None:
+                setattr(self, key, [])
+
+
+def register_multimodel_keys(multimodel_key: ModelKeys, *, exist_ok: bool = False) -> None:
+    model_dtype = multimodel_key.model_dtype
+    if not exist_ok and model_dtype in _MULTIMODEL_KEY_REGISTRY:
+        raise ValueError(f"The `{model_dtype}` has already been registered.")
+    _MULTIMODEL_KEY_REGISTRY[model_dtype] = multimodel_key
+
+
+def get_multimodel_target_modules(model_type: Optional[str]) -> Optional[Union[ModelKeys, MultiModelKeys]]:
+    if not model_type:
+        return None
+    return _MULTIMODEL_KEY_REGISTRY.get(model_type)
+
+
+def get_multimodel_lora_target_modules(model, target_modules, freeze_config):
+
+    model_type = model.config.model_type
+
+    multimodel_keys = get_multimodel_target_modules(model_type)
+    if not multimodel_keys:
+        logger.warning(
+            f"No MultiModelKeys registered for {model_type}. "
+            f"'freeze_config' only supports MLLM models and will not take effect here."
+        )
+        return target_modules
+
+    prefix_to_module = {}
+
+    for module in _ALL_MODULES:
+        prefixes = (
+            multimodel_keys.get(module, [])
+            if isinstance(multimodel_keys, dict)
+            else getattr(multimodel_keys, module, [])
+        )
+        for p in prefixes:
+            prefix_to_module[p] = module
+
+    sorted_prefixes = sorted(prefix_to_module.keys(), key=len, reverse=True)
+    active_freeze_config = {m for m in _ALL_MODULES if f"freeze_{m}" in freeze_config}
+
+    multimodel_target_modules = []
+    removed_info = defaultdict(list)
+
+    for tm in target_modules:
+        remove_module = None
+
+        for prefix in sorted_prefixes:
+            if tm.startswith(prefix):
+                remove_module = prefix_to_module[prefix]
+                break
+
+        if remove_module and remove_module in active_freeze_config:
+            removed_info[remove_module].append(tm)
+        else:
+            multimodel_target_modules.append(tm)
+
+    if removed_info:
+        log_info = [f"LoRA target modules filtered by [{freeze_config}]:"]
+        for module, keys in removed_info.items():
+            log_info.append(f"+ [{module}] removed {len(keys)} targets:")
+            log_info.extend([f"  - {k}" for k in keys])
+        logger.info("\n".join(log_info))
+
+    return multimodel_target_modules
+
+
+def freeze_model_parameters(model, freeze_config):
+
+    if not (hasattr(model, "config") and hasattr(model.config, "model_type")):
+        logger.warning("Model has no config.model_type, skip freezing.")
+        return
+    model_type = model.config.model_type
+
+    multimodel_keys = get_multimodel_target_modules(model_type)
+    if not multimodel_keys:
+        logger.warning(
+            f"No MultiModelKeys registered for {model_type}. "
+            f"'freeze_config' only supports MLLM models and will not take effect here."
+        )
+        return
+
+    prefix_to_module = {}
+
+    for module in _ALL_MODULES:
+        prefixes = (
+            multimodel_keys.get(module, [])
+            if isinstance(multimodel_keys, dict)
+            else getattr(multimodel_keys, module, [])
+        )
+        for p in prefixes:
+            prefix_to_module[p] = module
+
+    sorted_prefixes = sorted(prefix_to_module.keys(), key=len, reverse=True)
+    active_freeze_config = {m for m in _ALL_MODULES if f"freeze_{m}" in freeze_config}
+    full_pattern = re.compile("^(" + "|".join(re.escape(p) for p in sorted_prefixes) + ")")
+
+    frozen_keys = defaultdict(list)
+
+    for name, param in model.named_parameters():
+        match = full_pattern.match(name)
+
+        if match:
+            matched_prefix = match.group()
+            module_name = prefix_to_module[matched_prefix]
+            if module_name in active_freeze_config:
+                param.stop_gradient = True
+                frozen_keys[module_name].append(name)
+        else:
+            param.stop_gradient = False
+
+    if frozen_keys:
+        active_modules = ", ".join([f"freeze_{k}" for k in sorted(frozen_keys.keys())])
+        total_count = sum(len(k) for k in frozen_keys.values())
+
+        log_info = [f"Freeze Config: {active_modules} || Total Frozen Keys: {total_count}"]
+
+        for module_name, keys in frozen_keys.items():
+            patterns = sorted({re.sub(r"\.\d+\.", ".$LAYEY_ID.", k) for k in keys})
+            log_info.append(f"+ [{module_name}] ({len(keys)} keys)")
+            log_info.extend([f"  - {p}" for p in patterns])
+        logger.info("\n".join(log_info))
+
+
+register_multimodel_keys(
+    MultiModelKeys(
+        model_dtype=MLLMModelMapping.qwen2_5_vl,
+        aligner="model.visual.merger",
+        llm=["model.language_model", "lm_head"],
+        vision="model.visual",
+    )
+)
+
+register_multimodel_keys(
+    MultiModelKeys(
+        model_dtype=MLLMModelMapping.ernie4_5_moe_vl,
+        aligner="model.resampler_model",
+        llm=["model", "lm_head"],
+        vision="vision_model",
+    )
+)


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
1. 支持Qwen2.5-VL SFT-Full单卡及多卡TP、SP训练；
2. 支持Qwen2.5-VL SFT-LoRA单卡及多卡TP、SP训练；
3. 新增MLLM Freeze机制：通过`freeze_config`配置冻结ViT、Aligner及LLM模块。当freeze_vit生效时，ViT模块所有参数冻结(SFT-Full)，不进行LoRA训练(SFT-LoRA)，目前支持Qwen2.5-VL、Ernie4.5-VL组网。
> freeze_config: freeze_vision freeze_aligner
4. 修复Qwen2.5-VL training_args参数无法传入sub_config问题；