### PR TITLE
[Llama3] Fix sft function call CUDA ERROR 700

### DIFF
--- a/paddleformers/transformers/llama/modeling.py
+++ b/paddleformers/transformers/llama/modeling.py
@@ -641,13 +641,19 @@ class LlamaModel(LlamaPretrainedModel):
         past_key_values: Cache | None,
         use_cache: bool,
     ):
+        cos, sin = position_embeddings
+        cos = cos.clone()
+        sin = sin.clone()
+
+        position_embeddings_safe = (cos, sin)
+
         hidden_states = recompute(
             layer_module,
             hidden_states,
             attention_mask,
             attn_mask_startend_row_indices,
             position_ids,
-            position_embeddings,
+            position_embeddings_safe,
             past_key_values,
             use_cache,
         )


### PR DESCRIPTION
在 recompute 中 clone position_embeddings 再传给 recompute，以修复 Llama3 在 sft function call 中开 stage2 报 CUDA ERROR 700。

怀疑是 position_embeddings 在进行 recompute 前就已经被回收，尚不清楚具体原因