### PR TITLE
fix missing use_cache in model_kwargs

### DIFF
--- a/paddleformers/generation/utils.py
+++ b/paddleformers/generation/utils.py
@@ -964,6 +964,8 @@ class GenerationMixin(object):
         generation_config = copy.deepcopy(generation_config)
         model_kwargs = generation_config.update(**kwargs)
 
+        model_kwargs["use_cache"] = generation_config.use_cache
+
         assert generation_config.decode_strategy in [
             "greedy_search",
             "sampling",


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
问题：
model.generate(**input_features, use_cache=False)时，传递给模型forward时的use_cache仍然为True的问题

描述：
https://github.com/PaddlePaddle/PaddleFormers/blob/3c800f1e3309826262ac648507bf3508beeed391/paddleformers/generation/utils.py#L964-L965

https://github.com/PaddlePaddle/PaddleFormers/blob/3c800f1e3309826262ac648507bf3508beeed391/paddleformers/generation/configuration_utils.py#L575-L595

generation_config.update会把kwargs的use_cache更新到generation_config并且删除掉其中的use_cache，导致这里的model_kwargs中没有use_cache，因此model_kwargs.get("use_cache", True)只会得到True
https://github.com/PaddlePaddle/PaddleFormers/blob/3c800f1e3309826262ac648507bf3508beeed391/paddleformers/generation/utils.py#L1262
解决方法：
在调用generation_config.update之后添加model_kwargs["use_cache"] = generation_config.use_cache
https://github.com/PaddlePaddle/PaddleFormers/blob/3c800f1e3309826262ac648507bf3508beeed391/paddleformers/generation/utils.py#L964-L967
