### PR TITLE
Unification of device APIs

### DIFF
--- a/examples/experiments/ernie_pretrain/ernie/pretrain.py
+++ b/examples/experiments/ernie_pretrain/ernie/pretrain.py
@@ -25,7 +25,7 @@ import paddle
 from paddle.distributed import fleet
 from src.utils import logger
 
-from paddleformers.utils.tools import get_env_device
+from paddleformers.utils.tools import get_env_device, paddle_device
 
 try:
     from paddle.distributed.utils.process_utils import SUCCESS_CODE, set_affinity
@@ -251,7 +251,7 @@ def main():
         logger.info("set enable_optimizer_timer to True")
 
     if get_env_device() == "gpu":
-        prop = paddle.device.cuda.get_device_properties()
+        prop = paddle_device.get_device_properties()
         if prop.total_memory < args.pre_alloc_memory * 1024 * 1024 * 1024:
             logger.warning("Invalid value for `pre_alloc_memory`, so pre-allocating just failed.")
         elif args.pre_alloc_memory > 0:

--- a/paddleformers/cli/train/sft/workflow.py
+++ b/paddleformers/cli/train/sft/workflow.py
@@ -22,10 +22,12 @@ from functools import partial
 import numpy as np
 import paddle
 
+from paddleformers.utils.tools import paddle_device
+
 is_sm90 = (
     paddle.base.core.is_compiled_with_cuda()
-    and paddle.device.cuda.get_device_capability()[0] == 9
-    and paddle.device.cuda.get_device_capability()[1] == 0
+    and paddle_device.get_device_capability()[0] == 9
+    and paddle_device.get_device_capability()[1] == 0
 )
 if is_sm90:
     os.environ["FLAGS_flash_attn_version"] = "3"

--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -167,7 +167,7 @@ from ..utils.fault_tolerance import LOSS_INF_ERROR, LOSS_NAN_ERROR
 from ..utils.import_utils import is_datasets_available, is_paddle_cuda_available
 from ..utils.log import MetricsDumper, logger
 from ..utils.pdc_sdk import FLASH_DEVICE
-from ..utils.tools import get_env_device
+from ..utils.tools import get_env_device, paddle_device
 from .argparser import strtobool
 from .integrations import get_reporting_integration_callbacks
 from .plugins.timer import RuntimeTimer, get_timers, set_timers
@@ -2421,8 +2421,8 @@ class Trainer:
                 if is_paddle_cuda_available():
                     logs.update(
                         {
-                            "gpu_max_memory_allocated": paddle.device.cuda.max_memory_allocated() >> 20,
-                            "gpu_max_memory_reserved": paddle.device.cuda.max_memory_reserved() >> 20,
+                            "gpu_max_memory_allocated": paddle_device.max_memory_allocated() >> 20,
+                            "gpu_max_memory_reserved": paddle_device.max_memory_reserved() >> 20,
                         }
                     )
 

--- a/paddleformers/trainer/trainer_utils.py
+++ b/paddleformers/trainer/trainer_utils.py
@@ -60,7 +60,7 @@ from ..utils.fault_tolerance import PDC_DOWNLOAD_ERROR
 from ..utils.import_utils import is_paddle_cuda_available, is_psutil_available
 from ..utils.log import logger
 from ..utils.pdc_sdk import PDCErrorCode, PDCErrorMessageMap, pdc_tool
-from ..utils.tools import get_env_device
+from ..utils.tools import get_env_device, paddle_device
 from .utils.helper import distributed_file
 
 __all__ = [
@@ -991,11 +991,11 @@ class TrainerMemoryTracker:
 
         if self.paddle is not None:
             # self.paddle.cuda.reset_peak_memory_stats()?
-            self.paddle.device.cuda.empty_cache()
+            self.paddle_device.empty_cache()
 
         # gpu
         if self.paddle is not None:
-            self.gpu_mem_used_at_start = self.paddle.device.cuda.memory_allocated()
+            self.gpu_mem_used_at_start = paddle_device.memory_allocated()
 
         # cpu
         self.cpu_mem_used_at_start = self.cpu_mem_used()
@@ -1019,7 +1019,7 @@ class TrainerMemoryTracker:
         gc.collect()
 
         if self.paddle is not None:
-            self.paddle.device.cuda.empty_cache()
+            paddle_device.empty_cache()
 
         # concepts:
         # - alloc_delta:  the difference of allocated memory between the end and the start
@@ -1028,8 +1028,8 @@ class TrainerMemoryTracker:
 
         # gpu
         if self.paddle is not None:
-            self.gpu_mem_used_now = self.paddle.device.cuda.memory_allocated()
-            self.gpu_mem_used_peak = self.paddle.device.cuda.max_memory_allocated()
+            self.gpu_mem_used_now = paddle_device.memory_allocated()
+            self.gpu_mem_used_peak = paddle_device.max_memory_allocated()
             self.gpu[self.cur_stage] = dict(
                 begin=self.gpu_mem_used_at_start,
                 end=self.gpu_mem_used_now,
@@ -1060,7 +1060,7 @@ class TrainerMemoryTracker:
 
         if hasattr(self, "gpu_mem_used_peak"):
             metrics["gpu_mem_max_memory_allocated"] = self.gpu_mem_used_peak
-            metrics["gpu_mem_max_memory_reserved"] = self.paddle.device.cuda.max_memory_reserved()
+            metrics["gpu_mem_max_memory_reserved"] = paddle_device.max_memory_reserved()
 
         # since we don't have a way to return init metrics, we push them into the first of train/val/predict
         stages = [stage]

--- a/paddleformers/trainer/utils/zero_cost_checkpoint.py
+++ b/paddleformers/trainer/utils/zero_cost_checkpoint.py
@@ -53,6 +53,7 @@ from paddle.incubate.tensor.manipulation import (
 from paddle.optimizer.fusion_utils import FusionStorageHelper
 
 from paddleformers.trainer.utils.sharding_io import GroupGetter
+from paddleformers.utils.tools import paddle_device
 
 from ...transformers.model_utils import unwrap_optimizer
 from . import reshard as reshard_util
@@ -128,10 +129,10 @@ class ZCCWorkerStatus(Enum):
 
 def showmem(msg):
     return (
-        f"{msg} mem_alloc: {paddle.device.cuda.memory_allocated():.3e}"
-        f" Bytes/{paddle.device.cuda.max_memory_allocated():.3e} Bytes"
-        f"mem_reserv: {paddle.device.cuda.memory_reserved():.3e} "
-        f"Bytes/{paddle.device.cuda.max_memory_reserved():.3e} Bytes"
+        f"{msg} mem_alloc: {paddle_device.memory_allocated():.3e}"
+        f" Bytes/{paddle_device.max_memory_allocated():.3e} Bytes"
+        f"mem_reserv: {paddle_device.memory_reserved():.3e} "
+        f"Bytes/{paddle_device.max_memory_reserved():.3e} Bytes"
     )
 
 

--- a/paddleformers/utils/__init__.py
+++ b/paddleformers/utils/__init__.py
@@ -92,7 +92,6 @@ import_structure = {
     ],
     "tools": [
         "device_guard",
-        "paddle_device",
     ],
     "downloader": ["get_weights_path_from_url"],
     "type_validators": [

--- a/paddleformers/utils/__init__.py
+++ b/paddleformers/utils/__init__.py
@@ -90,7 +90,10 @@ import_structure = {
         "get_use_casual_mask",
         "get_triangle_upper_mask",
     ],
-    "tools": ["device_guard"],
+    "tools": [
+        "device_guard",
+        "paddle_device",
+    ],
     "downloader": ["get_weights_path_from_url"],
     "type_validators": [
         "positive_any_number",

--- a/paddleformers/utils/import_utils.py
+++ b/paddleformers/utils/import_utils.py
@@ -27,6 +27,7 @@ from typing import Optional, Tuple, Type, Union
 import pip
 
 from paddleformers.utils.log import logger
+from paddleformers.utils.tools import paddle_device
 
 _original_import = builtins.__import__
 _imported_modules = {}
@@ -208,9 +209,7 @@ def is_protobuf_available():
 
 def is_paddle_cuda_available() -> bool:
     if is_paddle_available():
-        import paddle
-
-        return paddle.device.cuda.device_count() > 0
+        return paddle_device.device_count() > 0
     else:
         return False
 

--- a/paddleformers/utils/import_utils.py
+++ b/paddleformers/utils/import_utils.py
@@ -27,7 +27,6 @@ from typing import Optional, Tuple, Type, Union
 import pip
 
 from paddleformers.utils.log import logger
-from paddleformers.utils.tools import paddle_device
 
 _original_import = builtins.__import__
 _imported_modules = {}
@@ -209,6 +208,8 @@ def is_protobuf_available():
 
 def is_paddle_cuda_available() -> bool:
     if is_paddle_available():
+        from .tools import paddle_device
+
         return paddle_device.device_count() > 0
     else:
         return False

--- a/paddleformers/utils/memory_utils.py
+++ b/paddleformers/utils/memory_utils.py
@@ -12,11 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-import paddle
-
 from .log import logger
-from .tools import get_env_device
+from .tools import get_env_device, paddle_device
 
 __all__ = [
     "empty_device_cache",
@@ -25,10 +22,8 @@ __all__ = [
 
 def empty_device_cache():
     device = get_env_device()
-    if device == "gpu":
-        paddle.device.cuda.empty_cache()
-    elif device == "xpu":
-        paddle.device.xpu.empty_cache()
+    if device != "cpu":
+        paddle_device.empty_cache()
     else:
         if not getattr(empty_device_cache, "has_warned", False):
             logger.warning(

--- a/paddleformers/utils/tools.py
+++ b/paddleformers/utils/tools.py
@@ -266,3 +266,69 @@ def device_guard(device="cpu", dev_id=0):
             paddle.set_device(origin_device)
 
     return _device_guard()
+
+
+class PaddleDeviceWrapper:
+    """
+    A wrapper class for PaddlePaddle's device-related functionalities, providing unified access
+    to both core device APIs and hardware-specific (e.g., CUDA) APIs.
+
+    This class dynamically resolves attributes by searching them in:
+    1. `paddle.device` (core APIs)
+    2. Hardware-specific modules (e.g., `paddle.device.cuda`)
+
+    Attributes:
+        paddle_device: The `paddle.device` module (core device APIs).
+        paddle_device_hardware: A hardware-specific module (e.g., `paddle.device.cuda`).
+
+    Example:
+        >>> paddle_device = PaddleDeviceWrapper()
+        >>> paddle_device.get_device()  # Calls `paddle.device.get_device()`
+        'gpu:0'
+        >>> paddle_device.cuda.get_device_count()  # Calls `paddle.device.cuda.get_device_count()`
+        1
+    """
+
+    def __init__(self):
+        self.paddle_device = paddle.device
+        self.paddle_device_hardware = self._get_available_hardware_modules()
+
+    def _get_available_hardware_modules(self):
+        """get available hardware modules"""
+        if get_env_device() == "gpu" or get_env_device() == "rocm":
+            return paddle.device.cuda
+        elif get_env_device() == "xpu":
+            return paddle.device.xpu
+        else:
+            return paddle.device
+
+    def get_nested_attr(self, module, attr_path, default=None):
+        """get nested attributes from a module"""
+        parts = attr_path.split(".")
+        current_module = module
+
+        try:
+            for part in parts:
+                if not hasattr(current_module, part):
+                    return default
+                current_module = getattr(current_module, part)
+
+            return current_module
+        except (AttributeError, TypeError):
+            return default
+
+    def __getattr__(self, name):
+        func = self.get_nested_attr(self.paddle_device, name)
+        if func is not None:
+            return func
+        else:
+            hardware_func = self.get_nested_attr(self.paddle_device_hardware, name)
+            if hardware_func is not None:
+                return hardware_func
+            else:
+                raise AttributeError(
+                    f" '{type(self.paddle_device_hardware).__name__}' object has no attribute '{name}'"
+                )
+
+
+paddle_device = PaddleDeviceWrapper()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
目的：为 paddle.device 添加硬件无关的统一包装层，简化多硬件（CPU/GPU/XPU/ROCM）环境下的设备 API 调用。

核心改动：
```
    def __getattr__(self, name):
        func = self.get_nested_attr(self.paddle_device, name)
        if func is not None:
            return func
        else:
            hardware_func = self.get_nested_attr(self.paddle_device_hardware, name)
            if hardware_func is not None:
                return hardware_func
            else:
                raise AttributeError(
                    f" '{type(self.paddle_device_hardware).__name__}' object has no attribute '{name}'"
                )
```
优先调用paddle.device下的接口，如果不存在paddle.device.xxx再根据当前存在的硬件类型调用paddle.device.xpu/cuda.xxx的函数

新增 PaddleDeviceWrapper 类，动态代理 paddle.device 核心 API 及硬件专属模块（如 cuda/xpu）。
通过 __getattr__ 实现属性自动路由，优先查询核心 API，未找到时回退到硬件专属模块。