### PR TITLE
[Fleet] Disable Default moe_grouped_gemm

### DIFF
--- a/examples/experiments/paddlefleet/glm45_provider.py
+++ b/examples/experiments/paddlefleet/glm45_provider.py
@@ -64,7 +64,7 @@ class GLMMoEModelProvider(GPTModelProvider):
     moe_router_load_balancing_type: str = "seq_aux_loss"
     router_aux_loss_coef: float = 1e-3
     moe_router_pre_softmax: bool = False
-    moe_grouped_gemm: bool = True
+    moe_grouped_gemm: bool = False
     scoring_func: str = "sigmoid"
     moe_permute_fusion: bool = True
     moe_router_dtype: str = "fp32"

--- a/examples/experiments/paddlefleet/qwen_provider.py
+++ b/examples/experiments/paddlefleet/qwen_provider.py
@@ -63,7 +63,7 @@ class Qwen3MoEModelProvider(GPTModelProvider):
     router_aux_loss_coef: float = 1e-3
     num_experts_per_tok: int = 8
     moe_router_pre_softmax: bool = False
-    moe_grouped_gemm: bool = True
+    moe_grouped_gemm: bool = False
     moe_token_dispatcher_type: str = "alltoall"
 
     # optimization

--- a/paddleformers/transformers/configuration_utils.py
+++ b/paddleformers/transformers/configuration_utils.py
@@ -419,7 +419,7 @@ class LlmMetaConfig:
         (
             "moe_grouped_gemm",
             bool,
-            True,
+            False,
             "Whether to enable grouped GEMM (General Matrix Multiplication) for MoE experts. Batches computations across multiple experts to improve hardware utilization. Defaults to True.",
         ),
     ]

--- a/paddleformers/transformers/glm4_moe/modeling.py
+++ b/paddleformers/transformers/glm4_moe/modeling.py
@@ -83,7 +83,7 @@ class GLMMoEModelProvider(GPTModelProvider):
     rope_scaling: float = 1.0
     bias_dropout_fusion: bool = True
     router_aux_loss_coef: float = 0.001
-    moe_grouped_gemm: bool = True
+    moe_grouped_gemm: bool = False
 
 
 def eager_attention_forward(


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description
https://github.com/PaddlePaddle/PaddleFleet/pull/175 PR 暂未支持热启，默认 moe_grouped_gemm 设置为 False，仍然使用分离的 experts。
