### PR TITLE
fix(llama): align to other model implementation, use dynamic shape in attention reshape

### DIFF
--- a/paddleformers/transformers/llama/modeling.py
+++ b/paddleformers/transformers/llama/modeling.py
@@ -163,8 +163,8 @@ class LLamaAttention(nn.Layer):
         else:
             batch_size, seq_len = hidden_states.shape[:2]
 
-        q_shape = (batch_size, seq_len, self.num_heads, self.head_dim)
-        kv_shape = (batch_size, seq_len, self.num_key_value_heads, self.head_dim)
+        q_shape = (batch_size, seq_len, -1, self.head_dim)
+        kv_shape = (batch_size, seq_len, -1, self.head_dim)
 
         query_states = self.q_proj(hidden_states).reshape(q_shape).transpose(1, 2)
         key_states = self.k_proj(hidden_states).reshape(kv_shape).transpose(1, 2)


### PR DESCRIPTION
### PR types
Bug fixes
### PR changes
LLaMA Models attention reshape
### Description
**问题**：
FastDeploy 会将 nn.Linear 替换为 ColumnParallelLinear/RowParallelLinear，导致输出维度被 TP size 整除。但 LLaMA 的 attention 代码中 reshape 使用了固定的 num_heads，造成形状不匹配。
**修复**：
将 LlamaAttention 中的 q_shape 和 kv_shape 从显式指定 head 数量改为使用 -1 动态推断，与其他模型实现（如 Qwen3）保持一致。
**测试验证**：
- Llama-3.1-8B-Instruct + FastDeploy Fallback + TP=2 验证通过