### PR TITLE
fix(lora): guard PP recompute stop_gradient workaround

### DIFF
--- a/paddleformers/nn/pp_model.py
+++ b/paddleformers/nn/pp_model.py
@@ -319,7 +319,18 @@ class EmbeddingPipe(nn.Layer):
 
             ret = (emb,)
 
-        ret[0].stop_gradient = False  # 开启lora 防止recompute pylayer因base weight输入没有gradient而报错
+        # NOTE: LoRA + PP
+        # In LoRA scenarios, base weights are typically frozen, causing embedding outputs to have stop_gradient=True.
+        # When recompute (PyLayer) is enabled, inputs must be differentiable, otherwise it will cause errors or
+        # fail to trigger recompute.
+        if (
+            getattr(self.config, "_paddleformers_peft_type", None) == "lora"
+            and self.training
+            and getattr(self.config, "recompute_granularity", None) == "full"
+            and getattr(self.config, "recompute_method", None) == "uniform"
+            and getattr(self.config, "recompute_num_layers", None) == 1
+        ):
+            ret[0].stop_gradient = False
         if attention_mask is not None:
             if attention_mask.dtype != paddle.int32:
                 if len(attention_mask.shape) == 2:

--- a/paddleformers/peft/lora/lora_model.py
+++ b/paddleformers/peft/lora/lora_model.py
@@ -214,6 +214,21 @@ class LoRAModel(nn.Layer):
         logger.info("Mark only lora and trainable_module as trainable.")
         self.mark_only_lora_as_trainable()
 
+        # Mark PEFT type for downstream components that need LoRA-specific handling
+        # (e.g. PipelineParallel recompute input stop_gradient).
+        if getattr(self.model, "config", None) is not None:
+            # Some config implementations (e.g. external configs with __slots__) may forbid adding new attrs.
+            try:
+                self.model.config._paddleformers_peft_type = "lora"
+            except Exception as exc:
+                logger.warning(
+                    "Failed to mark LoRA PEFT type on model config; LoRA+PP recompute special-casing may be disabled: "
+                    f"{exc}"
+                )
+            else:
+                if hasattr(self.model.config, "register_unsavable_keys"):
+                    self.model.config.register_unsavable_keys("_paddleformers_peft_type")
+
     def add_lora_split_mapping(self, module_name, is_column=False):
         self.lora_split_mapping[module_name] = is_column
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
### 背景
  之前 PR #3093 为解决 LoRA + PipelineParallel + recompute 场景的报错，在 PP EmbeddingPipe 中无条件设置了
  `ret[0].stop_gradient = False`。

反馈该无条件行为可能影响其他非 LoRA/非 recompute 场景，因此需要做 LoRA 场景特判。

  ### 主要改动
  1) 在 LoRA 模式下对底座 model.config 打标记：
  - `model.config._paddleformers_peft_type = "lora"`
  - 并通过 `register_unsavable_keys` 保证该内部字段不会写入 config.json
  - 若某些 config 不允许动态新增属性，会输出 warning（提示特判可能失效）

  2) 在 `paddleformers/nn/pp_model.py` 的 `EmbeddingPipe.forward()` 中把原来的无条件 `stop_gradient=False`
  改为条件触发：
  仅当同时满足：
  - LoRA 标记 `_paddleformers_peft_type == "lora"`
  - 训练态 `self.training == True`
  - 且 recompute 配置为 `full + uniform + recompute_num_layers == 1`
  才强制 `ret[0].stop_gradient = False`，以避免影响其他训练/推理路径。

  ### 为什么不影响其他模型/场景
  - 非 LoRA：不会设置 `_paddleformers_peft_type`，条件不成立
  - LoRA 但不开 PP：不会走 `EmbeddingPipe`，不触发
  - 推理：`self.training` 为 False，条件不成立
  - 只在特定 recompute 组合下触发，避免扩大影响面
  - 仅改变 embedding 输出张量的 stop_gradient，不会解冻 base 权重；base 权重的训练状态仍由 LoRA 的 trainable
  参数逻辑控制

  ### 风险与兼容性
  - 极少数 config 若禁止动态加属性：会 warning，且 LoRA+PP recompute 特判可能不生效（仍可能复现原报错）；但
  不会影响非该场景功能
  - 对命中条件的 LoRA+PP+recompute 场景：会让 embedding 输出可求导，属于为 recompute PyLayer “提供可导输
  入”的必要行为

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
