### PR TITLE
PP_Model: fix recompute in no_grad bug

### DIFF
--- a/paddleformers/nn/pp_model.py
+++ b/paddleformers/nn/pp_model.py
@@ -319,7 +319,8 @@ class EmbeddingPipe(nn.Layer):
 
             ret = (emb,)
 
-        ret[0].stop_gradient = False  # 开启lora 防止recompute pylayer因base weight输入没有gradient而报错
+        if paddle.core._has_grad():
+            ret[0].stop_gradient = False  # 开启lora 防止recompute pylayer因base weight输入没有gradient而报错
         if attention_mask is not None:
             if attention_mask.dtype != paddle.int32:
                 if len(attention_mask.shape) == 2:


### PR DESCRIPTION
改动：
在no grad状态下不转换pp组网里hidden_states的stop gradient状态，避免走入recompute分支