### PR TITLE
Qwen3Next supports flex_checkpoint

### DIFF
--- a/paddleformers/transformers/qwen3_next/modeling.py
+++ b/paddleformers/transformers/qwen3_next/modeling.py
@@ -1017,6 +1017,92 @@ class Qwen3NextPretrainedModel(PretrainedModel):
         mappings = make_base_actions()
         return mappings
 
+    @classmethod
+    def _gen_aoa_config(cls, config: Qwen3NextConfig):
+        model_prefix = "" if cls == cls.base_model_class else "model."
+        aoa_statements = [
+            f"model.embed_tokens.weight -> {model_prefix}embed_tokens.weight",
+            f"model.norm.weight -> {model_prefix}norm.weight",
+            f"model.layers.$LAYER_ID.input_layernorm.weight -> {model_prefix}layers.$LAYER_ID.input_layernorm.weight",
+            f"model.layers.$LAYER_ID.post_attention_layernorm.weight -> {model_prefix}layers.$LAYER_ID.post_attention_layernorm.weight",
+            # gate
+            f"model.layers.$LAYER_ID.mlp.gate.weight^T -> {model_prefix}layers.$LAYER_ID.mlp.gate.weight, dtype='float32'",
+            f"model.layers.$LAYER_ID.mlp.shared_expert_gate.weight^T -> {model_prefix}layers.$LAYER_ID.mlp.shared_expert_gate.weight",
+            # linear_attn
+            f"model.layers.$LAYER_ID.linear_attn.A_log -> {model_prefix}layers.$LAYER_ID.linear_attn.A_log",
+            f"model.layers.$LAYER_ID.linear_attn.conv1d.weight -> {model_prefix}layers.$LAYER_ID.linear_attn.conv1d.weight",
+            f"model.layers.$LAYER_ID.linear_attn.dt_bias -> {model_prefix}layers.$LAYER_ID.linear_attn.dt_bias",
+            f"model.layers.$LAYER_ID.linear_attn.in_proj_ba.weight^T -> {model_prefix}layers.$LAYER_ID.linear_attn.in_proj_ba.weight",
+            f"model.layers.$LAYER_ID.linear_attn.in_proj_qkvz.weight^T -> {model_prefix}layers.$LAYER_ID.linear_attn.in_proj_qkvz.weight",
+            f"model.layers.$LAYER_ID.linear_attn.norm.weight -> {model_prefix}layers.$LAYER_ID.linear_attn.norm.weight",
+            f"model.layers.$LAYER_ID.linear_attn.out_proj.weight^T -> {model_prefix}layers.$LAYER_ID.linear_attn.out_proj.weight",
+        ]
+
+        # self_attn
+        aoa_statements += [
+            f"model.layers.$LAYER_ID.self_attn.{x}_proj.weight^T -> {model_prefix}layers.$LAYER_ID.self_attn.{x}_proj.weight"
+            for x in ("q", "k", "v", "o")
+        ]
+        aoa_statements += [
+            f"model.layers.$LAYER_ID.self_attn.{x}_norm.weight -> {model_prefix}layers.$LAYER_ID.self_attn.{x}_norm.weight"
+            for x in ("q", "k")
+        ]
+
+        # experts
+        aoa_statements += [
+            f"model.layers.$LAYER_ID.mlp.experts.$EXPERT_ID.{x}_proj.weight^T -> {model_prefix}layers.$LAYER_ID.mlp.experts.$EXPERT_ID.{x}_proj.weight"
+            for x in ("gate", "up", "down")
+        ]
+        aoa_statements += [
+            f"model.layers.$LAYER_ID.mlp.shared_expert.{x}_proj.weight^T -> {model_prefix}layers.$LAYER_ID.mlp.shared_expert.{x}_proj.weight"
+            for x in ("gate", "up", "down")
+        ]
+
+        return {"aoa_statements": aoa_statements}
+
+    @classmethod
+    def _gen_inv_aoa_config(cls, config: Qwen3NextConfig):
+        model_prefix = "" if cls == cls.base_model_class else "model."
+        aoa_statements = [
+            f"{model_prefix}embed_tokens.weight -> model.embed_tokens.weight",
+            f"{model_prefix}norm.weight -> model.norm.weight",
+            f"{model_prefix}layers.$LAYER_ID.input_layernorm.weight -> model.layers.$LAYER_ID.input_layernorm.weight",
+            f"{model_prefix}layers.$LAYER_ID.post_attention_layernorm.weight -> model.layers.$LAYER_ID.post_attention_layernorm.weight",
+            # gate
+            f"{model_prefix}layers.$LAYER_ID.mlp.gate.weight^T -> model.layers.$LAYER_ID.mlp.gate.weight, dtype='bfloat16'",
+            f"{model_prefix}layers.$LAYER_ID.mlp.shared_expert_gate.weight^T -> model.layers.$LAYER_ID.mlp.shared_expert_gate.weight",
+            # linear_attn
+            f"{model_prefix}layers.$LAYER_ID.linear_attn.A_log -> model.layers.$LAYER_ID.linear_attn.A_log",
+            f"{model_prefix}layers.$LAYER_ID.linear_attn.conv1d.weight -> model.layers.$LAYER_ID.linear_attn.conv1d.weight",
+            f"{model_prefix}layers.$LAYER_ID.linear_attn.dt_bias -> model.layers.$LAYER_ID.linear_attn.dt_bias",
+            f"{model_prefix}layers.$LAYER_ID.linear_attn.in_proj_ba.weight^T -> model.layers.$LAYER_ID.linear_attn.in_proj_ba.weight",
+            f"{model_prefix}layers.$LAYER_ID.linear_attn.in_proj_qkvz.weight^T -> model.layers.$LAYER_ID.linear_attn.in_proj_qkvz.weight",
+            f"{model_prefix}layers.$LAYER_ID.linear_attn.norm.weight -> model.layers.$LAYER_ID.linear_attn.norm.weight",
+            f"{model_prefix}layers.$LAYER_ID.linear_attn.out_proj.weight^T -> model.layers.$LAYER_ID.linear_attn.out_proj.weight",
+        ]
+
+        # self_attn
+        aoa_statements += [
+            f"{model_prefix}layers.$LAYER_ID.self_attn.{x}_proj.weight^T -> model.layers.$LAYER_ID.self_attn.{x}_proj.weight"
+            for x in ("q", "k", "v", "o")
+        ]
+        aoa_statements += [
+            f"{model_prefix}layers.$LAYER_ID.self_attn.{x}_norm.weight -> model.layers.$LAYER_ID.self_attn.{x}_norm.weight"
+            for x in ("q", "k")
+        ]
+
+        # experts
+        aoa_statements += [
+            f"{model_prefix}layers.$LAYER_ID.mlp.experts.$EXPERT_ID.{x}_proj.weight^T -> model.layers.$LAYER_ID.mlp.experts.$EXPERT_ID.{x}_proj.weight"
+            for x in ("gate", "up", "down")
+        ]
+        aoa_statements += [
+            f"{model_prefix}layers.$LAYER_ID.mlp.shared_expert.{x}_proj.weight^T -> model.layers.$LAYER_ID.mlp.shared_expert.{x}_proj.weight"
+            for x in ("gate", "up", "down")
+        ]
+
+        return {"aoa_statements": aoa_statements}
+
     def _init_weights(self, module):
         if isinstance(module, Qwen3NextGatedDeltaNet):
             module.dt_bias.data.fill_(1.0)
@@ -1244,3 +1330,5 @@ class Qwen3NextForCausalLMPipe(GeneralModelForCausalLMPipe):
     _keep_in_fp32_modules = Qwen3NextModel._keep_in_fp32_modules
     _tied_weights_keys = ["lm_head.weight"]
     transpose_weight_keys = Qwen3NextModel.transpose_weight_keys
+    _gen_aoa_config = Qwen3NextPretrainedModel._gen_aoa_config
+    _gen_inv_aoa_config = Qwen3NextPretrainedModel._gen_inv_aoa_config

--- a/tests/transformers/qwen3next/test_modeling.py
+++ b/tests/transformers/qwen3next/test_modeling.py
@@ -280,6 +280,25 @@ class Qwen3NextModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestC
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_for_causal_lm(*config_and_inputs)
 
+    def test_save_load(self):
+        for model_class in self.all_model_classes:
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                config, input_dict = self.model_tester.prepare_config_and_inputs_for_common()
+                model = model_class(config)
+                model.save_pretrained(tmpdirname, save_checkpoint_format="flex_checkpoint")
+
+                model1 = model_class.from_pretrained(tmpdirname, convert_from_hf=True)
+
+                model2 = model_class.from_pretrained(tmpdirname, load_checkpoint_format="flex_checkpoint")
+
+                model_state_1 = model1.state_dict()
+                model_state_2 = model2.state_dict()
+
+                for k, v in model_state_1.items():
+                    md51 = v._md5sum()
+                    md52 = model_state_2[k]._md5sum()
+                    assert md51 == md52
+
 
 class Qwen3NextIntegrationTest(unittest.TestCase):
     def test_model_tiny_logits(self):


### PR DESCRIPTION
### PR types
New features

### PR changes
Models

### Description
给 Qwen3Next 模型增加 _gen_aoa_config/_gen_inv_aoa_config 方法
开启对应的 flex_checkpoint 加载/保存的单测