### PR TITLE
Fix(processor): Decouple transformers version via local AutoConfig

### DIFF
--- a/paddleformers/transformers/auto/processing.py
+++ b/paddleformers/transformers/auto/processing.py
@@ -19,7 +19,7 @@ import json
 import os
 from collections import OrderedDict
 
-from transformers import AutoConfig, PretrainedConfig
+from transformers import PretrainedConfig
 from transformers.dynamic_module_utils import (
     get_class_from_dynamic_module,
     resolve_trust_remote_code,
@@ -34,6 +34,8 @@ from transformers.utils import (
     PROCESSOR_NAME,
     VIDEO_PROCESSOR_NAME,
 )
+
+from paddleformers.transformers import AutoConfig
 
 from ...utils.download import resolve_file_path
 from ..image_processing_utils import ImageProcessingMixin
@@ -173,6 +175,7 @@ class AutoProcessor:
         if processor_class is None:
             # Otherwise, load config, if it can be loaded.
             if not isinstance(config, PretrainedConfig):
+                # NOTE: Use local AutoConfig to decouple transformers version dependency (Processor only).
                 config = AutoConfig.from_pretrained(
                     pretrained_model_name_or_path, trust_remote_code=trust_remote_code, **kwargs
                 )


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
AutoProcessor内部的AutoConfig调整为PaddleFormers本地实现（解耦transformers版本依赖，支持部分纯文模型加载）