### PR TITLE
fix(masking_utils): bypass mask generation for non-eager attention implementations

### DIFF
--- a/paddleformers/transformers/masking_utils.py
+++ b/paddleformers/transformers/masking_utils.py
@@ -131,9 +131,9 @@ def create_causal_masks_and_row_indices(
 
     # Enables the efficient built-in causal mode (is_causal=True)
     # for FA backends (sdpa/flashmask), bypassing manual mask generation.
-    FLASH_BACKENDS = {"sdpa", "flashmask"}
+    # for third-party attention registered via _attn_implementation, default to bypass mask generation.
     attn_impl = getattr(config, "_attn_implementation", "eager")
-    is_flash_backend = attn_impl in FLASH_BACKENDS
+    is_flash_backend = attn_impl != "eager"
     is_fully_attended = attention_mask is None or (attention_mask is not None and attention_mask.cast("bool").all())
     if is_flash_backend and is_fully_attended:
         if return_mapping:
@@ -241,12 +241,12 @@ def create_causal_mask_and_row_indices(
         causal_mask = None
         row_indices = attn_mask_startend_row_indices
     else:
-        FLASH_BACKENDS = {"sdpa", "flashmask"}
         attn_impl = getattr(config, "_attn_implementation", "eager")
-        is_flash_backend = attn_impl in FLASH_BACKENDS
+        is_flash_backend = attn_impl != "eager"
 
         # Check if the mask can be safely skipped
         # Condition: Must be Flash Backend AND No extra mask func AND No padding (mask is None or all True)
+        # For third-party attention registered via _attn_implementation, default to bypass mask generation.
         is_fully_attended = attention_mask is None or (
             attention_mask is not None and attention_mask.cast("bool").all()
         )


### PR DESCRIPTION
### Description
原有的 is_flash_backend 判断逻辑使用显式的后端集合 {"sdpa", "flashmask"} 来判断是否为 Flash Attention 后端，这导致通过 _attn_implementation 注册的第三方 attention 实现无法自动 bypass mask 生成。

### 修改内容： 
将判断逻辑从：
FLASH_BACKENDS = {"sdpa", "flashmask"}
is_flash_backend = attn_impl in FLASH_BACKENDS
改为：
is_flash_backend = attn_impl != "eager"

影响范围：
create_causal_masks_and_row_indices
create_causal_mask_and_row_indices

预期效果： 所有非 eager 类型的 attention 实现（包括第三方注册的 attention）都会被识别为 flash backend，从而在满足条件时 bypass 手动 mask 生成，支持CUDA Grpah提升性能