### PR TITLE
[Cherry Pick | MoE Layer] Fix EP Hang and Add Barrier

### DIFF
--- a/paddleformers/nn/moe_deepep/moe_communication.py
+++ b/paddleformers/nn/moe_deepep/moe_communication.py
@@ -125,6 +125,7 @@ class AllToAllMoECommunication(nn.Layer, MoECommunicationInterface):
         combined_key = expert_indices * seq_len + token_indices
         sort_indices = paddle.argsort(combined_key)
         sorted_token_indices = token_indices[sort_indices]
+        sorted_expert_indices = expert_indices[sort_indices]
         sorted_tokens = reshaped_input[
             sorted_token_indices
         ]  # Tokens that sorted by expert id. First `tokens_per_expert[0]` tokens belong to expert 0, next `tokens_per_expert[1]` tokens belong to expert 1, etc. Shape: [batch_size * seq_len * num_experts_per_token, d_model]
@@ -135,6 +136,11 @@ class AllToAllMoECommunication(nn.Layer, MoECommunicationInterface):
         tokens_per_ep_rank = tokens_per_expert.reshape([expert_model_parallel_size, -1]).sum(axis=1)
         # First All-to-All: Exchange expert token counts across ranks
         tokens_per_expert_group = _AllToAll.apply([tokens_per_expert.shape[0]], tokens_per_expert, group=moe_group)
+
+        if tokens_per_expert_group.sum().item() == 0:
+            self.is_empty_tokens = True
+        else:
+            self.is_empty_tokens = False
 
         tokens_per_expert_group_sum = tokens_per_expert_group.reshape([expert_model_parallel_size, -1])
         output_splits = tokens_per_expert_group_sum.sum(axis=1).cpu().tolist()
@@ -173,11 +179,17 @@ class AllToAllMoECommunication(nn.Layer, MoECommunicationInterface):
             expert_out = expert(tokens_for_this_expert)
             outputs.append(expert_out)
             start_idx = end_idx
-        outs = paddle.concat(outputs, axis=0) if len(outputs) > 0 else paddle.to_tensor(0, dtype=sorted_tokens.dtype)
+        if not outputs:
+            outs = sorted_tokens
+        else:
+            outs = paddle.concat(outputs, axis=0)
 
         # Third All-to-All: Exchange expert outputs back to original rank. `gathered_tokens` are the tokens that originally belong to current rank
-        new_x = paddle.empty_like(outs)
-        new_x[gatherd_idxs] = outs
+        if self.is_empty_tokens:
+            new_x = outs
+        else:
+            new_x = paddle.empty_like(outs)
+            new_x[gatherd_idxs] = outs
 
         gathered_tokens = _AllToAll.apply(
             sorted_tokens_shape,
@@ -188,21 +200,21 @@ class AllToAllMoECommunication(nn.Layer, MoECommunicationInterface):
         )
 
         # For every processed token, need to multiply the expert weight.
-        num_all_tokens = tokens_per_expert.sum().item()  # i.e. batch_size * seq_len * num_experts_per_token
-        boundaries = paddle.cumsum(tokens_per_expert, dim=0)
-        token_indices = paddle.arange(num_all_tokens)
-        expert_ids = paddle.searchsorted(boundaries, token_indices, right=False)  # shape [num_all_tokens]
-        expert_major_weights = gates_masked[sorted_token_indices, expert_ids]  # shape [num_all_tokens]
+        expert_major_weights = gates_masked[
+            sorted_token_indices, sorted_expert_indices
+        ]  # shape [batch_size * seq_len * num_experts_per_token]
         weighted_gathered_tokens = gathered_tokens * expert_major_weights.unsqueeze(-1).to(
             gathered_tokens.dtype
-        )  # shape [num_all_tokens, d_model]
+        )  # shape [batch_size * seq_len * num_experts_per_token, d_model]
 
         final_output_empty = paddle.zeros(reshaped_input.shape, dtype=gathered_tokens.dtype)
         token_indices_for_scatter = sorted_token_indices.unsqueeze(-1).expand(
             -1, d_model
-        )  # shape [num_all_tokens, d_model]
+        )  # shape [batch_size * seq_len * num_experts_per_token, d_model]
 
-        token_indices_for_scatter_single = token_indices_for_scatter[:, 0:1].squeeze()  # shape [num_all_tokens, 1]
+        token_indices_for_scatter_single = token_indices_for_scatter[
+            :, 0:1
+        ].squeeze()  # shape [batch_size * seq_len * num_experts_per_token, 1]
 
         final_output = paddle.index_add(
             final_output_empty, index=token_indices_for_scatter_single, axis=0, value=weighted_gathered_tokens
@@ -227,6 +239,9 @@ class DeepEPMoECommunication(nn.Layer, MoECommunicationInterface):
             current_expert_idx = i + moe_rank * num_experts_per_device
             expert = experts[current_expert_idx]
             outputs += [expert(chunk)]
+
+        if not outputs:
+            return dispatched_input
 
         return paddle.concat(outputs, axis=0)
 

--- a/paddleformers/transformers/fused_a2a.py
+++ b/paddleformers/transformers/fused_a2a.py
@@ -28,6 +28,11 @@ from paddle.distributed.communication.group import Group
 _buffer = None
 
 
+def barrier_ep(ep_group):
+    """barrier_ep"""
+    paddle.distributed.barrier(ep_group)
+
+
 def get_hidden_bytes(x: paddle.Tensor) -> int:
     """Calculate the number of hidden bytes for a tensor.
 
@@ -83,6 +88,8 @@ def fused_dispatch_forward_func(
     allocate_on_comm_stream=False,
 ):
     """Forward pass of fused dispatch."""
+    barrier_ep(group)
+
     # Calculate layout before actual dispatch
     if isinstance(x, tuple):
         buffer = get_buffer(group, get_hidden_bytes(x[0]))
@@ -137,6 +144,8 @@ def fused_dispatch_backward_func(
     allocate_on_comm_stream=False,
 ):
     """Backward pass of fused dispatch."""
+    barrier_ep(group)
+
     buffer = get_buffer(group, get_hidden_bytes(grad_output))
 
     grad_x, grad_token_probs, event = buffer.combine(
@@ -154,6 +163,8 @@ def fused_combine_forward_func(
     x, group, states, previous_event=None, async_finish=False, allocate_on_comm_stream=False
 ):
     """Forward pass of fused combine."""
+    barrier_ep(group)
+
     handle = states["handle"]
     buffer = get_buffer(group, get_hidden_bytes(x))
     combined_x, _, event = buffer.combine(
@@ -170,6 +181,8 @@ def fused_combine_backward_func(
     grad_output, group, handle, previous_event=None, async_finish=False, allocate_on_comm_stream=False
 ):
     """Backward pass of fused combine."""
+    barrier_ep(group)
+
     if isinstance(grad_output, tuple):
         buffer = get_buffer(group, get_hidden_bytes(grad_output[0]))
         grad_x, _, _, _, _, event = buffer.dispatch(

--- a/paddleformers/transformers/moe_layer.py
+++ b/paddleformers/transformers/moe_layer.py
@@ -124,7 +124,7 @@ class _AllToAll(paddle.autograd.PyLayer):
         if dist.get_world_size(group) <= 1:
             return input
 
-        output = paddle.empty(output_shape, dtype=input.dtype)
+        output = paddle.empty(output_shape, dtype=input.dtype, requires_grad=True)
         task = dist.alltoall_single(
             output,
             input,
@@ -389,6 +389,8 @@ class MoEFlexTokenLayer(nn.Layer):
             chunk = chunk.contiguous()
             expert = self.experts[i + self.moe_rank * self.moe_num_experts_per_device]
             outputs += [expert(chunk)]
+        if not outputs:
+            return dispatched_input
 
         return paddle.cat(outputs, axis=0)
 


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Models

### Description
Cherry pick
- https://github.com/PaddlePaddle/PaddleFormers/pull/3010
- https://github.com/PaddlePaddle/PaddleFormers/pull/3371

EP 通信中的分布式训练超时问题。

**问题原因**
当某个 rank 没有接收到 token 时，专家计算返回 `paddle.empty()` 这样一个新的 Tensor，打断了反向传播的梯度流。这导致：
- 受影响的 rank 不进行反向通信，提前结束反向
- 其他 rank 在正常进行反向通信，但因等待受影响的 rank 的回复，由于未等到回复超时

**解决方案**
当没有接收到 token 时，将专家计算的返回值从 `paddle.empty()` 改为 `input`，保证计算图中的梯度连续性

**其他**
为了防止其他情况，在 EP 通信前后添加 barrier
