### PR TITLE
Balance infer server workloads

### DIFF
--- a/paddleformers/data/causal_dataset.py
+++ b/paddleformers/data/causal_dataset.py
@@ -49,8 +49,13 @@ def get_logits(batch_ids, max_retries=1, timeout=1200, retry_delay=1, prob_nums=
         Exception: Thrown when all retry attempts fail
     """
 
+    hcg = paddle.distributed.fleet.get_hybrid_communicate_group()
+    sd_rank = hcg.get_sharding_parallel_rank()
+    infer_server_ips = INFER_SERVER_IP.split(",")
+    infer_server_ip = infer_server_ips[sd_rank % len(infer_server_ips)]
+
     headers = {"Content_Type": "application/json"}
-    url = f"http://{INFER_SERVER_IP}:{INFER_SERVER_PORT}/generate"
+    url = f"http://{infer_server_ip}:{INFER_SERVER_PORT}/generate"
     payload = {
         "prompt_token_ids": batch_ids,
         "max_tokens": 1,


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
Models

### Description
让训练机器不同的 sharding rank 访问不同的 infer server，实现负载均衡

指定 INFER_SERVER_IP 时用逗号隔开即可，例如 INFER_SERVER_IP="192.168.1.1,192.168.1.2,192.168.1.3"

我们一共是 8 路 sharding，sd_rank 取值从 0 到 7，用余数的方式映射到 3 台 infer server 上，你也可以实现自己的映射方式
