### PR TITLE
[PaddleFleet] Remove `moe_deep_gemm` configuration option

### DIFF
--- a/paddleformers/transformers/configuration_utils.py
+++ b/paddleformers/transformers/configuration_utils.py
@@ -410,12 +410,6 @@ class LlmMetaConfig:
             False,
             "Whether to enable grouped GEMM (General Matrix Multiplication) for MoE experts. Batches computations across multiple experts to improve hardware utilization. Defaults to True.",
         ),
-        (
-            "moe_deep_gemm",
-            bool,
-            True,
-            "Whether to enable deep GEMM for MoE experts. Defaults to True. Effective only after the moe_grouped_gemm is set. ",
-        ),
     ]
 
     mtp_attributes = [

--- a/paddleformers/transformers/configuration_utils.py
+++ b/paddleformers/transformers/configuration_utils.py
@@ -387,6 +387,12 @@ class LlmMetaConfig:
             "Whether to dequantize inputs to MoE experts (only applicable if inputs are quantized). Defaults to False (enable only for quantized inference/training pipelines).",
         ),
         (
+            "moe_expert_fusion",
+            bool,
+            True,
+            "Whether to fuse experts. Default to True.",
+        ),
+        (
             "moe_router_fusion",
             bool,
             True,

--- a/paddleformers/transformers/configuration_utils.py
+++ b/paddleformers/transformers/configuration_utils.py
@@ -387,12 +387,6 @@ class LlmMetaConfig:
             "Whether to dequantize inputs to MoE experts (only applicable if inputs are quantized). Defaults to False (enable only for quantized inference/training pipelines).",
         ),
         (
-            "moe_expert_fusion",
-            bool,
-            True,
-            "Whether to fuse experts. Default to True.",
-        ),
-        (
             "moe_router_fusion",
             bool,
             True,


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description
删除 `moe_deep_gemm` 配置项。

现在在开启 `moe_grouped_gemm` 时，会根据运行环境，如果支持 deepgemm 那么使用 deepgemm；否则退化到框架 batched_gemm。
