### PR TITLE
[Unified MoE Layer] Fix Router topk_weigtht in noaux_tc Method

### DIFF
--- a/paddleformers/nn/moe_deepep/moe_gate.py
+++ b/paddleformers/nn/moe_deepep/moe_gate.py
@@ -356,7 +356,7 @@ class MoEGateMixin:
 
         # The bias term b is used only to adjust affinity scores for Top-K expert selection (routing); it does not affect gating.
         # The gate applied during dispatch and to weight the FFN output is computed from the original affinity score s_{i,t} (without the bias).
-        topk_weight = scores.take_along_axis(topk_idx, axis=1) if not self.training else topk_weight
+        topk_weight = scores.take_along_axis(topk_idx, axis=1)
 
         return topk_weight, topk_idx
 


### PR DESCRIPTION
Unified MoE 中的 router 返回的四个值（仅考虑 noaux_tc 的 topk 方法）：

|                   | 检查标准                              | 目前是否正确 | 影响范围    |
|-------------------|-----------------------------------|------|---------|
| topk_weight       | 需要是未加 correction_bias 前的路由分数      | ❌   | 关 EP 时  |
| topk_indices      | 需要是加 correction_bias 后的路由分数进行专家选择 | ✅   | 关 EP 时  |
| gates_mask(probs) | 需要是未加 correction_bias 前的路由分数      | ✅    | 开 EP 时  |
| mask(routing_map) | 需要是加 correction_bias 后的路由分数进行专家选择 | ✅    | 开 EP 时  |

GLM4MoE，配置 use_unified_moe: true （目前默认没开启） + 关闭 EP 情况下会有问题，需要修复
