### PR TITLE
add trl/llm_utils

### DIFF
--- a/paddleformers/trl/llm_utils.py
+++ b/paddleformers/trl/llm_utils.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+
+from ..utils.log import logger
+
+logger.warning(
+    "paddleformers.trl.llm_utils is deprecated and will be removed in a future version. "
+    "Please use paddleformers.cli.utils.llm_utils instead."
+)
+
+_llm_utils = importlib.import_module("paddleformers.cli.utils.llm_utils")
+globals().update({k: v for k, v in _llm_utils.__dict__.items() if not k.startswith("_")})


### PR DESCRIPTION
为兼容已发版的FastDeploy 2.3，保留中 trl.llm_utils 指向 cli.utils.llm_utils，提示后续版本会废弃，建议写为cli.utils.llm_utils