### PR TITLE
[Refactor] Remove explicit Pipe model checks in lora utils

### DIFF
--- a/paddleformers/cli/train/tuner.py
+++ b/paddleformers/cli/train/tuner.py
@@ -19,7 +19,6 @@ import paddle
 from ..hparams import get_train_args, read_args
 from .auto_parallel import run_auto_parallel
 from .dpo import run_dpo
-from .pretrain import run_dsv3_pretrain
 from .sft import run_sft
 
 
@@ -56,6 +55,8 @@ def _training_function(config: dict[str, Any]) -> None:
         with paddle.amp.auto_cast(enable=False):
             run_dpo(model_args, data_args, generating_args, finetuning_args)
     elif model_args.stage == "dsv3_pretrain":
+        from .pretrain import run_dsv3_pretrain
+
         run_dsv3_pretrain(model_args, data_args, generating_args, finetuning_args)
     elif model_args.stage == "auto-parallel":
         run_auto_parallel(model_args, data_args, generating_args, finetuning_args)

--- a/paddleformers/cli/utils/llm_utils.py
+++ b/paddleformers/cli/utils/llm_utils.py
@@ -33,9 +33,6 @@ if TYPE_CHECKING:
 from paddleformers.generation import GenerationConfig
 from paddleformers.transformers import (  # ChatGLMv2Tokenizer,
     AutoTokenizer,
-    DeepseekV3ForCausalLMPipe,
-    Glm4MoeForCausalLMPipe,
-    LlamaForCausalLMPipe,
     PretrainedConfig,
 )
 from paddleformers.utils.log import logger
@@ -77,7 +74,7 @@ def get_lora_target_modules(model):
         ]
     elif model.config.model_type == "bloom":
         target_modules = [".*query_key_value.*", ".*dense.*", ".*dense_h_to_4h.*", ".*dense_4h_to_h.*"]
-    elif model.config.model_type in ["llama", "jamba"] or isinstance(model, LlamaForCausalLMPipe):
+    elif model.config.model_type in ["llama", "jamba"]:
         target_modules = [
             ".*q_proj.*",
             ".*v_proj.*",
@@ -230,7 +227,7 @@ def get_lora_target_modules(model):
             ".*up_proj.*",
             ".*down_proj.*",
         ]
-    elif model.config.model_type in ["deepseek_v3"] or isinstance(model, (DeepseekV3ForCausalLMPipe)):
+    elif model.config.model_type in ["deepseek_v3"]:
         target_modules = [
             ".*q_proj.*",
             ".*q_a_proj.*",
@@ -273,7 +270,7 @@ def get_lora_target_modules(model):
             ".*up_proj.*",
             ".*down_proj.*",
         ]
-    elif model.config.model_type == "glm4_moe" or isinstance(model, Glm4MoeForCausalLMPipe):
+    elif model.config.model_type == "glm4_moe":
         target_modules = [
             ".*qkv_proj.*",
             ".*up_gate_proj.*",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
Remove direct dependencies on *ForCausalLMPipe classes (Llama, DeepseekV3, Glm4Moe) from `get_lora_target_modules`.
The logic now relies solely on `model.config.model_type` to determine the LoRA target modules, reducing coupling and unnecessary imports.
Move the import of `run_dsv3_pretrain` inside `_training_function`. This avoids loading the pretrain module when it is not needed.