### PR TITLE
modify get_linear_type

### DIFF
--- a/paddleformers/nn/linear.py
+++ b/paddleformers/nn/linear.py
@@ -54,7 +54,7 @@ class Linear(GeneralInterface):
             raise ValueError("linear_type or config must be specified")
 
         if linear_type is None and config is not None:
-            linear_type = self.get_linear_type(config, tp_plan)
+            linear_type = self.get_linear_type(config, tp_plan, has_bias)
 
         linear_cls = self._global_mapping[linear_type]
         fuse_matmul_bias = config.get("fuse_linear", False) if config is not None else False
@@ -62,9 +62,9 @@ class Linear(GeneralInterface):
         return linear_cls(in_features=in_features, out_features=out_features, weight_attr=weight_attr, **kwargs)
 
     @classmethod
-    def get_linear_type(self, config: PretrainedConfig, tp_plan=None):
+    def get_linear_type(self, config: PretrainedConfig, tp_plan=None, has_bias=None):
         if config.tensor_model_parallel_size <= 1:
-            if config.get("fuse_linear", False):
+            if config.get("fuse_linear", False) and has_bias:
                 return "fuse_linear"
             else:
                 return "default"

--- a/paddleformers/nn/linear.py
+++ b/paddleformers/nn/linear.py
@@ -62,7 +62,7 @@ class Linear(GeneralInterface):
         return linear_cls(in_features=in_features, out_features=out_features, weight_attr=weight_attr, **kwargs)
 
     @classmethod
-    def get_linear_type(self, config: PretrainedConfig, tp_plan=None, has_bias=None):
+    def get_linear_type(self, config: PretrainedConfig, tp_plan: str = None, has_bias: bool = None):
         if config.tensor_model_parallel_size <= 1:
             if config.get("fuse_linear", False) and has_bias:
                 return "fuse_linear"

--- a/tests/nn/test_linear.py
+++ b/tests/nn/test_linear.py
@@ -117,7 +117,7 @@ class TestLinear(TestMultipleGpus):
         # Test fused linear type detection
         self.config.tensor_model_parallel_size = 1
         self.config.fuse_linear = True
-        linear_type = Linear.get_linear_type(self.config)
+        linear_type = Linear.get_linear_type(self.config, has_bias=True)
         self.assertEqual(linear_type, "fuse_linear")
 
     def test_get_linear_type_parallel(self):


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what this PR does -->
modify get_linear_type so that when has_bias is False, linear_type is default