### PR TITLE
fix CUDA_PATH Flag

### DIFF
--- a/examples/experiments/deepseek_v3_pretrain/script/train_gpu.sh
+++ b/examples/experiments/deepseek_v3_pretrain/script/train_gpu.sh
@@ -38,7 +38,7 @@ unset NVSHMEM_ENABLE_NIC_PE_MAPPING
 
 export PYTHONPATH=../../../:$PYTHONPATH
 
-export CUDA_PATH=/usr/local/cuda-12.9
+# export CUDA_PATH=/usr/local/cuda-12.9
 
 # Flags for allocator
 export FLAGS_large_pool_auto_growth_chunk_size_in_mb=128


### PR DESCRIPTION
注释测试脚本中的CUDA_PATH，改用pip install安装Paddle中单独装的 cuda 库
