### PR TITLE
Upgrade EB4.5 pretrain to Paddle 3.3.0

### DIFF
--- a/examples/experiments/ernie_pretrain/ernie/pretrain.py
+++ b/examples/experiments/ernie_pretrain/ernie/pretrain.py
@@ -47,6 +47,7 @@ from models.ernie.modeling_moe import ErnieMoEForCausalLM
 from models.ernie.modeling_pp import ErnieMoEForCausalLMPipe
 from omegaconf.dictconfig import DictConfig
 from omegaconf.listconfig import ListConfig
+from safetensors import safe_open
 from src.callbacks import (
     GlobalRNGCallback,
     MoECorrectionBiasAdjustCallback,
@@ -62,9 +63,11 @@ from paddleformers.data.causal_dataset import (
     build_train_valid_test_datasets,
     check_data_split,
 )
-from paddleformers.datasets.finetuning import collate_fn
-from paddleformers.datasets.finetuning import create_dataset as create_dataset_sft
+from paddleformers.datasets.collate import collate_fn
+from paddleformers.datasets.loader import create_dataset as create_dataset_sft
 from paddleformers.trainer import TrainingArguments
+from paddleformers.trainer.unified_checkpoint import unified_checkpoint
+from paddleformers.transformers.model_utils import unwrap_model
 
 try:
     from paddleformers.trainer.trainer_utils import log_trainer_start
@@ -78,6 +81,169 @@ except ImportError:
 
 
 log_trainer_start()
+
+
+def load_huggingface_checkpoint(model, args):
+    fused_rms_norm_replace = [
+        ("self_attn.fused_rms_norm_linear.rms_norm_weight", "input_layernorm.weight"),
+        ("self_attn.fused_rms_norm_linear.linear_weight", "self_attn.qkv_proj.weight"),
+    ]
+    shared_layers_prefix = "shared_layers.embed_weight_share."
+    unnamed_layers = ["ernie.norm.weight", "lm_head.weight"]
+
+    logger.info(f"Loading huggingface checkpoint from {args.model_name_or_path}")
+    with open(os.path.join(args.model_name_or_path, "model.safetensors.index.json")) as f:
+        weight_map = json.load(f)["weight_map"]
+
+    ep_degree = fleet.get_hybrid_communicate_group().get_expert_parallel_world_size()
+    ep_rank = fleet.get_hybrid_communicate_group().get_expert_parallel_rank()
+    expert_offset = (model.config.moe_num_experts // ep_degree) * ep_rank
+    use_torch_format = False
+
+    def param_to_weight(name):
+        # for PP=1, we only need to substitute the fused_rms_norm and expert_id
+        for src, dst in fused_rms_norm_replace:
+            name = name.replace(src, dst)
+        if m := re.search(r"mlp\.experts\.(\d+)", name):
+            expert_id = expert_offset + int(m.group(1))
+            s, e = m.span()
+            name = name[:s] + f"mlp.experts.{expert_id}" + name[e:]
+        if isinstance(model, ErnieMoEForCausalLM):
+            return name
+
+        # for PP>1, we also need to handle special layers and adjust layer_idx
+        if name.startswith(shared_layers_prefix):
+            return "ernie." + name[len(shared_layers_prefix) :]
+        layer_idx, stem = name.split(".", maxsplit=1)
+        if stem == "weight":
+            return unnamed_layers.pop(0)
+        if stem.startswith("mtp"):
+            return f"ernie.{stem}"
+        return f"ernie.layers.{int(layer_idx) - 1}.{stem}"
+
+    def try_torch_format(weight_key):
+        if weight_key.startswith("ernie."):
+            weight_key = "model." + weight_key[6:]
+
+        key_decompose = [weight_key]
+        if ".up_gate_proj." in weight_key:
+            key_decompose = [
+                weight_key.replace(".up_gate_proj.", ".gate_proj."),
+                weight_key.replace(".up_gate_proj.", ".up_proj."),
+            ]
+        elif ".qkv_proj." in weight_key:
+            key_decompose = [
+                weight_key.replace(".qkv_proj.", ".q_proj."),
+                weight_key.replace(".qkv_proj.", ".k_proj."),
+                weight_key.replace(".qkv_proj.", ".v_proj."),
+            ]
+
+        tensor_decompose = []
+        for key in key_decompose:
+            if not (weight_file := weight_map.get(key)):
+                return None
+            with safe_open(
+                os.path.join(args.model_name_or_path, weight_file),
+                framework="numpy",
+            ) as f:
+                tensor = paddle.to_tensor(f.get_tensor(key))
+            if "_proj." in key or ".gate." in key:
+                tensor = tensor.T.contiguous()
+            tensor_decompose.append(tensor)
+
+        if len(tensor_decompose) == 1:
+            return tensor_decompose[0]
+        else:
+            return paddle.concat(tensor_decompose, axis=-1)
+
+    for name, param in model.named_parameters():
+        weight_key = param_to_weight(name)
+        if weight_file := weight_map.get(weight_key):
+            with safe_open(
+                os.path.join(args.model_name_or_path, weight_file),
+                framework="numpy",
+            ) as f:
+                weight = paddle.to_tensor(f.get_tensor(weight_key))
+        elif (weight := try_torch_format(weight_key)) is not None:
+            use_torch_format = True
+        else:
+            logger.warning(f"param `{name}`'s weight `{weight_key}` not found.")
+            continue
+        if use_torch_format and "lm_head" in weight_key:
+            weight = weight.T.contiguous()
+        if param.shape != weight.shape:
+            logger.error(
+                f"param `{name}`'s shape doesn't match weight `{weight_key}`: {param.shape} and {weight.shape}."
+            )
+        param.copy_(weight)
+
+
+def get_expected_state_dict(model, **kwargs):
+    fused_rms_norm_replace = [
+        ("self_attn.fused_rms_norm_linear.rms_norm_weight", "input_layernorm.weight"),
+        ("self_attn.fused_rms_norm_linear.linear_weight", "self_attn.qkv_proj.weight"),
+    ]
+    shared_layers_prefix = "embed_share."
+
+    model = unwrap_model(model)
+    hcg = fleet.get_hybrid_communicate_group()
+    ep_degree = hcg.get_expert_parallel_world_size()
+    ep_rank = hcg.get_expert_parallel_rank()
+    expert_offset = (model.config.moe_num_experts // ep_degree) * ep_rank
+
+    if model.config.head_dim is None:
+        head_dim = model.config.hidden_size // model.config.num_attention_heads
+    else:
+        head_dim = model.config.head_dim
+    q_dim = head_dim * model.config.num_attention_heads
+    kv_dim = head_dim * model.config.num_key_value_heads
+
+    def copy_attr(out, param):
+        if hasattr(param, "is_distributed"):
+            out.is_distributed = param.is_distributed
+        if hasattr(param, "no_sync"):
+            out.no_sync = param.no_sync
+        return out
+
+    def param_to_weight(name):
+        # for PP=1, we only need to substitute the fused_rms_norm and expert_id
+        for src, dst in fused_rms_norm_replace:
+            name = name.replace(src, dst)
+        if m := re.search(r"\.experts\.(\d+)\.", name):
+            expert_id = expert_offset + int(m.group(1))
+            s, e = m.span()
+            name = name[:s] + f".experts.{expert_id}." + name[e:]
+        if isinstance(model, ErnieMoEForCausalLM):
+            return name
+
+        # for PP>1, we also need to handle shared layers
+        if name.startswith(shared_layers_prefix):
+            return "ernie." + name[len(shared_layers_prefix) :]
+        return name
+
+    state_dict = {}
+    for name, param in model.state_dict().items():
+        name = param_to_weight(name)
+        if name.startswith("ernie."):
+            name = "model." + name[6:]
+
+        if "_proj." in name or ".gate." in name or "lm_head" in name:
+            param = copy_attr(param.T, param)
+
+        if ".up_gate_proj." in name:
+            gate, up = param.split(2)
+            gate, up = copy_attr(gate, param), copy_attr(up, param)
+            state_dict[name.replace(".up_gate_proj.", ".gate_proj.")] = gate
+            state_dict[name.replace(".up_gate_proj.", ".up_proj.")] = up
+        elif ".qkv_proj." in name:
+            assert q_dim + kv_dim * 2 == param.shape[0]
+            state_dict[name.replace(".qkv_proj.", ".q_proj.")] = param[:q_dim]
+            state_dict[name.replace(".qkv_proj.", ".k_proj.")] = param[q_dim:-kv_dim]
+            state_dict[name.replace(".qkv_proj.", ".v_proj.")] = param[-kv_dim:]
+        else:
+            state_dict[name] = param
+
+    return state_dict
 
 
 def update_model_config_from_args(config: ErnieMoEConfig, model_args: dict):
@@ -178,17 +344,17 @@ def main():
         logger.warning("disabling `partial_send_recv` when using sequence parallel")
         config.trainer_args.partial_send_recv = False
 
-    if getattr(config.trainer_args, "bf16", False) and not config.trainer_args.pp_delay_scale_loss:
+    if getattr(config.trainer_args, "bf16", False) and not getattr(config.trainer_args, "pp_delay_scale_loss", False):
         logger.warning(
             "It is recommended to enable pp_delay_scale_loss for better performance "
             "of precision when using bf16 in training"
         )
         config.trainer_args.pp_delay_scale_loss = True
 
-    if config.trainer_args.dp_comm_overlap:
-        logger.warning("Pipeline dp_comm_overlap and FusedLinearWithGradAdd can not be used at " "the same time.")
+    if getattr(config.trainer_args, "dp_comm_overlap", False):
+        logger.warning("Pipeline dp_comm_overlap and FusedLinearWithGradAdd can not be used at the same time.")
 
-    if config.trainer_args.timer:
+    if getattr(config.trainer_args, "timer", False):
         from paddle.distributed.fleet.meta_parallel.pipeline_parallel import (
             PipelineParallel,
         )
@@ -437,21 +603,16 @@ def main():
         cfg.enable_delay_scale_loss = args.enable_delay_scale_loss
         register_pp_reshard_information(cfg.num_hidden_layers)
 
-        if args.from_scratch:
-            model = ErnieMoEForCausalLMPipe(cfg)
-        else:
-            model = ErnieMoEForCausalLMPipe.from_pretrained(
-                args.model_name_or_path,
-                config=cfg,
-            )
+        model = ErnieMoEForCausalLMPipe(cfg)
     else:
-        if args.from_scratch:
-            model = ErnieMoEForCausalLM(cfg)
-        else:
-            model = ErnieMoEForCausalLM.from_pretrained(
-                args.model_name_or_path,
-                config=cfg,
-            )
+        model = ErnieMoEForCausalLM(cfg)
+
+    if not args.from_scratch:
+        load_huggingface_checkpoint(model, args)
+
+    # We must use non-huggingface format to save intermediate checkpoints during training.
+    args.save_to_hf = False
+    args.load_checkpoint_format = "unified_checkpoint"
 
     cfg = model.config
     logger.info(f"using model type:{type(model)}")
@@ -530,6 +691,12 @@ def main():
     if args.do_train:
         train_result = trainer.train(resume_from_checkpoint=checkpoint)
         metrics = train_result.metrics
+
+        # After training, we use unified huggingface format to export the model.
+        trainer.args.save_to_hf = True
+        trainer.args.save_checkpoint_format = "unified_checkpoint"
+        unified_checkpoint.get_expected_state_dict = get_expected_state_dict
+
         trainer.save_model(args.output_dir)
         trainer.log_metrics("train", metrics)
         trainer.save_metrics("train", metrics)

--- a/examples/experiments/ernie_pretrain/ernie/src/callbacks/ortho_loss_callback.py
+++ b/examples/experiments/ernie_pretrain/ernie/src/callbacks/ortho_loss_callback.py
@@ -39,8 +39,10 @@ class OrthogonalCallback(TrainerCallback):
                         hook_id = list(gate._forward_pre_hooks.keys())[0]
                         gate._forward_pre_hooks[hook_id](gate, inputs=None)
                     assert gate.weight.dtype == paddle.float32, f"got unexpected dtype: {gate.weight.dtype}"
-                    oloss = gate._cal_orthogonal_loss_opt_each_weight(gate.weight, model.config.moe_group_experts)
-                    (oloss_grad,) = paddle.autograd.grad(oloss, gate.weight)
+                    weight = gate.weight.detach()
+                    weight.stop_gradient = False
+                    oloss = gate._cal_orthogonal_loss_opt_each_weight(weight, model.config.moe_group_experts)
+                    (oloss_grad,) = paddle.autograd.grad(oloss, weight)
                     with paddle.no_grad():
                         gate.weight.data.add_(-oloss_grad * self.ortho_loss_lambda)
                     gate.weight.stop_gradient = False

--- a/examples/experiments/ernie_pretrain/models/fp8_linear.py
+++ b/examples/experiments/ernie_pretrain/models/fp8_linear.py
@@ -31,7 +31,7 @@ incubate APIs for low-precision training. Key features include:
 import numpy
 import paddle
 from paddle.incubate.fp8 import deep_gemm
-from paddle.incubate.nn.functional import swiglu
+from paddle.nn.functional import swiglu
 
 # Keep reference to original linear op for fallback if needed
 original_linear = paddle.nn.functional.linear

--- a/examples/experiments/ernie_pretrain/models/moe/moe_layer.py
+++ b/examples/experiments/ernie_pretrain/models/moe/moe_layer.py
@@ -62,6 +62,12 @@ GateOutput = namedtuple(
 )
 
 
+def set_grad_in_dtype_non_consistent(ctx):
+    """Allow grad dtype not consistent with forward dtype"""
+    if hasattr(ctx, "set_grad_in_dtype_consistent"):
+        ctx.set_grad_in_dtype_consistent(False)
+
+
 class Fp8MoeGateDispatchAndQuant(paddle.autograd.PyLayer):
     """Fp8MoeGateDispatchAndQuant"""
 
@@ -77,6 +83,7 @@ class Fp8MoeGateDispatchAndQuant(paddle.autograd.PyLayer):
         use_pow2_scale=True,
     ):
         """forward"""
+        set_grad_in_dtype_non_consistent(ctx)
         assert moe_gate_dispatch_and_quant is not None, "Please use new version Paddle."
         with paddle.amp.auto_cast(enable=False):
             (out_fp8, scale, combine_weights, scatter_index, expert_offset, expert_id,) = moe_gate_dispatch_and_quant(
@@ -382,6 +389,18 @@ def combining_fused(x, combine_weights, scatter_index, hard_gate=False):
     return ret
 
 
+class ReshapeKeepGradDtype(PyLayer):
+    @staticmethod
+    def forward(ctx, x, shape):
+        set_grad_in_dtype_non_consistent(ctx)
+        ctx.orig_shape = x.shape
+        return x.reshape(shape)
+
+    @staticmethod
+    def backward(ctx, grad):
+        return grad.reshape(ctx.orig_shape)
+
+
 class MOELayer(nn.Layer):
     """Mixture of Experts (MoE) Layer implementation.
 
@@ -634,12 +653,13 @@ class MOELayer(nn.Layer):
         combine_weights = combine_weights.cast("bfloat16")
 
         def reshape_for_a2a(tensor):
-            return tensor.reshape(
+            return ReshapeKeepGradDtype.apply(
+                tensor,
                 [
                     self.world_size * self.num_local_experts,
                     capacity,
                     -1,
-                ]
+                ],
             )
 
         dispatched_input = reshape_for_a2a(dispatched_input)


### PR DESCRIPTION
### PR types
New features

### PR changes
Models

### Description
将 EB4.5 pretrain 代码升级至 Paddle 3.3.0，并提供正确的权重加载和保存的实现

#### Checklist
| | ERNIE-4.5-21B-A3B-Base-PT | ERNIE-4.5-300B-A47B-Base-PT |
| --- | :-: | :-: |
| 冷启能跑 | ✅ | ✅
| 冷启性能 | ✅<br>(旧: 11422, 新: 11573) | ✅<br>(旧: 1262, 新: 1287)
| 热启前5步loss&norm | ✅ | ✅
| 断点重训 | ✅ | ✅
| UC权重导出 | ✅ | ✅

性能和精度均是与 ERNIEKit + Paddle 3.2.1 对比，使用相同参数、相同数据集，发现前反向阶段性能提升2%，可能是因为算子库性能提升了