### PR TITLE
[Fleet]Fix num_experts for qwen

### DIFF
--- a/paddleformers/transformers/qwen3_moe/modeling.py
+++ b/paddleformers/transformers/qwen3_moe/modeling.py
@@ -67,6 +67,7 @@ class Qwen3MoEModelProvider(GPTModelProvider):
         "context_parallel_degree": "context_parallel_size",
         "expert_parallel_degree": "expert_model_parallel_size",
         "dtype": "params_dtype",
+        "num_experts": "n_routed_experts",
     }
 
     rotary_base: float = 1000000.0
@@ -89,7 +90,6 @@ class Qwen3MoEModelProvider(GPTModelProvider):
     moe_grouped_gemm: bool = True
 
     n_shared_experts: int = 0
-    transform_rules = {"num_experts": "n_routed_experts"}
 
 
 def rotate_half(x):

--- a/paddleformers/transformers/qwen3_moe/modeling.py
+++ b/paddleformers/transformers/qwen3_moe/modeling.py
@@ -88,8 +88,8 @@ class Qwen3MoEModelProvider(GPTModelProvider):
     router_aux_loss_coef: float = 0.001
     moe_grouped_gemm: bool = True
 
-    n_routed_experts: int = 128
     n_shared_experts: int = 0
+    transform_rules = {"num_experts": "n_routed_experts"}
 
 
 def rotate_half(x):
@@ -849,6 +849,10 @@ class Qwen3MoePretrainedModel(PretrainedModel):
 
     @classmethod
     def _gen_aoa_config(cls, config: Qwen3MoeConfig):
+        if hasattr(config, "n_routed_experts"):
+            num_experts = config.n_routed_experts
+        else:
+            num_experts = config.num_experts
         model_prefix = "" if cls == cls.base_model_class else "model."
         aoa_config = {
             "aoa_statements": [
@@ -912,7 +916,7 @@ class Qwen3MoePretrainedModel(PretrainedModel):
                 tgt_prefix = f"{model_prefix}layers.{layer_idx}"
                 ep_weight1 = []
                 ep_weight2 = []
-                for expert_id in range(config.num_experts):
+                for expert_id in range(num_experts):
                     ep_weight1.append(f"{src_prefix}.mlp.experts.{expert_id}.up_gate_proj.weight")
                     ep_weight2.append(f"{src_prefix}.mlp.experts.{expert_id}.down_proj.weight")
                 group_gemm1 = ",".join(ep_weight1)
@@ -930,6 +934,10 @@ class Qwen3MoePretrainedModel(PretrainedModel):
 
     @classmethod
     def _gen_inv_aoa_config(cls, config: Qwen3MoeConfig):
+        if hasattr(config, "n_routed_experts"):
+            num_experts = config.n_routed_experts
+        else:
+            num_experts = config.num_experts
         model_prefix = "" if cls == cls.base_model_class else "model."
         aoa_statements = [
             f"{model_prefix}layers.$LAYER_ID.self_attn.o_proj.weight^T -> model.layers.$LAYER_ID.self_attn.o_proj.weight",
@@ -986,7 +994,7 @@ class Qwen3MoePretrainedModel(PretrainedModel):
                 for layer_id in range(config.num_hidden_layers):
                     ep_weight1 = []
                     ep_weight2 = []
-                    for expert_id in range(config.num_experts):
+                    for expert_id in range(num_experts):
                         ep_weight1.append(
                             f"{model_prefix}layers.{layer_id}.mlp.experts.{expert_id}.up_gate_proj.weight"
                         )
@@ -999,7 +1007,7 @@ class Qwen3MoePretrainedModel(PretrainedModel):
                     ]
 
             for layer_id in range(config.num_hidden_layers):
-                for expert_id in range(config.num_experts):
+                for expert_id in range(num_experts):
                     if getattr(cls, "is_fleet", False):
                         aoa_statements += [
                             f"{model_prefix}layers.{layer_id}.mlp.experts.{expert_id}.up_gate_proj.weight -> model.layers.{layer_id}.mlp.experts.{expert_id}.gate_proj.weight, model.layers.{layer_id}.mlp.experts.{expert_id}.up_proj.weight, axis=1",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
Fix num_experts for qwen: qwen uses n_routed_experts instead