### PR TITLE
[cherry-pick] update deafult value for xxx_strategy and model_conf

### DIFF
--- a/paddleformers/trainer/training_args.py
+++ b/paddleformers/trainer/training_args.py
@@ -464,7 +464,7 @@ class TrainingArguments:
     do_predict: bool = field(default=False, metadata={"help": "Whether to run predictions on the test set."})
     do_export: bool = field(default=False, metadata={"help": "Whether to export infernece model."})
     evaluation_strategy: IntervalStrategy = field(
-        default="no",
+        default=IntervalStrategy.NO,
         metadata={"help": "The evaluation strategy to use."},
     )
     prediction_loss_only: bool = field(
@@ -520,14 +520,14 @@ class TrainingArguments:
     logging_dir: Optional[str] = field(default=None, metadata={"help": "VisualDL log dir."})
     output_signal_dir: Optional[str] = field(default=None, metadata={"help": "Asynchronous saving signal dir."})
     logging_strategy: IntervalStrategy = field(
-        default="steps",
+        default=IntervalStrategy.STEPS,
         metadata={"help": "The logging strategy to use."},
     )
     logging_first_step: bool = field(default=False, metadata={"help": "Log the first global_step"})
     logging_steps: int = field(default=500, metadata={"help": "Log every X updates steps."})
 
     save_strategy: IntervalStrategy = field(
-        default="steps",
+        default=IntervalStrategy.STEPS,
         metadata={"help": "The checkpoint save strategy to use."},
     )
     save_steps: int = field(default=500, metadata={"help": "Save checkpoint every X updates steps."})

--- a/paddleformers/transformers/configuration_utils.py
+++ b/paddleformers/transformers/configuration_utils.py
@@ -270,7 +270,7 @@ class LlmMetaConfig:
             None,
             "Recompute granularity, Choose among ['full', 'core_attn', 'full_attn']",
         ),
-        ("recompute_method", str, None, "Determines which transformer layers will be recomputed."),
+        ("recompute_method", Optional[str], None, "Determines which transformer layers will be recomputed."),
         (
             "recompute_num_layers",
             Optional[int],
@@ -442,15 +442,15 @@ class LlmMetaConfig:
     ]
 
     model_conf = [
-        ("num_hidden_layers", int, None, "Number of hidden layers in the model."),
-        ("num_attention_heads", int, None, "Number of attention heads in the model."),
-        ("num_key_value_heads", int, None, "Number of key/value heads in the model (for GQA/MQA)."),
-        ("num_experts_per_tok", int, None, "Number of experts to activate per token (for MoE models)."),
-        ("hidden_size", int, None, "Hidden size/dimension of the model."),
-        ("intermediate_size", int, None, "Intermediate size in the feed-forward network."),
-        ("n_routed_experts", int, None, "Number of routed experts in the model (for MoE models)."),
-        ("use_qk_norm", bool, None, "Whether to use query/key normalization."),
-        ("tie_word_embeddings", bool, None, "Whether to tie input and output embeddings."),
+        ("num_hidden_layers", Optional[int], None, "Number of hidden layers in the model."),
+        ("num_attention_heads", Optional[int], None, "Number of attention heads in the model."),
+        ("num_key_value_heads", Optional[int], None, "Number of key/value heads in the model (for GQA/MQA)."),
+        ("num_experts_per_tok", Optional[int], None, "Number of experts to activate per token (for MoE models)."),
+        ("hidden_size", Optional[int], None, "Hidden size/dimension of the model."),
+        ("intermediate_size", Optional[int], None, "Intermediate size in the feed-forward network."),
+        ("n_routed_experts", Optional[int], None, "Number of routed experts in the model (for MoE models)."),
+        ("use_qk_norm", Optional[bool], None, "Whether to use query/key normalization."),
+        ("tie_word_embeddings", Optional[bool], None, "Whether to tie input and output embeddings."),
     ]
 
     model_attributes = [


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Update deafult value for evaluation_strategy/logging_strategy/save_strategy.

When 
```python
OmegaConf.structured(dataclass_type) # TrainingArguments
```
will find evaluation_strategy's default value is `"no"`. However, `IntervalStrategy["no"]` can not find.

<img width="612" height="67" alt="image" src="https://github.com/user-attachments/assets/d5f8162b-2a55-46fb-b172-5bb58cf35e9d" />

根本原因是值默认类型和默认值不匹配，因此在此PR修改默认值。
虽然 IntervalStrategy 的定义中 NO = "no"，看起来值是小写的，但 Python 的 Enum 查找机制如下：
按名查找 (By Name): IntervalStrategy['NO'] -> 返回 IntervalStrategy.NO (这是 OmegaConf 在结构化转换时默认尝试的行为)。
按值查找 (By Value): IntervalStrategy('no') -> 返回 IntervalStrategy.NO。
OmegaConf 的 structured 方法在处理类型提示为 Enum 的字段时，通常期望输入匹配枚举的 Name。
Merged in dev: #3609 
Merged in dev:  [#3609](https://github.com/PaddlePaddle/PaddleFormers/pull/3609)