### PR TITLE
Fix attention precision mismatch align eager_attention_forward with hf

### DIFF
--- a/paddleformers/nn/attention/eager_attention.py
+++ b/paddleformers/nn/attention/eager_attention.py
@@ -33,10 +33,6 @@ def eager_attention_forward(
     is_causal: Optional[bool] = None,
     **kwargs,
 ):
-
-    # b h l d -> b l h d
-    key = key.transpose(1, 2)
-    value = value.transpose(1, 2)
     if hasattr(module, "num_key_value_groups"):
         num_key_value_groups = module.num_key_value_groups
         key = repeat_kv(key, num_key_value_groups)
@@ -53,10 +49,7 @@ def eager_attention_forward(
 
         attention_mask = _gen_from_sparse_attn_mask_indices(attn_mask_startend_row_indices, query.dtype, is_causal)
 
-    # b l h d -> b h l d
-    key = key.transpose(1, 2)
-    value = value.transpose(1, 2)
-    attn_weights = paddle.matmul(query, key.transpose([0, 1, 3, 2])) * scaling
+    attn_weights = paddle.matmul(query, key.transpose(2, 3)) * scaling
 
     if attention_mask is not None:
         attention_mask = attention_mask[:, :, :, : key.shape[-2]]
@@ -73,7 +66,6 @@ def eager_attention_forward(
         attn_weights = nn.functional.dropout(attn_weights, p=dropout, training=module.training)
 
     attn_output = paddle.matmul(attn_weights, value)  # b h l l @ b h l d -> b h l d
-    attn_output = attn_output.transpose([0, 2, 1, 3])  # b h l d -> b l h d
-    attn_output = paddle.reshape(x=attn_output, shape=[0, 0, attn_output.shape[2] * attn_output.shape[3]])
+    attn_output = attn_output.transpose(1, 2).contiguous()
 
     return attn_output, attn_weights

--- a/paddleformers/nn/attention/utils.py
+++ b/paddleformers/nn/attention/utils.py
@@ -20,9 +20,8 @@ def repeat_kv(hidden_states: paddle.Tensor, n_rep: int) -> paddle.Tensor:
     This is the equivalent of paddle.repeat_interleave(hidden_states, n_rep, axis=1). The hidden states go from (batch,
     num_key_value_heads, seqlen, head_dim) to (batch, num_attention_heads, seqlen, head_dim)
     """
-    batch, slen, num_key_value_heads, head_dim = hidden_states.shape
+    batch, num_key_value_heads, slen, head_dim = hidden_states.shape
     if n_rep == 1:
         return hidden_states
-
-    hidden_states = hidden_states.unsqueeze(-2).tile([1, 1, 1, n_rep, 1])
-    return hidden_states.reshape([batch, slen, num_key_value_heads * n_rep, head_dim])
+    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)
+    return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->
默认的 eager_attention_forward 与 hf 各个模型中的 eager_attention_forward 实现不同，可能产生精度 diff。例如，qwen3 中repeat_kv 结果的 stride 不同会导致后续 matmul 产生一个 1e-8的diff，因此需要对齐默认写法。对于其余模型组网中的eager_attention_forward如果与默认实现不同，建议参考 hf 单独实现。
