### PR TITLE
Add GLM SFT 128K yaml

### DIFF
--- a/tests/config/benchmark/config/sft/GLM4.5-Air_128k.yaml
+++ b/tests/config/benchmark/config/sft/GLM4.5-Air_128k.yaml
@@ -1,0 +1,105 @@
+### data /root/paddlejob/gpfs/xuxinyi/fleet/glm45_fleet_pt/data_sft_64k/sftdata_60to62k_messages_100.jsonl
+train_dataset_type: messages
+eval_dataset_type: messages
+train_dataset_path: /root/paddlejob/share-storage/gpfs/system-public/wangnian/NewFleet/glm45_fleet_pt/data_sft_10w/sft_data_10w.jsonl
+train_dataset_prob: "1.0"
+eval_dataset_path: /root/paddlejob/share-storage/gpfs/system-public/wangnian/NewFleet/glm45_fleet_pt/data_sft_10w/sft_data_10w.jsonl
+eval_dataset_prob: "1.0"
+
+max_seq_len: 131072
+packing: true
+use_template: false
+random_shuffle: true
+mix_strategy: concat
+truncate_packing: false
+padding_free: true
+
+### model
+model_name_or_path: /root/paddlejob/gpfs/efficient_benchmark/huggingface/GLM-4.5-Air
+attn_impl: flashmask
+
+### finetuning
+# base
+stage: SFT
+fine_tuning: full
+seed: 23
+do_train: true
+do_eval: true
+per_device_eval_batch_size: 1
+per_device_train_batch_size: 1
+num_train_epochs: 1
+max_steps: 10
+eval_iters: 1000
+eval_steps: 1000
+evaluation_strategy: steps
+save_steps: 100
+save_strategy: steps
+logging_steps: 1
+gradient_accumulation_steps: 32  # 16nodes
+logging_dir: ./vdl_log
+output_dir: ./checkpoint
+disable_tqdm: true
+eval_accumulation_steps: 16
+
+# train
+warmup_steps: 20
+learning_rate: 1.0e-5
+
+# performance
+context_parallel_size: 2
+tensor_model_parallel_size: 4
+expert_model_parallel_size: 8
+sequence_parallel: true
+use_expert_parallel: true
+pipeline_model_parallel_size: 4
+num_empty_layers_add_in_head: 0
+num_empty_layers_add_in_tail: 2
+
+# performance
+recompute_granularity: full
+# recompute_method: first_n
+# recompute_num_layers: 10
+recompute_method: uniform
+recompute_num_layers: 1
+
+# using_sonic_moe: true
+
+moe_grouped_gemm: true
+moe_deep_gemm: false
+
+apply_rope_fusion: true
+fuse_rms_norm: true
+moe_router_force_load_balancing: false
+
+split_param: true
+sharding: stage1
+stage1_overlap: true
+
+# pp
+pp_delay_scale_loss: true
+overlap_p2p_comm: true
+variable_seq_lengths: true
+best_unbalanced_scheduler: true
+pp_release_grads: true
+
+tp_delay_scale_loss: True
+
+amp_master_grad: true
+bf16: true
+fp16_opt_level: O2
+fa_version: 3
+
+save_checkpoint_format: flex_checkpoint
+load_checkpoint_format: flex_checkpoint
+continue_training: true
+dataloader_shuffle: false
+
+benchmark: true
+
+dataloader_num_workers: 24
+prefetch_factor: 24
+
+fuse_attention_qkv: true
+fuse_attention_ffn: true
+fp32_residual_connection: false
+tensorwise_offload_optimizer: false

--- a/tests/config/benchmark/config/sft/GLM4.5-Air_128k.yaml
+++ b/tests/config/benchmark/config/sft/GLM4.5-Air_128k.yaml
@@ -1,9 +1,9 @@
 ### data /root/paddlejob/gpfs/xuxinyi/fleet/glm45_fleet_pt/data_sft_64k/sftdata_60to62k_messages_100.jsonl
 train_dataset_type: messages
 eval_dataset_type: messages
-train_dataset_path: /root/paddlejob/share-storage/gpfs/system-public/wangnian/NewFleet/glm45_fleet_pt/data_sft_10w/sft_data_10w.jsonl
+train_dataset_path: /root/paddlejob/share-storage/gpfs/system-public/efficient_benchmark/dataset/data_sft_10w/sft_data_10w.jsonl
 train_dataset_prob: "1.0"
-eval_dataset_path: /root/paddlejob/share-storage/gpfs/system-public/wangnian/NewFleet/glm45_fleet_pt/data_sft_10w/sft_data_10w.jsonl
+eval_dataset_path: /root/paddlejob/share-storage/gpfs/system-public/efficient_benchmark/dataset/data_sft_10w/sft_data_10w.jsonl
 eval_dataset_prob: "1.0"
 
 max_seq_len: 131072
@@ -15,8 +15,8 @@ truncate_packing: false
 padding_free: true
 
 ### model
-model_name_or_path: /root/paddlejob/gpfs/efficient_benchmark/huggingface/GLM-4.5-Air
-attn_impl: flashmask
+model_name_or_path: /root/paddlejob/share-storage/gpfs/system-public/efficient_benchmark/huggingface/GLM-4.5-Air
+_attn_implementation: flashmask
 
 ### finetuning
 # base
@@ -37,7 +37,7 @@ save_strategy: steps
 logging_steps: 1
 gradient_accumulation_steps: 32  # 16nodes
 logging_dir: ./vdl_log
-output_dir: ./checkpoint
+output_dir: /root/ckpt
 disable_tqdm: true
 eval_accumulation_steps: 16
 
@@ -99,7 +99,5 @@ benchmark: true
 dataloader_num_workers: 24
 prefetch_factor: 24
 
-fuse_attention_qkv: true
-fuse_attention_ffn: true
 fp32_residual_connection: false
 tensorwise_offload_optimizer: false


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description
GLM 16机最优128k sft配置
需要使用VMM所以paddle需要在https://github.com/PaddlePaddle/Paddle/pull/77200这个pr之后的包，需要两个export
FLAGS_use_virtual_memory_auto_growth=True
FLAGS_vmm_large_pool_pre_alloc_in_mb=66560
如果机器少于16机导致OOM可以修改yaml中配置tensorwise_offload_optimizer为true

16机性能1673