### PR TITLE
Fix attention precision mismatch align eager_attention_forward with hf

### DIFF
--- a/paddleformers/nn/attention/eager_attention.py
+++ b/paddleformers/nn/attention/eager_attention.py
@@ -18,7 +18,14 @@ import paddle
 import paddle.nn as nn
 
 from ...utils.masking_utils import _gen_from_sparse_attn_mask_indices
-from .utils import repeat_kv
+
+
+def repeat_kv(hidden_states: paddle.Tensor, n_rep: int) -> paddle.Tensor:
+    batch, num_key_value_heads, slen, head_dim = hidden_states.shape
+    if n_rep == 1:
+        return hidden_states
+    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)
+    return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
 
 
 def eager_attention_forward(
@@ -34,9 +41,6 @@ def eager_attention_forward(
     **kwargs,
 ):
 
-    # b h l d -> b l h d
-    key = key.transpose(1, 2)
-    value = value.transpose(1, 2)
     if hasattr(module, "num_key_value_groups"):
         num_key_value_groups = module.num_key_value_groups
         key = repeat_kv(key, num_key_value_groups)
@@ -53,10 +57,7 @@ def eager_attention_forward(
 
         attention_mask = _gen_from_sparse_attn_mask_indices(attn_mask_startend_row_indices, query.dtype, is_causal)
 
-    # b l h d -> b h l d
-    key = key.transpose(1, 2)
-    value = value.transpose(1, 2)
-    attn_weights = paddle.matmul(query, key.transpose([0, 1, 3, 2])) * scaling
+    attn_weights = paddle.matmul(query, key.transpose(2, 3)) * scaling
 
     if attention_mask is not None:
         attention_mask = attention_mask[:, :, :, : key.shape[-2]]
@@ -72,8 +73,8 @@ def eager_attention_forward(
         attn_weights = nn.functional.softmax(attn_weights, axis=-1, dtype=paddle.float32).astype(query.dtype)
         attn_weights = nn.functional.dropout(attn_weights, p=dropout, training=module.training)
 
-    attn_output = paddle.matmul(attn_weights, value)  # b h l l @ b h l d -> b h l d
-    attn_output = attn_output.transpose([0, 2, 1, 3])  # b h l d -> b l h d
+    attn_output = paddle.matmul(attn_weights, value)
+    attn_output = attn_output.transpose(1, 2).contiguous()
     attn_output = paddle.reshape(x=attn_output, shape=[0, 0, attn_output.shape[2] * attn_output.shape[3]])
 
     return attn_output, attn_weights

--- a/paddleformers/transformers/qwen3/modeling.py
+++ b/paddleformers/transformers/qwen3/modeling.py
@@ -37,7 +37,6 @@ from ...nn.mlp import MLP as Qwen3MLP
 from ...nn.norm import Norm as GeneralNorm
 from ...nn.pp_model import GeneralModelForCausalLMPipe
 from ...utils.log import logger
-from ...utils.masking_utils import _gen_from_sparse_attn_mask_indices
 from ..cache_utils import Cache, DynamicCache
 from ..contrastive_loss import SimpleContrastiveLoss
 from ..embedding_utils import dist_gather_tensor_with_gradient
@@ -70,52 +69,6 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
     q_embed = (q * cos) + (rotate_half(q) * sin)
     k_embed = (k * cos) + (rotate_half(k) * sin)
     return q_embed.astype(q.dtype), k_embed.astype(k.dtype)
-
-
-def repeat_kv(hidden_states: paddle.Tensor, n_rep: int) -> paddle.Tensor:
-    batch, num_key_value_heads, slen, head_dim = hidden_states.shape
-    if n_rep == 1:
-        return hidden_states
-    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)
-    return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
-
-
-def eager_attention_forward(
-    module: nn.Layer,
-    query: paddle.Tensor,
-    key: paddle.Tensor,
-    value: paddle.Tensor,
-    attention_mask: Optional[paddle.Tensor],
-    scaling: float,
-    dropout: float = 0.0,
-    **kwargs,
-):
-    key_states = repeat_kv(key, module.num_key_value_groups)
-    value_states = repeat_kv(value, module.num_key_value_groups)
-
-    if attention_mask is None and kwargs.get("attn_mask_startend_row_indices", None) is not None:
-        attn_mask_startend_row_indices = kwargs["attn_mask_startend_row_indices"]
-        if attn_mask_startend_row_indices.ndim == 3:
-            attn_mask_startend_row_indices = attn_mask_startend_row_indices.unsqueeze(-1)
-        if attn_mask_startend_row_indices is not None and attn_mask_startend_row_indices.shape[-1] == 1:
-            is_causal = True
-        if attn_mask_startend_row_indices is not None and attn_mask_startend_row_indices.shape[-1] == 4:
-            is_causal = False
-
-        attention_mask = _gen_from_sparse_attn_mask_indices(attn_mask_startend_row_indices, query.dtype, is_causal)
-
-    attn_weights = paddle.matmul(query, key_states.transpose(2, 3)) * scaling
-
-    if attention_mask is not None:
-        causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
-        attn_weights = attn_weights + causal_mask
-
-    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=paddle.float32).to(query.dtype)
-    attn_weights = nn.functional.dropout(attn_weights, p=dropout, training=module.training)
-    attn_output = paddle.matmul(attn_weights, value_states)
-    attn_output = attn_output.transpose(1, 2).contiguous()
-
-    return attn_output, attn_weights
 
 
 class Qwen3Attention(nn.Layer):
@@ -274,9 +227,7 @@ class Qwen3Attention(nn.Layer):
         if past_key_values is not None:
             key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
 
-        attention_interface = eager_attention_forward
-        if self.config._attn_implementation != "eager":
-            attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+        attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
 
         attn_output, attn_weights = attention_interface(
             self,
@@ -293,7 +244,6 @@ class Qwen3Attention(nn.Layer):
         # else their shape are [bs, q_len, num_head * head_dim], n is mp parallelism.
         if self.config.sequence_parallel:
             attn_output = attn_output.reshape([-1, attn_output.shape[-1]])
-        attn_output = attn_output.reshape(*hidden_states.shape[:-1], -1).contiguous()
         attn_output = self.o_proj(attn_output)
 
         return attn_output, attn_weights


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->
默认的 eager_attention_forward 与 hf 各个模型中的 eager_attention_forward 实现不同，可能产生精度 diff。例如，qwen3 中repeat_kv 结果的 stride 不同会导致后续 matmul 产生一个 1e-8的diff，因此需要对齐默认写法。对于其余模型组网中的eager_attention_forward如果与默认实现不同，建议参考 hf 单独实现。
