### PR TITLE
feat: support external templates and plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,7 @@ autogen/
 ops/csrc/fp8/deep_gemm/include/cutlass
 ops/csrc/fp8/deep_gemm/include/cute
 .ccls-cache
+
+# logs and running results
+paddleformers_dist_log
+checkpoints

--- a/docs/zh/template.md
+++ b/docs/zh/template.md
@@ -8,8 +8,17 @@
 | `encode_one_turn` | str | 只在 `template_backend` 为 `jinja` 时生效）`True`表示将多轮对话进行拆分，分别对每一轮对话套用`apply_chat_template`，`False`表示直接对整段对话套用`apply_chat_template` |
 
 ## 自定义 template
+
+### 源代码修改方式
 在`paddleformers/datasets/template/template.py`文件中，通过`register_template`实现自定义 template
+
+### 运行时外挂方式
+可通过`--custom_register_path`参数指定一个Python文件来注册自定义对话模板。
 
 ## 多模 plugin 接入流程
 
+### 源代码修改方式
 在 `paddleformers/datasets/template/mm_plugin.py` 文件中实现各种多模预处理的处理，基类是`BasePlugin`，已经实现了各种图片、视频、音频的预处理操作，如果需要自定义 plugin，需要继承`BasePlugin`实现自定义的类，如`Qwen2VLPlugin`。在自定义的类中实现各种多模数据预处理的操作，并在`PLUGINS`里面注册 template 名字和类名的对应关系
+
+### 运行时外挂方式
+可通过`--custom_register_path`参数指定一个 Python 文件来注册自定义 mm_plugin。在重写 plugin 后，需要进行`register_mm_plugin`，并在`register_template`中通过`get_mm_plugin`获取对应的 plugin。

--- a/docs/zh/template_zh.md
+++ b/docs/zh/template_zh.md
@@ -2,7 +2,8 @@
 
 ## 1.1. 注册方法
 
-在 paddleformers/datasets/template/template.py 文件中实现模型 chat template 的注册，如：
+### 1.1.1 源代码修改（适用于 git clone 安装用户）
+在 `paddleformers/datasets/template/template.py` 文件中实现模型 chat template 的注册，如：
 ```python
 register_template(
     name="ernie",
@@ -14,6 +15,16 @@ register_template(
     stop_words=["<|im_end|>"],
 )
 ```
+### 1.1.2 运行时外挂（适用于 pip 安装用户）
+可通过`--custom_register_path`参数指定一个Python文件来注册自定义对话模板。该文件应包含类似以下代码：
+```python
+from paddleformers.datasets.template.template import *
+
+register_template(
+    ...同上
+)
+```
+
 
 ## 1.2. 参数说明
 
@@ -61,13 +72,37 @@ register_template(
 ```
 
 # 2. 注册 mm_plugin
-多模模型需要实现自己的多模数据处理方法，包括图片处理、视频处理、音频处理、获取处理后的 tokens 数量来填充占位符
-可以参考 Qwen2VLPlugin 类，类实现后在下面注册：
+## 2.1. 注册方法
+### 2.1.1 源代码修改（适用于 git clone 安装用户）
+多模态模型需要实现自己的多模数据处理方法，包括图片处理、视频处理、音频处理、获取处理后的 tokens 数量来填充占位符
+可以参考 Qwen2VLPlugin 类，类实现后在 `paddleformers/datasets/template/mm_plugin.py` 中注册：
 ```python
+@dataclass
+class MyCustomPlugin(BasePlugin):
+    ...
 PLUGINS = {
     "base": BasePlugin,
     "qwen2_vl": Qwen2VLPlugin,
     "qwen3_vl": Qwen3VLPlugin,
     "glm4v": GLM4VPlugin,
 }
+```
+### 2.1.2 运行时外挂（适用于 pip 安装用户）
+可通过`--custom_register_path`参数指定一个Python文件来注册自定义 mm_plugin。该文件应包含类似以下代码：
+```python
+from paddleformers.datasets.template.template import *
+from paddleformers.datasets.template.mm_plugin import *
+
+@dataclass
+class MyCustomPlugin(BasePlugin):
+    ...
+register_mm_plugin(
+    name = "myplugin",
+    plugin_class = MyCustomPlugin,
+)
+register_template(
+    name="mytemplate",
+    mm_plugin=get_mm_plugin(name="myplugin"...),
+    ...
+)
 ```

--- a/paddleformers/cli/hparams/parser.py
+++ b/paddleformers/cli/hparams/parser.py
@@ -83,7 +83,23 @@ def read_args(args: Optional[Union[dict[str, Any], list[str]]] = None) -> Union[
     r"""Get arguments from the command line or a config file."""
     if args is not None:
         return args
-
+    
+    if "custom_register_path" in sys.argv:
+        custom_idx = sys.argv.index("custom_register_path")
+        if custom_idx + 1 < len(sys.argv):
+            custom_path = sys.argv[custom_idx + 1]
+            try:
+                import importlib.util
+                spec = importlib.util.spec_from_file_location("custom_template", custom_path)
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                print(f"Successfully loaded custom templates from {custom_path}")
+            except Exception as e:
+                print(f"Failed to load custom templates from {custom_path}: {e}")
+        # Remove custom register args to avoid conflict with main arg parsing
+        sys.argv.pop(custom_idx)
+        sys.argv.pop(custom_idx)
+        
     assert len(sys.argv) > 2, "Missing configuration files."
 
     if sys.argv[2].endswith(".yaml") or sys.argv[2].endswith(".yml"):


### PR DESCRIPTION
### PR types
Function optimization

### PR changes
APIs

### Description

本PR实现了对自定义对话模板和多模态插件的运行时外挂支持，主要包含以下改进：

1. **新增运行时外挂机制**：
- 通过`--custom_register_path`参数支持在运行时加载自定义的对话模板和多模态插件
- 无需修改源代码即可注册自定义功能，特别适合pip安装用户

2. **功能增强**：
- `paddleformers/cli/hparams/parser.py`：添加了在参数解析时自动加载自定义模板的逻辑
- 支持动态导入用户自定义的Python文件来注册template和plugin

3. **文档完善**：
- `docs/zh/template.md` 和 `docs/zh/template_zh.md`：详细说明了两种注册方式（源代码修改和运行时外挂）
- 提供了完整的使用示例和API说明

4. **配置优化**：
  - 更新[`.gitignore`](PaddleFormers/.gitignore)文件，忽略运行日志和checkpoints目录