### PR TITLE
[MoE Layer] Use PaddleFleet (PFCC Lab) Version DeepEP

### DIFF
--- a/.github/workflows/ce-build-images.yml
+++ b/.github/workflows/ce-build-images.yml
@@ -79,7 +79,7 @@ jobs:
           RUN python -m pip install -r requirements-dev.txt --progress-bar off
           RUN python -m pip install -r tests/requirements.txt --progress-bar off
           RUN python setup.py bdist_wheel
-          RUN python -m pip install dist/*.whl --progress-bar off
+          RUN python -m pip install "$(ls -t dist/*.whl | head -1)[paddlefleet]" --progress-bar off
           WORKDIR /
           RUN rm -rf /tmp/paddleformers
           RUN python -m pip install opt_einsum --progress-bar off  # for paddle

--- a/.github/workflows/model-unittest-gpu.yml
+++ b/.github/workflows/model-unittest-gpu.yml
@@ -96,6 +96,7 @@ jobs:
             tar xf PaddleFormers.tar && rm -rf PaddleFormers.tar
             echo "work_dir = ${work_dir}"
             source ${work_dir}/../../../proxy
+            pip install uv
             cd PaddleFormers
             git config --global user.name "PaddleCI"
             git config --global user.email "paddle_ci@example.com"

--- a/.github/workflows/unittest-gpu.yml
+++ b/.github/workflows/unittest-gpu.yml
@@ -130,6 +130,7 @@ jobs:
           cd /workspace/PaddleFormers && git config --global --add safe.directory $PWD
           source $work_dir/../../../proxy
           source $work_dir/../../../AISTUDIO_ACCESS_TOKEN
+          pip install uv
           echo "work_dir = ${work_dir}"
           cp -r ${work_dir}/../../../models ./models
           echo "Check whether the local model file exists:"

--- a/paddleformers/nn/moe_deepep/modular_moe_layer.py
+++ b/paddleformers/nn/moe_deepep/modular_moe_layer.py
@@ -35,6 +35,9 @@ from .moe_loss_instance import get_global_loss_registry
 logger = logging.getLogger(__name__)
 global_loss_registry = get_global_loss_registry()
 
+# To avoid repeated imports and backend switching
+_PFCC_DEEP_EP_BACKEND_SET = False
+
 
 class ModularMoELayer(nn.Layer):
     def __init__(
@@ -162,6 +165,12 @@ class ModularMoELayer(nn.Layer):
 
         if self.ep_communication_type == "deepep":
             self.communication = DeepEPMoECommunication()
+            global _PFCC_DEEP_EP_BACKEND_SET
+            if pretrained_config.moe_use_pfcc_deepep and not _PFCC_DEEP_EP_BACKEND_SET:
+                from ...transformers.fused_a2a import set_pfcc_deep_ep_backend
+
+                set_pfcc_deep_ep_backend()
+                _PFCC_DEEP_EP_BACKEND_SET = True
         elif self.ep_communication_type == "alltoall":
             self.communication = AllToAllMoECommunication()
         else:

--- a/paddleformers/trainer/training_args.py
+++ b/paddleformers/trainer/training_args.py
@@ -1218,6 +1218,13 @@ class TrainingArguments:
         metadata={"help": "Whether to save replicas cross files in distributed save load system."},
     )
 
+    moe_use_pfcc_deepep: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to use PFCC DeepEP for MoE, by default uses paddle DeepEP. Only works when moe_token_dispatcher_type == 'deepep'."
+        },
+    )
+
     def __post_init__(self):
         world_size = paddle.distributed.get_world_size()
         if in_auto_parallel_align_mode():
@@ -1351,7 +1358,6 @@ class TrainingArguments:
 
         # use_hybrid_parallel
         if self.use_hybrid_parallel:
-
             if ShardingOption.OFFLOAD in self.sharding:
                 warnings.warn("`offload` is not supported NOW!")
 

--- a/paddleformers/transformers/configuration_utils.py
+++ b/paddleformers/transformers/configuration_utils.py
@@ -323,6 +323,12 @@ class LlmMetaConfig:
             0.0,
             "Scaling factor for MoE expert capacity (controls maximum tokens per expert). Defaults to 0.0 (no dropping tokens).",
         ),
+        (
+            "moe_use_pfcc_deepep",
+            bool,
+            False,
+            "Whether to use PFCC DeepEP for MoE for the moelayer.",
+        ),
     ]
 
     mtp_attributes = [
@@ -531,6 +537,8 @@ class PretrainedConfig:
             The number of tokens in a subbatch for MoE.
         ep_communication_type (`str`, *optional*, defaults to `deepep`):
             Communication type for expert parallel. Can be one of `deepep`, `alltoall`.
+        moe_use_pfcc_deepep (`bool`, *optional*, defaults to `False`):
+            Whether to use PFCC DeepEP for MoE for the moelayer. If set to False, the default Paddle DeepEP will be used.
         use_unified_moe (`bool`, *optional*, defaults to `False`):
             Whether to use unified MoE.
         > Parameters for general components
@@ -680,6 +688,7 @@ class PretrainedConfig:
         self.kto_config = kwargs.pop("kto_config", None)
 
         self.ep_communication_type = kwargs.pop("ep_communication_type", "deepep")
+        self.moe_use_pfcc_deepep = kwargs.pop("moe_use_pfcc_deepep", False)
         self.use_unified_moe = kwargs.pop("use_unified_moe", False)
         self.using_fake_gate = kwargs.pop("using_fake_gate", False)
 

--- a/paddleformers/transformers/fused_a2a.py
+++ b/paddleformers/transformers/fused_a2a.py
@@ -14,21 +14,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 
 import paddle
 from paddle.autograd import PyLayer
 from paddle.distributed.communication.group import Group
-from paddlefleet.ops import is_deep_ep_available
 
-if is_deep_ep_available():
-    from paddlefleet.ops import deep_ep
+try:
+    from paddle.distributed.communication import deep_ep
 
     HAVE_DEEP_EP = True
-else:
-    deep_ep = None
+except ImportError:
     HAVE_DEEP_EP = False
 
 _buffer = None
+
+
+def set_pfcc_deep_ep_backend():
+    global deep_ep, HAVE_DEEP_EP, _buffer
+    pfcc_deep_ep = importlib.import_module("paddlefleet.ops.deep_ep")
+    deep_ep = pfcc_deep_ep
+    _buffer = None
+    HAVE_DEEP_EP = deep_ep is not None
 
 
 def barrier_ep(ep_group):

--- a/paddleformers/transformers/fused_a2a.py
+++ b/paddleformers/transformers/fused_a2a.py
@@ -14,16 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-try:
-    import paddle.distributed.communication.deep_ep as deep_ep
-
-    HAVE_DEEP_EP = True
-except ImportError:
-    HAVE_DEEP_EP = False
 
 import paddle
 from paddle.autograd import PyLayer
 from paddle.distributed.communication.group import Group
+from paddlefleet.ops import is_deep_ep_available
+
+if is_deep_ep_available():
+    from paddlefleet.ops import deep_ep
+
+    HAVE_DEEP_EP = True
+else:
+    deep_ep = None
+    HAVE_DEEP_EP = False
 
 _buffer = None
 

--- a/paddleformers/transformers/moe_layer.py
+++ b/paddleformers/transformers/moe_layer.py
@@ -27,6 +27,9 @@ from paddle.distributed.communication.group import Group
 from .moe_gate import PretrainedMoEGate
 from .token_dispatcher import MoEFlexTokenDispatcher
 
+# To avoid repeated imports and backend switching
+_PFCC_DEEP_EP_BACKEND_SET = False
+
 
 def dispatching(x, dispatch_mask, scatter_index, num_experts, capacity):
     """
@@ -181,7 +184,7 @@ class MoELayer(nn.Layer):
             elif moe_group == "expert":
                 self.moe_group = dist.fleet.get_hybrid_communicate_group().get_expert_parallel_group()
             else:
-                assert NotImplementedError("moe_group can only be data or expert, but given {}".format(self.moe_group))
+                assert NotImplementedError(f"moe_group can only be data or expert, but given {self.moe_group}")
             self.moe_rank = dist.get_rank(self.moe_group)
             self.moe_rank = 0 if self.moe_rank < 0 else self.moe_rank
             self.expert_model_parallel_size = dist.get_world_size(self.moe_group)
@@ -340,7 +343,6 @@ class MoELayer(nn.Layer):
 
 class MoEFlexTokenLayer(nn.Layer):
     def __init__(self, config, moe_num_experts, expert_class, expert_kwargs, gate, moe_group):
-
         super().__init__()
         self.config = config
         self.moe_group = moe_group
@@ -365,6 +367,13 @@ class MoEFlexTokenLayer(nn.Layer):
             else:
                 self.experts.append(None)
         self.gate = gate
+        global _PFCC_DEEP_EP_BACKEND_SET
+        if config.moe_use_pfcc_deepep and not _PFCC_DEEP_EP_BACKEND_SET:
+            from .fused_a2a import set_pfcc_deep_ep_backend
+
+            set_pfcc_deep_ep_backend()
+            _PFCC_DEEP_EP_BACKEND_SET = True
+
         self._post_init()
 
     def _post_init(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,5 +21,5 @@ tokenizers<=0.20.3; python_version<="3.8"
 tokenizers>=0.21,<0.22; python_version>"3.8"
 omegaconf
 modelscope
-transformers>=4.55.1
+transformers>=4.55.1, <5.0.0
 GPUtil

--- a/scripts/regression/ci_model_unittest.sh
+++ b/scripts/regression/ci_model_unittest.sh
@@ -30,8 +30,15 @@ install_requirements() {
     python -m pip install -r requirements.txt
     python -m pip install -r requirements-dev.txt
     python -m pip install -r tests/requirements.txt
-    python -m pip uninstall paddlepaddle paddlepaddle_gpu -y
-    python -m pip install https://paddle-qa.bj.bcebos.com/paddle-pipeline/Release-TagBuild-Training-Linux-Gpu-Cuda12.9-Cudnn9.9-Trt10.5-Mkl-Avx-Gcc11-SelfBuiltPypiUse/cbf3469113cd76b7d5f4cba7b8d7d5f55d9e9911/paddlepaddle_gpu-3.3.0-cp310-cp310-linux_x86_64.whl
+    python -m pip uninstall paddlepaddle paddlepaddle_gpu paddlefleet -y
+    python -m pip install -U --no-cache-dir transformers
+    # echo "paddlepaddle-gpu @ https://paddle-qa.bj.bcebos.com/paddle-pipeline/Release-TagBuild-Training-Linux-Gpu-Cuda12.9-Cudnn9.9-Trt10.5-Mkl-Avx-Gcc11-SelfBuiltPypiUse/cbf3469113cd76b7d5f4cba7b8d7d5f55d9e9911/paddlepaddle_gpu-3.3.0-cp310-cp310-linux_x86_64.whl" >> requirements.txt
+    python setup.py bdist_wheel > /dev/null
+    uv cache clean paddlefleet
+    export UV_SKIP_WHEEL_FILENAME_CHECK=1
+    uv pip install "$(ls -t dist/*.whl | head -1)[paddlefleet]" --system --prerelease=allow -i https://pypi.tuna.tsinghua.edu.cn/simple --extra-index-url https://www.paddlepaddle.org.cn/packages/stable/cu126/ --index-strategy unsafe-best-match
+    echo "paddlefleet commit:"
+    python -c "import paddlefleet; print(paddlefleet.version.commit)"
     python -c "import paddle;print('paddle');print(paddle.__version__);print(paddle.version.show())" >> ${log_path}/commit_info.txt
     python setup.py bdist_wheel > /dev/null
     python -m pip install  dist/p****.whl

--- a/scripts/unit_test/ci_unittest.sh
+++ b/scripts/unit_test/ci_unittest.sh
@@ -40,8 +40,14 @@ install_requirements() {
     python -m pip install -r requirements.txt
     python -m pip install -r requirements-dev.txt
     python -m pip install -r tests/requirements.txt
-    python -m pip uninstall paddlepaddle paddlepaddle_gpu -y
-    python -m pip install --no-cache-dir ${paddle} --no-dependencies --progress-bar off
+    python -m pip uninstall paddlepaddle paddlepaddle_gpu paddlefleet -y
+    python setup.py bdist_wheel > /dev/null
+    uv cache clean paddlefleet
+    export UV_SKIP_WHEEL_FILENAME_CHECK=1
+    uv pip install "$(ls -t dist/*.whl | head -1)[paddlefleet]" --system --prerelease=allow -i https://pypi.tuna.tsinghua.edu.cn/simple --extra-index-url https://www.paddlepaddle.org.cn/packages/stable/cu126/ --index-strategy unsafe-best-match
+    python -m pip install torch==2.8.0
+    echo "paddlefleet commit:"
+    python -c "import paddlefleet; print(paddlefleet.version.commit)"
     python -c "import paddle;print('paddle');print(paddle.__version__);print(paddle.version.show())" >> ${log_path}/commit_info.txt
     python setup.py bdist_wheel > /dev/null
     python -m pip install  dist/p****.whl

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ def append_version_py(filename="paddleformers/__init__.py"):
 
 append_version_py(filename="paddleformers/__init__.py")
 
-extras = {}
+
 REQUIRED_PACKAGES = read_requirements_file("requirements.txt")
 
 
@@ -179,6 +179,12 @@ def get_console_scripts() -> list[str]:
     return console_scripts
 
 
+import sys
+
+major = sys.version_info.major
+minor = sys.version_info.minor
+ver_str = f"{major}{minor}"
+
 if commit != "unknown":
     write_version_py(filename="paddleformers/version/__init__.py")
 
@@ -203,7 +209,11 @@ try:
         setup_requires=["cython", "numpy"],
         install_requires=REQUIRED_PACKAGES,
         entry_points={"console_scripts": get_console_scripts()},
-        extras_require=extras,
+        extras_require={
+            "paddlefleet": [
+                f"paddlefleet @ https://paddle-github-action.bj.bcebos.com/PaddleFleet/release/0.1.0/latest/cu129/paddlefleet-0.0.0-cp{ver_str}-cp{ver_str}-linux_x86_64.whl"
+            ],
+        },
         python_requires=">=3.8",
         classifiers=[
             "Programming Language :: Python :: 3",


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description
使用 PaddleFleet 内的 PFCC Lab 的 DeepEP，代替原有 Paddle 框架内的 DeepEP。

可通过 yaml 配置项 `moe_use_pfcc_deepep` 控制是否走 PFCC Lab 的 DeepEP，默认为 **False**，即走 Paddle 框架内的 DeepEP。

CI 相关文件修改是由于引入了 PaddleFleet，所以需要在 CI/CE 里添加安装 Fleet 的代码。
