### PR TITLE
feat: support external templates and plugins with custom args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,7 @@ autogen/
 ops/csrc/fp8/deep_gemm/include/cutlass
 ops/csrc/fp8/deep_gemm/include/cute
 .ccls-cache
+
+# logs and running results
+paddleformers_dist_log
+checkpoints

--- a/docs/zh/template.md
+++ b/docs/zh/template.md
@@ -8,8 +8,17 @@
 | `encode_one_turn` | str | 只在 `template_backend` 为 `jinja` 时生效）`True`表示将多轮对话进行拆分，分别对每一轮对话套用`apply_chat_template`，`False`表示直接对整段对话套用`apply_chat_template` |
 
 ## 自定义 template
+
+### 源代码修改方式
 在`paddleformers/datasets/template/template.py`文件中，通过`register_template`实现自定义 template
+
+### 运行时外挂方式
+可通过`--custom_register_path`参数指定一个 Python 文件来注册自定义对话模板。
 
 ## 多模 plugin 接入流程
 
+### 源代码修改方式
 在 `paddleformers/datasets/template/mm_plugin.py` 文件中实现各种多模预处理的处理，基类是`BasePlugin`，已经实现了各种图片、视频、音频的预处理操作，如果需要自定义 plugin，需要继承`BasePlugin`实现自定义的类，如`Qwen2VLPlugin`。在自定义的类中实现各种多模数据预处理的操作，并在`PLUGINS`里面注册 template 名字和类名的对应关系
+
+### 运行时外挂方式
+可通过`--custom_register_path`参数指定一个 Python 文件来注册自定义 mm_plugin。在重写 plugin 后，需要进行`register_mm_plugin`，并在`register_template`中通过`get_mm_plugin`获取对应的 plugin。

--- a/docs/zh/template_zh.md
+++ b/docs/zh/template_zh.md
@@ -2,7 +2,8 @@
 
 ## 1.1. 注册方法
 
-在 paddleformers/datasets/template/template.py 文件中实现模型 chat template 的注册，如：
+### 1.1.1 源代码修改（适用于 git clone 安装用户）
+在 `paddleformers/datasets/template/template.py` 文件中实现模型 chat template 的注册，如：
 ```python
 register_template(
     name="ernie",
@@ -14,30 +15,40 @@ register_template(
     stop_words=["<|im_end|>"],
 )
 ```
+### 1.1.2 运行时外挂（适用于 pip 安装用户）
+可通过`--custom_register_path`参数指定一个 Python 文件来注册自定义对话模板。该文件应包含类似以下代码：
+```python
+from paddleformers.datasets.template.template import *
+
+register_template(
+    ...同上
+)
+```
+
 
 ## 1.2. 参数说明
 
 | 参数名              | 解释       |
 |--------------------|-----------|
 | `name` | template 的名字，也就是训练的时候需要指定的 template 参数 |
-| `format_user` | 对 role 为user 的content 进行 format，{{content}}表示塞入实际的 content，其他为拼接的 token |
-| `format_assistant` | 对 role 为assistant 的content 进行 format |
-| `format_system` | 对 role 为system 的content 进行 format |
-| `format_function` | 对 role 为function（申请工具调用）的 content 进行 format |
+| `format_user` | 对 role 为 user 的 content 进行 format，{{content}}表示塞入实际的 content，其他为拼接的 token |
+| `format_assistant` | 对 role 为 assistant 的 content 进行 format |
+| `format_system` | 对 role 为 system 的 content 进行 format |
+| `format_function` | 对 role 为 function（申请工具调用）的 content 进行 format |
 | `format_observation` | format_observation |
 | `format_tools` | 对 tools 信息进行 format |
 | `format_prefix` | 在 system 前面加的内容 |
-| `default_system` | 默认的 system 信息，如果数据里面没有 role 为system 的，就用这个 |
-| `stop_words` | 当 replace_eos 为true 的时候，会用 stop words 替换掉实际的 eos token |
+| `default_system` | 默认的 system 信息，如果数据里面没有 role 为 system 的，就用这个 |
+| `stop_words` | 当 replace_eos 为 true 的时候，会用 stop words 替换掉实际的 eos token |
 | `replace_eos` | 是否使用 stop_words 替换默认的 eos token |
 | `thought_words` | 数据里面的思考标志是什么，比如<think></think> |
 | `efficient_eos` | eos 是否有效，即是否在最后拼接 eos token |
 | `chat_sep` | 历史轮对话末尾加的字符串 |
 | `auto_add_bos` | 如果 bos 没添加，会自动添加上 |
-| `enable_thinking` | 否的话，会把思考信息删掉（当 template_class 选ReasoningTemplate 时候生效） |
+| `enable_thinking` | 否的话，会把思考信息删掉（当 template_class 选 ReasoningTemplate 时候生效） |
 | `mm_plugin` | 使用什么插件来处理多模信息 |
 | `grounding_plugin` | 使用什么插件来处理 grounding 任务的 target 信息 |
-| `template_class` | template 类，可以选 Template 或ReasoningTemplate，ReasoningTemplate 一般是思考模型会用的，会根据 enable_thinking 决定是否删除思考信息 |
+| `template_class` | template 类，可以选 Template 或 ReasoningTemplate，ReasoningTemplate 一般是思考模型会用的，会根据 enable_thinking 决定是否删除思考信息 |
 
 ## 1.3. 示例
 
@@ -61,13 +72,37 @@ register_template(
 ```
 
 # 2. 注册 mm_plugin
-多模模型需要实现自己的多模数据处理方法，包括图片处理、视频处理、音频处理、获取处理后的 tokens 数量来填充占位符
-可以参考 Qwen2VLPlugin 类，类实现后在下面注册：
+## 2.1. 注册方法
+### 2.1.1 源代码修改（适用于 git clone 安装用户）
+多模态模型需要实现自己的多模数据处理方法，包括图片处理、视频处理、音频处理、获取处理后的 tokens 数量来填充占位符
+可以参考 Qwen2VLPlugin 类，类实现后在 `paddleformers/datasets/template/mm_plugin.py` 中注册：
 ```python
+@dataclass
+class MyCustomPlugin(BasePlugin):
+    ...
 PLUGINS = {
     "base": BasePlugin,
     "qwen2_vl": Qwen2VLPlugin,
     "qwen3_vl": Qwen3VLPlugin,
     "glm4v": GLM4VPlugin,
 }
+```
+### 2.1.2 运行时外挂（适用于 pip 安装用户）
+可通过`--custom_register_path`参数指定一个 Python 文件来注册自定义 mm_plugin。该文件应包含类似以下代码：
+```python
+from paddleformers.datasets.template.template import *
+from paddleformers.datasets.template.mm_plugin import *
+
+@dataclass
+class MyCustomPlugin(BasePlugin):
+    ...
+register_mm_plugin(
+    name = "myplugin",
+    plugin_class = MyCustomPlugin,
+)
+register_template(
+    name="mytemplate",
+    mm_plugin=get_mm_plugin(name="myplugin"...),
+    ...
+)
 ```

--- a/docs/zh/training_arguments.md
+++ b/docs/zh/training_arguments.md
@@ -89,6 +89,8 @@
   --remove_unused_columns
                         是否在使用 `datasets.Dataset` 时自动移除模型 `forward` 方法未使用的列。
                         默认为 `True`。(`bool`, 可选)
+  --custom_register_path
+                        自定义注册路径，用于加载自定义 template 和 mm_plugin。若不指定，则只注册默认部分。 (`str`, 可选)
 ```
 
 # 2. 优化器与学习率调度

--- a/paddleformers/cli/hparams/data_args.py
+++ b/paddleformers/cli/hparams/data_args.py
@@ -147,3 +147,7 @@ class DataArguments:
         default=True,
         metadata={"help": "Whether to truncate data in packing (only valid in pretrain online dataflow)."},
     )
+    custom_register_path: str = field(
+        default=None,
+        metadata={"help": "Register python file path for custom templates and mm_plugin."},
+    )

--- a/paddleformers/cli/hparams/parser.py
+++ b/paddleformers/cli/hparams/parser.py
@@ -79,6 +79,18 @@ _SERVER_ARGS = [
 _SERVER_CLS = tuple[ModelArguments, GeneratingArguments, FinetuningArguments, ServerArguments]
 
 
+def _load_custom_template(custom_path):
+    try:
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("custom_template", custom_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        print(f"Successfully loaded custom templates from {custom_path}")
+    except Exception as e:
+        print(f"Failed to load custom templates from {custom_path}: {e}")
+
+
 def read_args(args: Optional[Union[dict[str, Any], list[str]]] = None) -> Union[dict[str, Any], list[str]]:
     r"""Get arguments from the command line or a config file."""
     if args is not None:
@@ -120,6 +132,10 @@ def _parse_args(
     """
 
     args = read_args(args)
+
+    if isinstance(args, dict) and "custom_register_path" in args:
+        _load_custom_template(args.pop("custom_register_path"))
+
     if isinstance(args, dict):
         return parser.parse_dict(args)
 

--- a/paddleformers/cli/hparams/parser.py
+++ b/paddleformers/cli/hparams/parser.py
@@ -16,6 +16,7 @@
 # Copyright (c) 2025 LLaMA-Factory
 # Licensed under the Apache License - https://github.com/hiyouga/LLaMA-Factory/blob/main/LICENSE
 
+import importlib.util
 import json
 import os
 import sys
@@ -81,14 +82,12 @@ _SERVER_CLS = tuple[ModelArguments, GeneratingArguments, FinetuningArguments, Se
 
 def _load_custom_template(custom_path):
     try:
-        import importlib.util
-
         spec = importlib.util.spec_from_file_location("custom_template", custom_path)
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
         print(f"Successfully loaded custom templates from {custom_path}")
     except Exception as e:
-        print(f"Failed to load custom templates from {custom_path}: {e}")
+        raise RuntimeError(f"Failed to load custom templates from {custom_path}: {e}")
 
 
 def read_args(args: Optional[Union[dict[str, Any], list[str]]] = None) -> Union[dict[str, Any], list[str]]:


### PR DESCRIPTION
### PR types
Function optimization

### PR changes
APIs

### Description

本PR实现了对自定义对话模板和多模态插件的运行时外挂支持，主要包含以下改进：

1. **新增运行时外挂机制**：
- 通过`--custom_register_path`参数支持在运行时加载自定义的对话模板和多模态插件
- 无需修改源代码即可注册自定义功能，特别适合pip安装用户
- `paddleformers/cli/hparams/parser.py`：添加了在参数解析时自动加载自定义模板的逻辑
- 支持动态导入用户自定义的Python文件来注册template和plugin

2. **文档完善**：
- `docs/zh/template(_zh).md` 和 `training_arguments.md`：详细说明了两种注册方式（源代码修改和运行时外挂）
- 提供了完整的使用示例和API说明

3. **配置优化**：
  - 更新[`.gitignore`](PaddleFormers/.gitignore)文件，忽略运行日志和checkpoints目录