### PR TITLE
feat: support additional special tokens

### DIFF
--- a/docs/zh/training_arguments.md
+++ b/docs/zh/training_arguments.md
@@ -89,6 +89,9 @@
   --remove_unused_columns
                         是否在使用 `datasets.Dataset` 时自动移除模型 `forward` 方法未使用的列。
                         默认为 `True`。(`bool`, 可选)
+  --additional_special_tokens
+                        额外的特殊 Token 列表，用于扩展模型词汇表。
+                        默认为 `[]`。(`list`, 可选)
 ```
 
 # 2. 优化器与学习率调度

--- a/paddleformers/cli/hparams/data_args.py
+++ b/paddleformers/cli/hparams/data_args.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass, field
+from typing import List
 
 
 @dataclass
@@ -146,4 +147,8 @@ class DataArguments:
     truncate_packing: bool = field(
         default=True,
         metadata={"help": "Whether to truncate data in packing (only valid in pretrain online dataflow)."},
+    )
+    additional_special_tokens: List[str] = field(
+        default_factory=list,
+        metadata={"help": "Additional special tokens."},
     )

--- a/paddleformers/cli/train/sft/workflow.py
+++ b/paddleformers/cli/train/sft/workflow.py
@@ -78,6 +78,12 @@ from paddleformers.cli.utils import (
 )
 
 
+def add_new_special_tokens(tokenizer, new_special_tokens):
+    num_new_tokens = tokenizer.add_special_tokens({"additional_special_tokens": new_special_tokens})
+    if num_new_tokens > 0:
+        logger.info(f"Added {num_new_tokens} new additional special tokens.")
+
+
 def create_pretrained_dataset(training_args, data_args, model_args):
     assert data_args.input_dir is not None and len(data_args.input_dir.split()) > 1
 
@@ -331,6 +337,7 @@ def run_sft(
 
     # Load tokenizer & processor & dataset
     tokenizer = AutoTokenizer.from_pretrained(model_args.model_name_or_path)
+    add_new_special_tokens(tokenizer, data_args.additional_special_tokens)
     if tokenizer.pad_token_id is None:
         tokenizer.pad_token_id = tokenizer.eos_token_id
 


### PR DESCRIPTION
### PR Summary
本PR为PaddleFormers添加了对自定义特殊token的支持，允许用户在训练时扩展模型的词汇表，添加额外的特殊token（如`<global_setting>`、`</global_setting>`等）。

### PR Types
APIs

### PR Changes

- `paddleformers/cli/hparams/data_args.py`
- `paddleformers/cli/train/sft/workflow.py`
- `docs/zh/training_arguments.md`
- `docs/zh/sft_and_lora_guide.md`

使用示例
命令行传入或
```yaml
additional_special_tokens: [
    "<global_setting>",
    "</global_setting>",
]
```
### PR Description
1. **新增参数支持**
   - 在 `DataArguments` 中添加 `additional_special_tokens` 参数，支持传入自定义特殊token列表

2. **核心功能实现**
   - 新增 `add_new_special_tokens()` 函数，用于向tokenizer添加特殊token
   - 在SFT训练流程中集成特殊token添加逻辑（tokenizer加载后立即执行）

3. **文档完善**
   - 添加参数说明，提供使用示例