### PR TITLE
fix: new_special_tokens to path & extend it to DPO

### DIFF
--- a/docs/zh/training_arguments.md
+++ b/docs/zh/training_arguments.md
@@ -89,11 +89,11 @@
   --remove_unused_columns
                         是否在使用 `datasets.Dataset` 时自动移除模型 `forward` 方法未使用的列。
                         默认为 `True`。(`bool`, 可选)
-                        
-  --additional_special_tokens
-                        额外的特殊 Token 列表，用于扩展模型词汇表。
-                        默认为 `[]`。(`list`, 可选)
-                        
+
+  --new_special_tokens_path
+                        存储额外的特殊 Token 的文本文件路径，用于扩展模型词汇表。
+                        (`str`, 可选)
+
   --custom_register_path
                         自定义注册路径，用于加载自定义 template 和 mm_plugin。若不指定，则只注册默认部分。 (`str`, 可选)
 ```

--- a/paddleformers/cli/hparams/data_args.py
+++ b/paddleformers/cli/hparams/data_args.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from dataclasses import dataclass, field
-from typing import List
 
 
 @dataclass
@@ -148,9 +147,9 @@ class DataArguments:
         default=True,
         metadata={"help": "Whether to truncate data in packing (only valid in pretrain online dataflow)."},
     )
-    additional_special_tokens: List[str] = field(
-        default_factory=list,
-        metadata={"help": "Additional special tokens."},
+    new_special_tokens_path: str = field(
+        default=None,
+        metadata={"help": "The path of the new special tokens."},
     )
     custom_register_path: str = field(
         default=None,

--- a/paddleformers/cli/train/dpo/workflow.py
+++ b/paddleformers/cli/train/dpo/workflow.py
@@ -19,6 +19,7 @@ from functools import partial
 
 import paddle
 
+from paddleformers.cli.utils.process import add_new_special_tokens
 from paddleformers.datasets.collate import dpo_collate_fn as collate_fn
 from paddleformers.datasets.loader import create_dataset
 from paddleformers.datasets.template.template import get_template_and_fix_tokenizer
@@ -211,6 +212,7 @@ def run_dpo(
         tokenizer = AutoTokenizer.from_pretrained(model_args.tokenizer_name_or_path)
     else:
         tokenizer = AutoTokenizer.from_pretrained(model_args.model_name_or_path)
+    add_new_special_tokens(tokenizer, data_args.new_special_tokens_path)
     if tokenizer.pad_token_id is None:
         tokenizer.pad_token_id = tokenizer.eos_token_id
 

--- a/paddleformers/cli/train/sft/workflow.py
+++ b/paddleformers/cli/train/sft/workflow.py
@@ -22,6 +22,7 @@ from functools import partial
 import numpy as np
 import paddle
 
+from paddleformers.cli.utils.process import add_new_special_tokens
 from paddleformers.data.causal_dataset import (
     build_train_valid_test_datasets,
     check_data_split,
@@ -76,12 +77,6 @@ from paddleformers.cli.utils import (
     get_lora_target_modules,
     get_multimodel_lora_target_modules,
 )
-
-
-def add_new_special_tokens(tokenizer, new_special_tokens):
-    num_new_tokens = tokenizer.add_special_tokens({"additional_special_tokens": new_special_tokens})
-    if num_new_tokens > 0:
-        logger.info(f"Added {num_new_tokens} new additional special tokens.")
 
 
 def create_pretrained_dataset(training_args, data_args, model_args):
@@ -337,7 +332,7 @@ def run_sft(
 
     # Load tokenizer & processor & dataset
     tokenizer = AutoTokenizer.from_pretrained(model_args.model_name_or_path)
-    add_new_special_tokens(tokenizer, data_args.additional_special_tokens)
+    add_new_special_tokens(tokenizer, data_args.new_special_tokens_path)
     if tokenizer.pad_token_id is None:
         tokenizer.pad_token_id = tokenizer.eos_token_id
 

--- a/paddleformers/cli/utils/process.py
+++ b/paddleformers/cli/utils/process.py
@@ -20,6 +20,8 @@ import subprocess
 import paddle
 import psutil
 
+from paddleformers.utils.log import logger
+
 
 def terminate_process_tree(pid: int) -> None:
     """
@@ -205,3 +207,34 @@ def set_env_if_empty(key, value):
     """
     if not os.environ.get(key):
         os.environ[key] = value
+
+
+def add_new_special_tokens(tokenizer, path):
+    if path is None:
+        return
+    if not isinstance(path, str):
+        raise TypeError(f"new_special_tokens_path must be a string, but got {type(path)}")
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"Special tokens file not found: {path}")
+    new_special_tokens = []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for line_num, line in enumerate(f, 1):
+                line = line.strip()
+                if not line:
+                    continue
+                if line.startswith("#") or line.startswith("//"):
+                    continue
+                new_special_tokens.append(line)
+        if not new_special_tokens:
+            logger.warning(f"No valid special tokens found in {path}")
+            return
+        num_new_tokens = tokenizer.add_special_tokens({"additional_special_tokens": new_special_tokens})
+        if num_new_tokens > 0:
+            logger.info(f"Added {num_new_tokens} new special tokens from {path}: {new_special_tokens}")
+        else:
+            logger.info(f"All special tokens from {path} already exist in tokenizer.")
+    except UnicodeDecodeError as e:
+        raise ValueError(f"Failed to read {path} with UTF-8 encoding: {e}")
+    except Exception as e:
+        raise RuntimeError(f"Error processing special tokens file {path}: {e}")


### PR DESCRIPTION
### PR types
APIs

### PR changes
Backwards Incompatible

### Description

#### 问题背景
原有的 `additional_special_tokens` 参数是一个列表类型，在命令行中传递多个特殊 token 不够灵活，且不便于管理和维护。

#### 主要改动
1. **参数重构**：将 `additional_special_tokens: List[str]` 改为 `new_special_tokens_path: str`
   - 从直接传递 token 列表改为通过文件路径读取
   - 参数类型从 `List[str]` 改为 `str`
   - 这是一个不兼容的 API 变更

2. **新增工具函数**：在 `paddleformers/cli/utils/process.py` 中新增 `add_new_special_tokens()` 函数
   - 从文本文件中读取特殊 token（每行一个）
   - 支持 `#` 和 `//` 注释语法
   - 自动跳过空行
   - 添加完整的错误处理和日志记录

3. **扩展应用范围**：将新功能同时应用到 **SFT** 和 **DPO** 训练流程
   - SFT: `paddleformers/cli/train/sft/workflow.py`
   - DPO: `paddleformers/cli/train/dpo/workflow.py`

4. **文档更新**：更新训练参数文档 `docs/zh/training_arguments.md`

#### 使用示例
创建 `new_tokens.txt` 文件：
```text
# 这是注释
<|special_token_1|>
<|special_token_2|>
// 也支持双斜杠注释

<|special_token_3|>

命令行使用：
```bash
--new_special_tokens_path /path/to/new_tokens.txt
```
#### 影响范围
⚠️ 不兼容变更：使用 --additional_special_tokens 参数的现有脚本需要迁移到新的 --new_special_tokens_path 参数。