### PR TITLE
[Refactor] unify get_mm_inputs args and fix PaddleOCRVL plugin

### DIFF
--- a/paddleformers/cli/hparams/parser.py
+++ b/paddleformers/cli/hparams/parser.py
@@ -28,6 +28,7 @@ from omegaconf import OmegaConf
 
 from paddleformers.trainer import PdArgumentParser
 
+from ...utils.log import logger
 from ..utils.process import (
     is_env_enabled,
     remove_paddle_shm_files,
@@ -85,7 +86,7 @@ def _load_custom_template(custom_path):
         spec = importlib.util.spec_from_file_location("custom_template", custom_path)
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
-        print(f"Successfully loaded custom templates from {custom_path}")
+        logger.info(f"Successfully loaded custom templates from {custom_path}")
     except Exception as e:
         raise RuntimeError(f"Failed to load custom templates from {custom_path}: {e}")
 

--- a/paddleformers/datasets/DPODataset.py
+++ b/paddleformers/datasets/DPODataset.py
@@ -237,7 +237,14 @@ class DPODataSet(IterableDataset):
                 rejected_encoded_messages = self.tokenizer.encode_chat_inputs(example["rejected"])
         else:
             mm_inputs = self.template.mm_plugin.get_mm_inputs(
-                images, videos, audios, [len(images)], [len(videos)], [len(audios)], None, self.processor
+                images,
+                videos,
+                audios,
+                self.processor,
+                imglens=[len(images)],
+                vidlens=[len(videos)],
+                audlens=[len(audios)],
+                batch_ids=None,
             )
             chosen_messages = self.template.mm_plugin.process_messages(
                 example["chosen"]["messages"], images, videos, audios, mm_inputs, self.processor

--- a/paddleformers/datasets/SFTDataset.py
+++ b/paddleformers/datasets/SFTDataset.py
@@ -388,7 +388,15 @@ class SFTDataSet(IterableDataset):
                     objects,
                 )
                 mm_inputs = self.template.mm_plugin.get_mm_inputs(
-                    images, videos, audios, [len(images)], [len(videos)], [len(audios)], None, self.processor
+                    images,
+                    videos,
+                    audios,
+                    self.processor,
+                    imglens=[len(images)],
+                    vidlens=[len(videos)],
+                    audlens=[len(audios)],
+                    batch_ids=None,
+                    messages=messages,
                 )
                 messages = self.template.mm_plugin.process_messages(
                     messages, images, videos, audios, mm_inputs, self.processor

--- a/paddleformers/datasets/template/mm_plugin.py
+++ b/paddleformers/datasets/template/mm_plugin.py
@@ -252,7 +252,7 @@ class MMPluginMixin:
         videos,
         audios,
         processor,
-        imglens=None,
+        **kwargs,
     ):
         mm_inputs = {}
         if len(images) != 0:
@@ -262,6 +262,7 @@ class MMPluginMixin:
                 image_max_pixels=getattr(processor, "image_max_pixels", 768 * 768),
                 image_min_pixels=getattr(processor, "image_min_pixels", 32 * 32),
             )["images"]
+            imglens = kwargs.get("imglens", None)
             if imglens is not None:  # if imglens are provided, make batched images
                 images = _make_batched_images(images, imglens)
 
@@ -321,15 +322,17 @@ class BasePlugin(MMPluginMixin):
         images,
         videos,
         audios,
-        imglens,
-        vidlens,
-        audlens,
-        batch_ids,
         processor,
+        **kwargs,
     ):
         r"""Build batched multimodal inputs for VLMs."""
+        # imglens = kwargs.get("imglens", None)
+        # vidlens = kwargs.get("vidlens", None)
+        # audlens = kwargs.get("audlens", None)
+        # batch_ids = kwargs.get("batch_ids", None)
+
         self._validate_input(processor, images, videos, audios)
-        return self._get_mm_inputs(images, videos, audios, processor)
+        return self._get_mm_inputs(images, videos, audios, processor, **kwargs)
 
 
 @dataclass
@@ -418,14 +421,15 @@ class PaddleOCRVLPlugin(BasePlugin):
         videos,
         audios,
         processor,
+        **kwargs,
     ):
         image_processor = getattr(processor, "image_processor", None)
         mm_inputs = {}
         if len(images) != 0:
             images = self._regularize_images(
                 images,
-                image_max_pixels=getattr(processor, "max_pixels", 2822400),
-                image_min_pixels=getattr(processor, "min_pixels", 147384),
+                image_max_pixels=getattr(image_processor, "max_pixels", 2822400),
+                image_min_pixels=getattr(image_processor, "min_pixels", 147384),
                 image_processor=image_processor,
             )["images"]
             mm_inputs.update(image_processor(images, return_tensors="pd"))
@@ -607,6 +611,7 @@ class ErnieVLPlugin(BasePlugin):
         videos,
         audios,
         processor,
+        **kwargs,
     ):
         image_processor = getattr(processor, "image_processor", None)
         mm_inputs = {}
@@ -756,6 +761,7 @@ class Qwen2VLPlugin(BasePlugin):
         videos,
         audios,
         processor,
+        **kwargs,
     ):
         image_processor = getattr(processor, "image_processor", None)
         mm_inputs = {}
@@ -844,6 +850,7 @@ class Qwen3VLPlugin(Qwen2VLPlugin):
         videos,
         audios,
         processor,
+        **kwargs,
     ):
         image_processor = getattr(processor, "image_processor", None)
         video_processor = getattr(processor, "video_processor", None)
@@ -970,6 +977,7 @@ class GLM4VPlugin(Qwen2VLPlugin):
         videos,
         audios,
         processor,
+        **kwargs,
     ):
         image_processor = getattr(processor, "image_processor", None)
         video_processor = getattr(processor, "video_processor", None)
@@ -1083,14 +1091,11 @@ class GLM4VPlugin(Qwen2VLPlugin):
         images,
         videos,
         audios,
-        imglens,
-        vidlens,
-        audlens,
-        batch_ids,
         processor,
+        **kwargs,
     ):
         self._validate_input(processor, images, videos, audios)
-        mm_inputs = self._get_mm_inputs(images, videos, audios, processor)
+        mm_inputs = self._get_mm_inputs(images, videos, audios, processor, **kwargs)
         mm_inputs.pop("timestamps", None)
         return mm_inputs
 
@@ -1141,14 +1146,11 @@ class Gemma3Plugin(BasePlugin):
         images,
         videos,
         audios,
-        imglens,
-        vidlens,
-        audlens,
-        batch_ids,
         processor,
+        **kwargs,
     ):
         self._validate_input(processor, images, videos, audios)
-        mm_inputs = self._get_mm_inputs(images, videos, audios, processor)
+        mm_inputs = self._get_mm_inputs(images, videos, audios, processor, **kwargs)
         mm_inputs.pop("num_crops", None)
         return mm_inputs
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
- Refactor `get_mm_inputs` in MMPlugin to use `**kwargs` for flexible argument passing.
- Update `SFTDataset` and `DPODataset` to invoke `get_mm_inputs` with keyword arguments.
- Fix `PaddleOCRVLPlugin` to correctly retrieve `max_pixels` and `min_pixels` attributes from `image_processor`.
- Replace `print` with `logger` in `cli/hparams/parser.py`.