### PR TITLE
Change default value of router_aux_loss_coef.

### DIFF
--- a/paddleformers/trainer/training_args.py
+++ b/paddleformers/trainer/training_args.py
@@ -1093,7 +1093,7 @@ class TrainingArguments:
         metadata={"help": "Enable MoE (Mixture of Experts) expert parallel training"},
     )
     router_aux_loss_coef: Optional[float] = field(
-        default=0.0001,
+        default=0.0,
         metadata={"help": "MoE (Mixture of Experts) Auxiliary loss weight coefficient"},
     )
     release_grads: Optional[bool] = field(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
修改router_aux_loss_coef默认值为0.0，对齐竞品。Merged in dev: #3775 
