### PR TITLE
Remove more aux loss coef

### DIFF
--- a/examples/experiments/deepseek_v3_pretrain/config/configuration.py
+++ b/examples/experiments/deepseek_v3_pretrain/config/configuration.py
@@ -69,8 +69,6 @@ class DeepseekV2FastConfig(PretrainedConfig):
             Whether to normalize the weights of the routed experts.
         scoring_func (`str`, *optional*, defaults to 'softmax'):
             Method of computing expert weights.
-        router_aux_loss_coef (`float`, *optional*, defaults to 0.001):
-            Auxiliary loss weight coefficient.
         seq_aux = (`bool`, *optional*, defaults to True):
             Whether to compute the auxiliary loss for each individual sample.
         num_key_value_heads (`int`, *optional*):
@@ -159,7 +157,6 @@ class DeepseekV2FastConfig(PretrainedConfig):
         first_k_dense_replace=0,
         norm_topk_prob=False,
         scoring_func="softmax",
-        router_aux_loss_coef=0.001,
         seq_aux=True,
         hidden_act="silu",
         max_position_embeddings=2048,
@@ -234,7 +231,6 @@ class DeepseekV2FastConfig(PretrainedConfig):
         self.first_k_dense_replace = first_k_dense_replace
         self.norm_topk_prob = norm_topk_prob
         self.scoring_func = scoring_func
-        self.router_aux_loss_coef = router_aux_loss_coef
         self.seq_aux = seq_aux
         # for backward compatibility
         if num_key_value_heads is None:

--- a/examples/experiments/paddlefleet/glm45_provider.py
+++ b/examples/experiments/paddlefleet/glm45_provider.py
@@ -159,7 +159,6 @@ class GLM45AirModelSingleCardDebugProvider(GLMMoEModelProvider):
     use_bias: bool = False
     num_hidden_layers: int = 2
     num_attention_heads: int = 8
-    router_aux_loss_coef: float = 1e-4
     num_key_value_heads: int = 8
     seq_length: int = 8192
     num_experts_per_tok: int = 4

--- a/paddleformers/cli/train/deepseek_v3_pretrain/configuration.py
+++ b/paddleformers/cli/train/deepseek_v3_pretrain/configuration.py
@@ -68,8 +68,6 @@ class DeepseekV2FastConfig(PretrainedConfig):
             Whether to normalize the weights of the routed experts.
         scoring_func (`str`, *optional*, defaults to 'softmax'):
             Method of computing expert weights.
-        router_aux_loss_coef (`float`, *optional*, defaults to 0.001):
-            Auxiliary loss weight coefficient.
         seq_aux = (`bool`, *optional*, defaults to True):
             Whether to compute the auxiliary loss for each individual sample.
         num_key_value_heads (`int`, *optional*):
@@ -158,7 +156,6 @@ class DeepseekV2FastConfig(PretrainedConfig):
         first_k_dense_replace=0,
         norm_topk_prob=False,
         scoring_func="softmax",
-        router_aux_loss_coef=0.001,
         seq_aux=True,
         hidden_act="silu",
         max_position_embeddings=2048,
@@ -233,7 +230,6 @@ class DeepseekV2FastConfig(PretrainedConfig):
         self.first_k_dense_replace = first_k_dense_replace
         self.norm_topk_prob = norm_topk_prob
         self.scoring_func = scoring_func
-        self.router_aux_loss_coef = router_aux_loss_coef
         self.seq_aux = seq_aux
         # for backward compatibility
         if num_key_value_heads is None:

--- a/paddleformers/transformers/deepseek_v3/configuration.py
+++ b/paddleformers/transformers/deepseek_v3/configuration.py
@@ -70,8 +70,6 @@ class DeepseekV3Config(PretrainedConfig):
             Whether to normalize the weights of the routed experts.
         scoring_func (`str`, *optional*, defaults to 'softmax'):
             Method of computing expert weights.
-        router_aux_loss_coef (`float`, *optional*, defaults to 0.001):
-            Auxiliary loss weight coefficient.
         seq_aux = (`bool`, *optional*, defaults to True):
             Whether to compute the auxiliary loss for each individual sample.
         num_key_value_heads (`int`, *optional*):
@@ -163,7 +161,6 @@ class DeepseekV3Config(PretrainedConfig):
         first_k_dense_replace=0,
         norm_topk_prob=False,
         scoring_func="softmax",
-        router_aux_loss_coef=0.0001,
         seq_aux=True,
         hidden_act="silu",
         max_position_embeddings=2048,
@@ -211,7 +208,6 @@ class DeepseekV3Config(PretrainedConfig):
         self.first_k_dense_replace = first_k_dense_replace
         self.norm_topk_prob = norm_topk_prob
         self.scoring_func = scoring_func
-        self.router_aux_loss_coef = router_aux_loss_coef
         self.seq_aux = seq_aux
         self.fd_fallback = fd_fallback
         # for backward compatibility

--- a/paddleformers/transformers/qwen3_moe/configuration.py
+++ b/paddleformers/transformers/qwen3_moe/configuration.py
@@ -122,8 +122,6 @@ class Qwen3MoeConfig(PretrainedConfig):
         output_router_logits (`bool`, *optional*, defaults to `False`):
             Whether or not the router logits should be returned by the model. Enabling this will also
             allow the model to output the auxiliary loss, including load balancing loss and router z-loss.
-        router_aux_loss_coef (`float`, *optional*, defaults to 0.001):
-            The aux loss factor for the total loss.
         mlp_only_layers (`list[int]`, *optional*, defaults to `[]`):
             Indicate which layers use Qwen3MoeMLP rather than Qwen3MoeSparseMoeBlock
             The list contains layer index, from 0 to num_layers-1 if we have num_layers layers
@@ -175,7 +173,6 @@ class Qwen3MoeConfig(PretrainedConfig):
         num_experts=128,
         norm_topk_prob=False,
         output_router_logits=False,
-        router_aux_loss_coef=0.001,
         mlp_only_layers=None,
         moe_subbatch_token_num_before_dispatch=0,
         fd_fallback=False,
@@ -215,7 +212,6 @@ class Qwen3MoeConfig(PretrainedConfig):
         self.num_experts = num_experts
         self.norm_topk_prob = norm_topk_prob
         self.output_router_logits = output_router_logits
-        self.router_aux_loss_coef = router_aux_loss_coef
         self.mlp_only_layers = [] if mlp_only_layers is None else mlp_only_layers
         self.moe_subbatch_token_num_before_dispatch = moe_subbatch_token_num_before_dispatch
 


### PR DESCRIPTION
改动：
补充 https://github.com/PaddlePaddle/PaddleFormers/pull/3781 漏掉的内容
从config和组网中移除aux_loss_coef的初始化默认值，只使用llm meta config的默认值或yaml传入，避免误导