### PR TITLE
[Feat] support multi-modal pretraining (VL-PT) without packing

### DIFF
--- a/paddleformers/cli/hparams/parser.py
+++ b/paddleformers/cli/hparams/parser.py
@@ -216,7 +216,7 @@ def get_train_args(args: Optional[Union[dict[str, Any], list[str]]] = None) -> _
     """
     model_args, data_args, preprocess_args, generating_args, finetuning_args = _parse_train_args(args)
 
-    if model_args.stage == "VL-SFT":
+    if "VL" in model_args.stage:
         os.environ["NCCL_DEBUG"] = "INFO"
         os.environ["PYTHONUNBUFFERED"] = "1"
         os.environ["FLAGS_use_auto_growth_pinned_allocator"] = "True"
@@ -240,6 +240,9 @@ def get_train_args(args: Optional[Union[dict[str, Any], list[str]]] = None) -> _
 
         os.environ["FLAGS_call_stack_level"] = "2"
         os.environ["FLAGS_eager_communication_connection"] = "0"
+
+        if data_args.packing and data_args.truncate_packing:
+            raise ValueError(" VLMs training does not support Truncate Packing, please set --truncate_packing False")
 
     if data_args.split_multi_turn and data_args.template_backend != "jinja":
         raise ValueError("data_args.template_backend must be jinja when split_multi_turn is True")

--- a/paddleformers/cli/train/sft/workflow.py
+++ b/paddleformers/cli/train/sft/workflow.py
@@ -296,7 +296,7 @@ def run_sft(
     logger.info(f"Final model config: {model_config}")
     logger.info("Creating model")
 
-    if model_args.stage == "VL-SFT":
+    if "VL" in model_args.stage:
         model_class = AutoModelForConditionalGeneration
         if training_args.pipeline_model_parallel_size > 1:
             if data_args.eval_with_do_generation and training_args.do_eval:
@@ -369,7 +369,7 @@ def run_sft(
         "mix_strategy": data_args.mix_strategy,
         "encode_one_turn": data_args.encode_one_turn,
         "use_template": data_args.use_template,
-        "is_pretraining": True if model_args.stage.lower() == "pt" else False,
+        "is_pretraining": True if "pt" in model_args.stage.lower() else False,
         "truncate_packing": data_args.truncate_packing,
         "stage": model_args.stage,
         "template_backend": data_args.template_backend,
@@ -558,7 +558,7 @@ def run_sft(
         )
         logger.info(f"Setting max_seq_len to {max_seq_len} using PaddleFormers Model.")
     if data_args.dataset_type != "pretrain":
-        if model_args.stage == "VL-SFT":
+        if "VL" in model_args.stage:
             data_collator = partial(
                 mm_collate_fn,
                 template=template_instance,

--- a/paddleformers/datasets/SFTDataset.py
+++ b/paddleformers/datasets/SFTDataset.py
@@ -343,24 +343,79 @@ class SFTDataSet(IterableDataset):
                 yield from self.__iter_func()
 
     def _postprocess_pretraining_sequence(self, example, actual_example_num):
-        tokens = self._encode_pretraining_example(example, actual_example_num)
+
+        messages = example.get("messages", [])
+        images = example.get("images", [])
+        videos = example.get("videos", [])
+        audios = example.get("audios", [])
+
+        mm_inputs = self.template.mm_plugin.get_mm_inputs(
+            images,
+            videos,
+            audios,
+            self.processor,
+            imglens=[len(images)],
+            vidlens=[len(videos)],
+            audlens=[len(audios)],
+            batch_ids=None,
+            messages=messages,
+        )
+
+        messages = self.template.mm_plugin.process_messages(
+            messages, images, videos, audios, mm_inputs, self.processor
+        )
+
+        tokens = self._encode_pretraining_messages(messages, actual_example_num)
         if len(tokens) > self.max_seq_len + 1:
             # Truncate the sequence to the maximum length
             tokens = tokens[: self.max_seq_len + 1]
-        res_tokens = tokens[:-1]
-        res_labels = tokens[1:]
-        pos_ids = list(range(len(res_tokens)))
-        sequence = Sequence(
-            token_ids=res_tokens,
-            position_ids=pos_ids,
-            labels=res_labels,
-            num_examples=actual_example_num,
-        )
-        return sequence
 
-    def _encode_pretraining_example(self, example, actual_example_num):
+        labels = self.template.mm_plugin.process_tokens(tokens, self.processor)
+
+        # label shift
+        labels = labels[1:] + [-100]
+
+        pos_ids = list(range(len(tokens)))
+
+        if all(x == -100 for x in labels):
+            logger.warning(f"[SKIP] all labels set to 0: {example}")
+            return None
+
+        assert len(tokens) == len(labels), f"{len(tokens)}-{len(labels)}"
+
+        enable_dataset_debug = os.getenv("FLAGS_enable_dataset_debug", "false").lower() in ("true", "1", "t")
+        if enable_dataset_debug:
+            logger.info("\n" + "=" * 50)
+            logger.info("[dataset debug] Debug mode enabled")
+            if hasattr(self, "tokenizer"):
+                print("========================================")
+                print("tokens: ", [tokens])
+                print_debug_info(self.tokenizer, tokens, "input")
+                print("========================================\n")
+
+                filtered_labels = [x for x in labels if x != -100]  # remove -100
+                print("========================================")
+                print("labels: ", [labels])
+                print_debug_info(self.tokenizer, filtered_labels, "labels")
+                print("========================================\n")
+            else:
+                logger.info("[dataset debug] Tokenizer not available")
+            logger.info("=" * 50 + "\n")
+
+        return Sequence(
+            token_ids=tokens,
+            position_ids=pos_ids,
+            labels=labels,
+            num_examples=actual_example_num,
+            images=images,
+            videos=videos,
+            audios=audios,
+            mm_inputs=mm_inputs,
+        )
+
+    def _encode_pretraining_messages(self, messages, actual_example_num):
         # tokens
-        content = example["messages"][0]["content"]
+        content = messages[0]["content"]
         tokens = self.tokenizer.convert_tokens_to_ids(self.tokenizer.tokenize(content))
         # Add an EOS token at the end of each sample
         tokens = tokens + [self.tokenizer.eos_token_id]

--- a/paddleformers/datasets/SFTDataset.py
+++ b/paddleformers/datasets/SFTDataset.py
@@ -138,7 +138,7 @@ class SFTDataSet(IterableDataset):
             for _ in range(len(self.mix_datasets)):
                 example = next(dataset_iterator)
                 try:
-                    tokens = self._encode_pretraining_example(example, actual_example_num)
+                    tokens = self._encode_pretraining_messages(example["messages"], actual_example_num)
                 except Exception as e:
                     print(f"Warning: Error processing example, skipping. Error: {str(e)}")
                     if self.estimate:
@@ -416,14 +416,6 @@ class SFTDataSet(IterableDataset):
     def _encode_pretraining_messages(self, messages, actual_example_num):
         # tokens
         content = messages[0]["content"]
-        tokens = self.tokenizer.convert_tokens_to_ids(self.tokenizer.tokenize(content))
-        # Add an EOS token at the end of each sample
-        tokens = tokens + [self.tokenizer.eos_token_id]
-        return tokens
-
-    def _encode_pretraining_example(self, example, actual_example_num):
-        # tokens
-        content = example["messages"][0]["content"]
         tokens = self.tokenizer.convert_tokens_to_ids(self.tokenizer.tokenize(content))
         # Add an EOS token at the end of each sample
         tokens = tokens + [self.tokenizer.eos_token_id]

--- a/paddleformers/datasets/SFTDataset.py
+++ b/paddleformers/datasets/SFTDataset.py
@@ -421,6 +421,14 @@ class SFTDataSet(IterableDataset):
         tokens = tokens + [self.tokenizer.eos_token_id]
         return tokens
 
+    def _encode_pretraining_example(self, example, actual_example_num):
+        # tokens
+        content = example["messages"][0]["content"]
+        tokens = self.tokenizer.convert_tokens_to_ids(self.tokenizer.tokenize(content))
+        # Add an EOS token at the end of each sample
+        tokens = tokens + [self.tokenizer.eos_token_id]
+        return tokens
+
     def _postprocess_sequence(self, example, actual_example_num):
         """Process code completion examples into token sequences.
 

--- a/paddleformers/datasets/template/mm_plugin.py
+++ b/paddleformers/datasets/template/mm_plugin.py
@@ -317,6 +317,27 @@ class BasePlugin(MMPluginMixin):
         self._validate_input(processor, images, videos, audios)
         return messages
 
+    def process_tokens(self, tokens, processor):
+        r"""Pre-process input tokens for VLMs."""
+
+        labels = deepcopy(tokens)
+
+        tokenizer = getattr(processor, "tokenizer")
+
+        masked_tokens = getattr(self, "masked_tokens", None)
+        if masked_tokens:
+            masked_tokens_ids = tokenizer.convert_tokens_to_ids(masked_tokens)
+
+            if len(masked_tokens) != len(masked_tokens_ids):
+                raise ValueError(
+                    f"The number of masked tokens {masked_tokens} does not match the number of masked tokens ids {masked_tokens_ids} tokens."
+                )
+
+            # Mask tokens that should be ignored in loss calculation
+            for i, token in enumerate(labels):
+                if token in masked_tokens_ids:
+                    labels[i] = -100
+
     def get_mm_inputs(
         self,
         images,
@@ -472,6 +493,8 @@ class PaddleOCRVLPlugin(BasePlugin):
                 num_image_tokens += 1
 
             message["content"] = content
+
+        self.masked_tokens = [self.image_token, self.image_bos_token, self.image_eos_token]
 
         return messages
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
- Update stage validation in `workflow.py` to support 'VL' and 'pt' partial matching.
- Refactor `SFTDataset` pretraining pipeline to handle multi-modal inputs (images/videos/audios) via `mm_plugin`.
- Add `process_tokens` in `mm_plugin` to support masking special tokens (e.g., image tokens) in labels.
- Add dataset debug logging.