### PR TITLE
Change default router_aux_loss_coef to 0.0

### DIFF
--- a/paddleformers/transformers/configuration_utils.py
+++ b/paddleformers/transformers/configuration_utils.py
@@ -340,7 +340,7 @@ class LlmMetaConfig:
         (
             "router_aux_loss_coef",
             Optional[float],
-            None,
+            0.0,
             "Coefficient for MoE router auxiliary loss (encourages balanced expert usage). Defaults to 0.0 (disable auxiliary loss).",
         ),
         (


### PR DESCRIPTION
改动：
把router_aux_loss_coef默认值从None改成0.0