### PR TITLE
Remove NumPy dependency for position_ids generation（PaddleOCRVLForConditionalGeneration）

### DIFF
--- a/paddleformers/transformers/paddleocr_vl/modeling.py
+++ b/paddleformers/transformers/paddleocr_vl/modeling.py
@@ -1996,14 +1996,13 @@ class PaddleOCRVLForConditionalGeneration(Ernie4_5PretrainedModel, GenerationMix
                 sample_indices = paddle.repeat_interleave(paddle.arange(bs), sizes)
 
                 cum_sizes = paddle.cumsum(sizes, axis=0)
-                cu_seqlens = F.pad(cum_sizes, (1, 0), value=0, data_format="NCL")
-                cu_seqlens = cu_seqlens.astype("int64")
+                cu_seqlens = F.pad(cum_sizes, (1, 0), value=0, data_format="NCL").astype("int32")
 
-                global_range = paddle.arange(sizes.sum())
+                global_range = paddle.arange(sizes.sum(), dtype="int32")
                 offsets = cu_seqlens[:-1]
                 expanded_offsets = paddle.repeat_interleave(offsets, sizes)
                 local_indices = global_range - expanded_offsets
-                spatial_sizes = paddle.prod(image_grid_thw[:, 1:], axis=1)
+                spatial_sizes = paddle.prod(image_grid_thw[:, 1:], axis=1, dtype="int32")
                 expanded_spatial_sizes = paddle.repeat_interleave(spatial_sizes, sizes)
                 siglip_position_ids = local_indices % expanded_spatial_sizes
 

--- a/paddleformers/transformers/paddleocr_vl/modeling.py
+++ b/paddleformers/transformers/paddleocr_vl/modeling.py
@@ -1990,21 +1990,19 @@ class PaddleOCRVLForConditionalGeneration(Ernie4_5PretrainedModel, GenerationMix
                 pixel_values = pixel_values.astype(inputs_embeds.dtype)
                 pixel_values = pixel_values.unsqueeze(0)
 
-                sizes = paddle.prod(image_grid_thw, axis=1)
-
                 bs, _ = image_grid_thw.shape
+                sizes = paddle.prod(image_grid_thw, axis=1)
+                spatial_sizes = paddle.prod(image_grid_thw[:, 1:], axis=1, dtype="int64")
                 sample_indices = paddle.repeat_interleave(paddle.arange(bs), sizes)
 
                 cum_sizes = paddle.cumsum(sizes, axis=0)
-                cu_seqlens = F.pad(cum_sizes, (1, 0), value=0, data_format="NCL").astype("int32")
+                cu_seqlens = F.pad(cum_sizes, (1, 0), value=0, data_format="NCL")
 
-                global_range = paddle.arange(sizes.sum(), dtype="int32")
-                offsets = cu_seqlens[:-1]
-                expanded_offsets = paddle.repeat_interleave(offsets, sizes)
-                local_indices = global_range - expanded_offsets
-                spatial_sizes = paddle.prod(image_grid_thw[:, 1:], axis=1, dtype="int32")
-                expanded_spatial_sizes = paddle.repeat_interleave(spatial_sizes, sizes)
-                siglip_position_ids = local_indices % expanded_spatial_sizes
+                global_range = paddle.arange(sizes.sum())
+                per_sample_offset = cu_seqlens[sample_indices]
+                per_sample_spatial = spatial_sizes[sample_indices]
+                local_indices = global_range - per_sample_offset
+                siglip_position_ids = local_indices % per_sample_spatial
 
                 vision_outputs = self.visual(
                     pixel_values=pixel_values,
@@ -2013,7 +2011,7 @@ class PaddleOCRVLForConditionalGeneration(Ernie4_5PretrainedModel, GenerationMix
                     vision_return_embed_list=True,
                     interpolate_pos_encoding=True,
                     sample_indices=sample_indices,
-                    cu_seqlens=cu_seqlens,
+                    cu_seqlens=cu_seqlens.astype("int32"),
                     return_pooler_output=False,
                     use_rope=True,
                     window_size=-1,

--- a/paddleformers/transformers/paddleocr_vl/modeling.py
+++ b/paddleformers/transformers/paddleocr_vl/modeling.py
@@ -21,6 +21,7 @@ from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import paddle
+import paddle.nn.functional as F
 from paddle import nn
 from paddle.distributed.fleet.utils import recompute
 from paddle.distributed.fleet.utils.sequence_parallel_utils import (
@@ -69,7 +70,7 @@ def _ensure_cos_sin_dim(cos, sin, dim_needed):
         sin = paddle.concat([sin, sin], axis=-1)
         return cos, sin
     else:
-        raise ValueError(f"Unexpected cos/sin last-dim: {last}, expected {dim_needed} or {dim_needed//2}")
+        raise ValueError(f"Unexpected cos/sin last-dim: {last}, expected {dim_needed} or {dim_needed // 2}")
 
 
 def apply_multimodal_rotary_pos_emb(q, k, cos, sin, mrope_section, unsqueeze_dim=1):
@@ -1988,27 +1989,27 @@ class PaddleOCRVLForConditionalGeneration(Ernie4_5PretrainedModel, GenerationMix
 
                 pixel_values = pixel_values.astype(inputs_embeds.dtype)
                 pixel_values = pixel_values.unsqueeze(0)
-                siglip_position_ids = list()
-                image_grid_hws = list()
-                sample_indices = list()
-                cu_seqlens = [0]
 
-                for idx, thw in enumerate(image_grid_thw):
-                    thw_tuple = tuple(thw.detach().cpu().numpy().tolist())
-                    numel = np.prod(thw_tuple)
-                    image_grid_hws.append(thw_tuple)
-                    image_position_ids = paddle.arange(numel) % np.prod(thw_tuple[1:])
-                    siglip_position_ids.append(image_position_ids)
-                    sample_indices.append(paddle.full((numel,), idx, dtype=paddle.int64))
-                    cu_seqlens.append(cu_seqlens[-1] + numel)
+                sizes = paddle.prod(image_grid_thw, axis=1)
 
-                siglip_position_ids = paddle.concat(siglip_position_ids, axis=0)
-                cu_seqlens = paddle.to_tensor(cu_seqlens, dtype=paddle.int32)
-                sample_indices = paddle.concat(sample_indices, axis=0)
+                bs, _ = image_grid_thw.shape
+                sample_indices = paddle.repeat_interleave(paddle.arange(bs), sizes)
+
+                cum_sizes = paddle.cumsum(sizes, axis=0)
+                cu_seqlens = F.pad(cum_sizes, (1, 0), value=0, data_format="NCL")
+                cu_seqlens = cu_seqlens.astype("int64")
+
+                global_range = paddle.arange(sizes.sum())
+                offsets = cu_seqlens[:-1]
+                expanded_offsets = paddle.repeat_interleave(offsets, sizes)
+                local_indices = global_range - expanded_offsets
+                spatial_sizes = paddle.prod(image_grid_thw[:, 1:], axis=1)
+                expanded_spatial_sizes = paddle.repeat_interleave(spatial_sizes, sizes)
+                siglip_position_ids = local_indices % expanded_spatial_sizes
 
                 vision_outputs = self.visual(
                     pixel_values=pixel_values,
-                    image_grid_thw=image_grid_hws,
+                    image_grid_thw=image_grid_thw,
                     position_ids=siglip_position_ids,
                     vision_return_embed_list=True,
                     interpolate_pos_encoding=True,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->

把这部分 numpy + for 循环的实现修改为 paddle 实现
https://github.com/PaddlePaddle/PaddleFormers/blob/6b24874ddd682c87458589de83f792d496376e77/paddleformers/transformers/paddleocr_vl/modeling.py#L1991-L2007

测试代码：
```python
import numpy as np
import paddle
import paddle.nn.functional as F
import time

image_grid_thw = paddle.arange(24, dtype="int32").reshape([8, 3]) + 1


def np_func(image_grid_thw):
    siglip_position_ids = list()
    sample_indices = list()
    cu_seqlens = [0]
    for idx, thw in enumerate(image_grid_thw):
        thw_tuple = tuple(thw.detach().cpu().numpy().tolist())
        numel = np.prod(thw_tuple)
        image_position_ids = paddle.arange(numel) % np.prod(thw_tuple[1:])
        siglip_position_ids.append(image_position_ids)
        sample_indices.append(paddle.full((numel,), idx, dtype=paddle.int64))
        cu_seqlens.append(cu_seqlens[-1] + numel)

    siglip_position_ids = paddle.concat(siglip_position_ids, axis=0)
    cu_seqlens = paddle.to_tensor(cu_seqlens, dtype=paddle.int32)
    sample_indices = paddle.concat(sample_indices, axis=0)

    return sample_indices, cu_seqlens, siglip_position_ids, image_grid_thw


def pd_func(image_grid_thw):

    sizes = paddle.prod(image_grid_thw, axis=1)

    bs, _ = image_grid_thw.shape
    sample_indices = paddle.repeat_interleave(paddle.arange(bs), sizes)

    cum_sizes = paddle.cumsum(sizes, axis=0)
    cu_seqlens = F.pad(cum_sizes, (1, 0), value=0, data_format="NCL")

    spatial_sizes = paddle.prod(image_grid_thw[:, 1:], axis=1, dtype="int64")

    global_range = paddle.arange(sizes.sum())
    per_sample_offset = cu_seqlens[sample_indices]
    per_sample_spatial = spatial_sizes[sample_indices]
    local_indices = global_range - per_sample_offset
    siglip_position_ids = local_indices % per_sample_spatial

    return sample_indices, cu_seqlens.astype("int32"), siglip_position_ids, image_grid_thw


# -------- baseline --------
start = time.time()
for i in range(100):
    a = np_func(image_grid_thw)
step = time.time() - start
print("NumPy + For: ", step)

# -------- Paddle 动态图 --------
for i in range(10):
    b = pd_func(image_grid_thw)

start = time.time()
for i in range(100):
    b = pd_func(image_grid_thw)
step = time.time() - start
print("Paddle 动态图: ", step)

# -------- Paddle 静态图( PHI ) --------
static_fn = paddle.jit.to_static(pd_func, backend=None)
for i in range(10):
    b = static_fn(image_grid_thw)

start = time.time()
for i in range(100):
    b = static_fn(image_grid_thw)
step = time.time() - start
print("Paddle 静态图(PHI): ", step)

# -------- Paddle 静态图( CINN ) --------
static_fn = paddle.jit.to_static(pd_func, backend="CINN")
for i in range(10):
    b = static_fn(image_grid_thw)

start = time.time()
for i in range(100):
    b = static_fn(image_grid_thw)
step = time.time() - start
print("Paddle 静态图(CINN): ", step)


assert (a[0] == b[0]).all()
assert (a[1] == b[1]).all()
assert (a[2] == b[2]).all()
assert (a[3] == b[3]).all()


# ------- 旧版本实现，速度太慢，已废弃 ------
# def pd_func(image_grid_thw):
#     sizes = paddle.prod(image_grid_thw, axis=1)

#     bs, _ = image_grid_thw.shape
#     sample_indices = paddle.repeat_interleave(paddle.arange(bs), sizes)

#     cum_sizes = paddle.cumsum(sizes, axis=0)
#     cu_seqlens = F.pad(cum_sizes, (1, 0), value=0, data_format="NCL")

#     global_range = paddle.arange(sizes.sum())
#     offsets = cu_seqlens[:-1]
#     expanded_offsets = paddle.repeat_interleave(offsets, sizes)
#     local_indices = global_range - expanded_offsets
#     spatial_sizes = paddle.prod(image_grid_thw[:, 1:], axis=1)
#     expanded_spatial_sizes = paddle.repeat_interleave(spatial_sizes, sizes)
#     siglip_position_ids = local_indices % expanded_spatial_sizes.astype("int64")

#     return sample_indices, cu_seqlens.astype("int32"), siglip_position_ids, image_grid_thw

```

测试指令：
```shell
MIN_GRAPH_SIZE=0 python np2paddle.py
```

测试速度对比，改进后速度提升3倍以上
```
NumPy + For:  1.1855034828186035
Paddle 动态图:  0.3628847599029541

这个计算图太小，执行器自己的调度成了瓶颈
Paddle 静态图(PHI):  0.37288999557495117
Paddle 静态图(CINN):  0.36542320251464844
```