### PR TITLE
Fix DSV3 speed degradation after adapting to Paddle 3.3.0

### DIFF
--- a/examples/experiments/deepseek_v3_pretrain/modeling.py
+++ b/examples/experiments/deepseek_v3_pretrain/modeling.py
@@ -2210,6 +2210,16 @@ def rearrange_kv(kv, k_pe, qk_nope_head_dim, num_heads):
     return key_states, value_states
 
 
+@contextlib.contextmanager
+def enable_to_static(value):
+    old_value = paddle.jit.dy2static.program_translator.ProgramTranslator().enable_to_static
+    paddle.jit.enable_to_static(value)
+    try:
+        yield
+    finally:
+        paddle.jit.enable_to_static(old_value)
+
+
 def qkv_pre_process(
     q, kv, k_pe, rotary_emb, num_heads, q_head_dim, qk_nope_head_dim, v_head_dim, qk_rope_head_dim, position_ids
 ):
@@ -2247,7 +2257,8 @@ def qkv_pre_process(
     query_states = fused_partial_rope(q, cos, sin)
     k_pe = fused_partial_rope(k_pe, cos, sin)
 
-    key_states, value_states = rearrange_kv(kv, k_pe, qk_nope_head_dim, num_heads)
+    with enable_to_static(True):
+        key_states, value_states = rearrange_kv(kv, k_pe, qk_nope_head_dim, num_heads)
 
     return query_states, key_states, value_states
 

--- a/examples/experiments/deepseek_v3_pretrain/modeling_pp.py
+++ b/examples/experiments/deepseek_v3_pretrain/modeling_pp.py
@@ -78,6 +78,22 @@ import queue
 global_inputs_embeds_mtp_queue = queue.Queue()
 
 
+def check_accept_none_grad():
+    x = paddle.empty([0])
+    x.stop_gradient = False
+    node = ScheduleNode(lambda x: (x.clone(), x.detach()))
+    node.forward(x)
+    try:
+        node.backward((x, None))
+    except:
+        return False
+    return True
+
+
+# Since Paddle 3.4.0, ScheduleNode no more accepts None in grad.
+ACCEPT_NONE_GRAD = check_accept_none_grad()
+
+
 def parse_args(args):
     if isinstance(args, (tuple, list)):
         if len(args) == 4:
@@ -978,6 +994,10 @@ class FusionFp8DecoderLayerNode(ScheduleNode):
         )
 
         output_grad = (residual_grad, probs_grad, routing_map_grad, l_aux_grad)
+
+        if not ACCEPT_NONE_GRAD:
+            assert routing_map_grad is None, "routing_map should not have grad"
+            output_grad = (residual_grad, probs_grad, l_aux_grad)
 
         output_grad = (
             (hidden_states_grad, *output_grad, hidden_states_grad_)

--- a/paddleformers/cli/train/deepseek_v3_pretrain/modeling.py
+++ b/paddleformers/cli/train/deepseek_v3_pretrain/modeling.py
@@ -2211,6 +2211,16 @@ def rearrange_kv(kv, k_pe, qk_nope_head_dim, num_heads):
     return key_states, value_states
 
 
+@contextlib.contextmanager
+def enable_to_static(value):
+    old_value = paddle.jit.dy2static.program_translator.ProgramTranslator().enable_to_static
+    paddle.jit.enable_to_static(value)
+    try:
+        yield
+    finally:
+        paddle.jit.enable_to_static(old_value)
+
+
 def qkv_pre_process(
     q, kv, k_pe, rotary_emb, num_heads, q_head_dim, qk_nope_head_dim, v_head_dim, qk_rope_head_dim, position_ids
 ):
@@ -2248,7 +2258,8 @@ def qkv_pre_process(
     query_states = fused_partial_rope(q, cos, sin)
     k_pe = fused_partial_rope(k_pe, cos, sin)
 
-    key_states, value_states = rearrange_kv(kv, k_pe, qk_nope_head_dim, num_heads)
+    with enable_to_static(True):
+        key_states, value_states = rearrange_kv(kv, k_pe, qk_nope_head_dim, num_heads)
 
     return query_states, key_states, value_states
 

--- a/paddleformers/cli/train/deepseek_v3_pretrain/modeling_pp.py
+++ b/paddleformers/cli/train/deepseek_v3_pretrain/modeling_pp.py
@@ -79,6 +79,22 @@ import queue
 global_inputs_embeds_mtp_queue = queue.Queue()
 
 
+def check_accept_none_grad():
+    x = paddle.empty([0])
+    x.stop_gradient = False
+    node = ScheduleNode(lambda x: (x.clone(), x.detach()))
+    node.forward(x)
+    try:
+        node.backward((x, None))
+    except:
+        return False
+    return True
+
+
+# Since Paddle 3.4.0, ScheduleNode no more accepts None in grad.
+ACCEPT_NONE_GRAD = check_accept_none_grad()
+
+
 def parse_args(args):
     if isinstance(args, (tuple, list)):
         if len(args) == 4:
@@ -979,6 +995,10 @@ class FusionFp8DecoderLayerNode(ScheduleNode):
         )
 
         output_grad = (residual_grad, probs_grad, routing_map_grad, l_aux_grad)
+
+        if not ACCEPT_NONE_GRAD:
+            assert routing_map_grad is None, "routing_map should not have grad"
+            output_grad = (residual_grad, probs_grad, l_aux_grad)
 
         output_grad = (
             (hidden_states_grad, *output_grad, hidden_states_grad_)

--- a/paddleformers/transformers/fp8_utils.py
+++ b/paddleformers/transformers/fp8_utils.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from functools import partial
 
 import numpy
@@ -32,13 +31,8 @@ except ImportError:
 
 from paddle.distributed.fleet.meta_parallel.zero_bubble_utils import WeightGradStore
 
-USE_DS_GEMM = os.getenv("USE_DS_GEMM", "False").lower() == "true"
-
 try:
-    if USE_DS_GEMM:
-        import deep_gemm
-    else:
-        from paddle.incubate.fp8 import deep_gemm
+    from paddlefleet.ops import deep_gemm
 except:
     pass
 
@@ -178,13 +172,6 @@ class FP8LinearFunctionBase:
     def kitchen_gemm(
         x_fp8, x_scale, w_fp8, w_scale, is_a_1d_scaled, is_b_1d_scaled, out=None, rtn_dtype=paddle.bfloat16
     ):
-        if USE_DS_GEMM:
-            if out is None:
-                out = paddle.zeros([x_fp8.shape[0], w_fp8.shape[0]], rtn_dtype)
-            if numpy.prod(x_fp8.shape) != 0 and numpy.prod(w_fp8.shape) != 0:
-                deep_gemm.wgrad_gemm_fp8_fp8_fp32_nt((x_fp8, x_scale), (w_fp8, w_scale), out, num_sms=get_sm_num())
-            return out
-
         if out is not None:
             accumulate = True
             out_dtype = out.dtype
@@ -266,9 +253,8 @@ class FP8LinearFunctionBase:
         if out is None:
             out = paddle.empty([input_fp8.shape[0], weight_fp8.shape[0]], dtype=weight.dtype)
 
-        deep_gemm.gemm_fp8_fp8_bf16_nt(
-            (input_fp8, input_scale.T), (weight_fp8, weight_scale), out, num_sms=get_sm_num()
-        )
+        deep_gemm.set_num_sms(get_sm_num())
+        deep_gemm.fp8_gemm_nt((input_fp8, input_scale.T), (weight_fp8, weight_scale), out)
 
         # Return outputs
         if return_mode == "output_only":
@@ -358,7 +344,7 @@ class FP8LinearFunctionBase:
             # Recompute o1 using deep_gemm(x_fp8, w1_t_fp8)
             w1_fp8, w1_scale = weight_quant(w1, True)
             o1 = paddle.empty([x_fp8.shape[0], w1_fp8.shape[0]], dtype=do3.dtype)
-            deep_gemm.gemm_fp8_fp8_bf16_nt((x_fp8, x_scale.T), (w1_fp8, w1_scale), o1, num_sms=get_sm_num())
+            deep_gemm.fp8_gemm_nt((x_fp8, x_scale.T), (w1_fp8, w1_scale), o1)
 
         # [recompute] o2 = swiglu(o1)
         o2 = swiglu(o1)
@@ -852,11 +838,10 @@ def split_group_gemm(x_fp8, x_scale, w_fp8, w_scale, tokens_per_expert, gemm_out
 
         x_scale_tma_align = x_scale[start_idx:end_idx].T.contiguous().T
 
-        deep_gemm.gemm_fp8_fp8_bf16_nt(
+        deep_gemm.fp8_gemm_nt(
             (x_fp8[start_idx:end_idx], x_scale_tma_align),
             (w_fp8[i], w_scale[i]),
             gemm_out[start_idx:end_idx],
-            num_sms=get_sm_num(),
         )
 
         start_idx = end_idx
@@ -940,12 +925,11 @@ class FP8GroupGemmMlpFunctionNode:
             if self.is_split_group_gemm:
                 split_group_gemm(x_fp8, x_scale, w1_t_quant, w1_t_scale, tokens_per_expert, o1)
             else:
-                deep_gemm.m_grouped_gemm_fp8_fp8_bf16_nt_contiguous(
+                deep_gemm.m_grouped_fp8_gemm_nt_contiguous(
                     (x_fp8, x_scale),
                     (w1_t_quant, w1_t_scale),
                     o1,
                     m_indices=self.m_indices if m_indices is None else m_indices,
-                    num_sms=get_sm_num(),
                 )
 
         if m_indices is None:
@@ -994,12 +978,11 @@ class FP8GroupGemmMlpFunctionNode:
             if self.is_split_group_gemm:
                 split_group_gemm(o2_fp8, o2_scale, w2_quant, w2_scale, tokens_per_expert, o3)
             else:
-                deep_gemm.m_grouped_gemm_fp8_fp8_bf16_nt_contiguous(
+                deep_gemm.m_grouped_fp8_gemm_nt_contiguous(
                     (o2_fp8, o2_scale),
                     (w2_quant, w2_scale),
                     o3,
                     m_indices=m_indices if self.fwd_subbatch else self.m_indices,
-                    num_sms=get_sm_num(),
                 )
 
         return o3
@@ -1035,12 +1018,11 @@ class FP8GroupGemmMlpFunctionNode:
                     unzipped_grad_fp8, unzipped_grad_scale, bw_w2_quant, bw_w2_scale, tokens_per_expert, do2_s
                 )
             else:
-                deep_gemm.m_grouped_gemm_fp8_fp8_bf16_nt_contiguous(
+                deep_gemm.m_grouped_fp8_gemm_nt_contiguous(
                     (unzipped_grad_fp8, unzipped_grad_scale),
                     (bw_w2_quant, bw_w2_scale),
                     do2_s,
                     m_indices=m_indices if self.bwd_subbatch else self.m_indices,
-                    num_sms=get_sm_num(),
                 )
 
         with paddle.amp.auto_cast(False):
@@ -1081,12 +1063,11 @@ class FP8GroupGemmMlpFunctionNode:
             if self.is_split_group_gemm:
                 split_group_gemm(do1_fp8, do1_scale, bw_w1_quant, bw_w1_scale, tokens_per_expert, dx)
             else:
-                deep_gemm.m_grouped_gemm_fp8_fp8_bf16_nt_contiguous(
+                deep_gemm.m_grouped_fp8_gemm_nt_contiguous(
                     (do1_fp8, do1_scale),
                     (bw_w1_quant, bw_w1_scale),
                     dx,
                     m_indices=m_indices if self.bwd_subbatch else self.m_indices,
-                    num_sms=get_sm_num(),
                 )
 
         return dx


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
Models

### Description
DeepseekV3 模型适配 Paddle 3.3.0/3.4.0，解决性能和正确性问题

#### PR 内容
* rearrange_kv 没有开启动转静，因此手动进行开启
* Paddle 3.4.0 的 ScheduleNode 存在不兼容升级，因此用一个简单的函数判断 Paddle 版本，代码可以自动适配 3.3.0 和 3.4.0
* 将外部 deep_gemm 替换成 paddlefleet.ops.deep_gemm，彻底摆脱第三方依赖

#### 无需修复
* fused_rms_norm_ext_grad 的 amp 问题已经在 3.4.0 修复，因此无需在组网中修改

#### 可运行性
✅ Paddle 3.3.0 + PaddleFleet 0.1.0
✅ Paddle 3.4.0.dev20260308 + PaddleFleet 0.1.0

#### 性能测试
以下性能为 Paddle 3.3.0 + NLP版deep_gemm 测得，但是后面更新后对比了单机的 timeline 没有区别，说明替换 deep_gemm 对性能无影响

序号 | 配置 | 权重 | 其他参数修改 | 性能
:-: | -- | -- | -- | --
1 | PP8EP32-ACC60 | 冷启 | 开fake_gate | 1342
2 | PP8EP32-ACC60 | 冷启 | 开fake_gate，关优化器 | 1550
3 | PP8EP32-ACC60 | 冷启 | 开fake_gate，关优化器，关recompute_fa3 | 1594