### PR TITLE
Fix(requirement): Limit transformers version into v5.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,6 @@ tiktoken
 ml_dtypes
 omegaconf
 modelscope
-transformers>=5.0.0
+transformers==5.0.0
 GPUtil
 importlib_metadata


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
限制dev分支transformers版本为v5.0.0