### PR TITLE
Optimize slicing in PaddleOCRVisionEmbeddings

### DIFF
--- a/paddleformers/transformers/paddleocr_vl/modeling.py
+++ b/paddleformers/transformers/paddleocr_vl/modeling.py
@@ -238,61 +238,6 @@ class PaddleOCRVisionEmbeddings(nn.Layer):
             persistable=False,
         )
 
-    def interpolate_pos_encoding(self, embeddings, height: int, width: int, is_after_patchify: bool = False):
-
-        num_positions = self.position_embedding.weight.shape[0]
-
-        patch_pos_embed = self.position_embedding.weight.unsqueeze(0)
-
-        dim = embeddings.shape[-1]
-
-        if is_after_patchify:
-            new_height = height
-            new_width = width
-        else:
-            new_height = height // self.patch_size
-            new_width = width // self.patch_size
-
-        sqrt_num_positions = paddle.to_tensor(num_positions**0.5, dtype=paddle.int64)
-        patch_pos_embed = patch_pos_embed.reshape((1, sqrt_num_positions, sqrt_num_positions, dim))
-        patch_pos_embed = patch_pos_embed.transpose((0, 3, 1, 2))
-
-        patch_pos_embed = nn.functional.interpolate(
-            patch_pos_embed,
-            size=(new_height, new_width),
-            mode="bilinear",
-            align_corners=False,
-        )
-
-        patch_pos_embed = patch_pos_embed.transpose((0, 2, 3, 1)).reshape((1, -1, dim))
-        return patch_pos_embed
-
-    @staticmethod
-    def flatten_list(image_grid_thw):
-        tmp_image_grid_thw = list()
-        for image_grid in image_grid_thw:
-            if isinstance(image_grid, list):
-                tmp_image_grid_thw.extend(image_grid)
-            else:
-                tmp_image_grid_thw.append(image_grid)
-        return tmp_image_grid_thw
-
-    def fetch_position_embedding_lfu_cache(self, embeddings, h, w, max_cache=20):
-        grid = (h, w)
-        if grid in self.cache_position_embedding:
-            self.cache_position_count[grid] += 1
-            return self.cache_position_embedding[grid]
-
-        if len(self.cache_position_embedding) >= max_cache:
-            min_hit_grid = min(self.cache_position_count, key=self.cache_position_count.get)
-            self.cache_position_count.pop(min_hit_grid)
-            self.cache_position_embedding.pop(min_hit_grid)
-
-        position_embedding = self.interpolate_pos_encoding(embeddings, h, w, True)
-        self.cache_position_count[grid] = 1
-        self.cache_position_embedding[grid] = position_embedding
-        return position_embedding
-
     def forward(
         self,
         pixel_values: paddle.Tensor,  # [B, L, C, H, W]
@@ -301,34 +246,39 @@ class PaddleOCRVisionEmbeddings(nn.Layer):
         interpolate_pos_encoding: bool = False,
     ) -> paddle.Tensor:
         if pixel_values.dim() == 5:
-            assert position_ids is not None
+
+            sqrt_num_positions = int(self.num_positions**0.5)
+            patch_pos_embed = self.position_embedding.weight.reshape(
+                (1, sqrt_num_positions, sqrt_num_positions, self.embed_dim)
+            ).transpose((0, 3, 1, 2))
 
             batch_size, squence_len, channel, height, width = pixel_values.shape
             target_dtype = self.patch_embedding.weight.dtype
             pixel_values = pixel_values.reshape(batch_size * squence_len, channel, height, width)
-            patch_embeds = self.patch_embedding(pixel_values.to(dtype=target_dtype))  # shape = [*, width, grid, grid]
-            embeddings = patch_embeds.flatten(-2).squeeze(-1)
-            embeddings = embeddings.reshape(batch_size, squence_len, -1)
+            patch_embeds = self.patch_embedding(
+                pixel_values.astype(dtype=target_dtype)
+            )  # shape = [*, channel, grid, grid]
+            embeddings = patch_embeds.flatten(-3)
 
-            flatten_image_grid_thw = self.flatten_list(image_grid_thw)
-            assert sum([np.prod(x) for x in flatten_image_grid_thw]) == embeddings.shape[1], (
-                flatten_image_grid_thw,
-                embeddings.shape,
-            )
+            image_grid_thw = image_grid_thw.cpu().numpy()
+            split_lengths = image_grid_thw.prod(axis=1).tolist()
+            image_embeddings = paddle.split(embeddings, num_or_sections=split_lengths, axis=0)
 
-            start = 0
-            embeddings = embeddings.squeeze(0)
-            tmp_embeddings = list()
-            for image_grid in image_grid_thw:
-                t, h, w = image_grid
-                end = start + t * h * w
-                image_embeddings = embeddings[int(start) : int(end), :]
+            tmp_embeddings = []
+            for (t, h, w), image_embedding in zip(image_grid_thw, image_embeddings):
                 position_embedding = (
-                    self.interpolate_pos_encoding(image_embeddings, h, w, True).squeeze(0).tile((t, 1))
+                    nn.functional.interpolate(
+                        patch_pos_embed,
+                        size=(h, w),
+                        mode="bilinear",
+                        align_corners=False,
+                    )
+                    .flatten(-2)
+                    .squeeze(0)
+                    .T.tile([t, 1])
                 )
-                image_embeddings = image_embeddings + position_embedding
-                tmp_embeddings.append(image_embeddings)
-                start = end
+
+                tmp_embeddings.append(image_embedding + position_embedding)
             embeddings = paddle.concat(tmp_embeddings, axis=0).unsqueeze(0)
             return embeddings
         else:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization 

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->
稍稍重构一下 `PaddleOCRVisionEmbeddings`，提升运行速度，修改 Tensor slice 操作

```python
import paddle
import time
import paddle.nn as nn
import numpy as np
from typing import Optional, List, Union, Tuple
from dataclasses import dataclass


@dataclass
class PaddleOCRVisionConfig:
    hidden_size = 1152
    image_size = 384
    patch_size = 14
    num_channels = 3


class PaddleOCRVisionEmbeddings(nn.Layer):
    def __init__(self, config: PaddleOCRVisionConfig):
        super().__init__()
        self.config = config
        self.embed_dim = config.hidden_size  # 1152
        self.image_size = config.image_size  # 384
        self.patch_size = config.patch_size  # 14

        # Note：Paddle should use "VALID" or 0
        self.patch_embedding = nn.Conv2D(
            in_channels=config.num_channels,
            out_channels=self.embed_dim,
            kernel_size=self.patch_size,
            stride=self.patch_size,
            padding="VALID",
        )

        self.num_patches = (self.image_size // self.patch_size) ** 2  # 729
        self.num_positions = self.num_patches
        self.cache_position_embedding = dict()
        self.cache_position_count = dict()
        self.position_embedding = nn.Embedding(num_embeddings=self.num_positions, embedding_dim=self.embed_dim)

        self.register_buffer(
            "position_ids",
            paddle.arange(self.num_positions).unsqueeze(0),
            persistable=False,
        )

    def interpolate_pos_encoding(self, embeddings, height: int, width: int, is_after_patchify: bool = False):

        num_positions = self.position_embedding.weight.shape[0]
        patch_pos_embed = self.position_embedding.weight.unsqueeze(0)
        dim = embeddings.shape[-1]

        if is_after_patchify:
            new_height = height
            new_width = width
        else:
            new_height = height // self.patch_size
            new_width = width // self.patch_size

        sqrt_num_positions = paddle.to_tensor(num_positions**0.5, dtype=paddle.int64)
        patch_pos_embed = patch_pos_embed.reshape((1, sqrt_num_positions, sqrt_num_positions, dim))
        patch_pos_embed = patch_pos_embed.transpose((0, 3, 1, 2))

        patch_pos_embed = nn.functional.interpolate(
            patch_pos_embed,
            size=(new_height, new_width),
            mode="bilinear",
            align_corners=False,
        )

        patch_pos_embed = patch_pos_embed.transpose((0, 2, 3, 1)).reshape((1, -1, dim))
        return patch_pos_embed

    @staticmethod
    def flatten_list(image_grid_thw):
        tmp_image_grid_thw = list()
        for image_grid in image_grid_thw:
            if isinstance(image_grid, list):
                tmp_image_grid_thw.extend(image_grid)
            else:
                tmp_image_grid_thw.append(image_grid)
        return tmp_image_grid_thw

    def fetch_position_embedding_lfu_cache(self, embeddings, h, w, max_cache=20):
        grid = (h, w)
        if grid in self.cache_position_embedding:
            self.cache_position_count[grid] += 1
            return self.cache_position_embedding[grid]

        if len(self.cache_position_embedding) >= max_cache:
            min_hit_grid = min(self.cache_position_count, key=self.cache_position_count.get)
            self.cache_position_count.pop(min_hit_grid)
            self.cache_position_embedding.pop(min_hit_grid)

        position_embedding = self.interpolate_pos_encoding(embeddings, h, w, True)
        self.cache_position_count[grid] = 1
        self.cache_position_embedding[grid] = position_embedding
        return position_embedding

    def forward(
        self,
        pixel_values: paddle.Tensor,  # [B, L, C, H, W]
        position_ids: Optional[paddle.Tensor] = None,  # [B or 1, S]
        image_grid_thw: Optional[List[Union[Tuple[int, int, int], List[Tuple[int, int, int]]]]] = None,
        interpolate_pos_encoding: bool = False,
    ) -> paddle.Tensor:
        if pixel_values.dim() == 5:
            # assert position_ids is not None

            batch_size, squence_len, channel, height, width = pixel_values.shape
            target_dtype = self.patch_embedding.weight.dtype
            pixel_values = pixel_values.reshape(batch_size * squence_len, channel, height, width)
            patch_embeds = self.patch_embedding(pixel_values.to(dtype=target_dtype))  # shape = [*, width, grid, grid]
            embeddings = patch_embeds.flatten(-2).squeeze(-1)
            embeddings = embeddings.reshape(batch_size, squence_len, -1)

            flatten_image_grid_thw = self.flatten_list(image_grid_thw)
            assert sum([np.prod(x) for x in flatten_image_grid_thw]) == embeddings.shape[1], (
                flatten_image_grid_thw,
                embeddings.shape,
            )

            start = 0
            embeddings = embeddings.squeeze(0)
            tmp_embeddings = list()
            for image_grid in image_grid_thw:
                t, h, w = image_grid
                end = start + t * h * w
                image_embeddings = embeddings[int(start) : int(end), :]
                position_embedding = self.interpolate_pos_encoding(image_embeddings, h, w, True).squeeze(0).tile((t, 1))
                image_embeddings = image_embeddings + position_embedding
                tmp_embeddings.append(image_embeddings)
                start = end
            embeddings = paddle.concat(tmp_embeddings, axis=0).unsqueeze(0)
            return embeddings
        else:
            raise NotImplementedError(str(pixel_values.shape))


class PaddleOCRVisionEmbeddingsProMax(nn.Layer):
    def __init__(self, config: PaddleOCRVisionConfig):
        super().__init__()
        self.config = config
        self.embed_dim = config.hidden_size  # 1152
        self.image_size = config.image_size  # 384
        self.patch_size = config.patch_size  # 14

        # Note：Paddle should use "VALID" or 0
        self.patch_embedding = nn.Conv2D(
            in_channels=config.num_channels,
            out_channels=self.embed_dim,
            kernel_size=self.patch_size,
            stride=self.patch_size,
            padding="VALID",
        )

        self.num_patches = (self.image_size // self.patch_size) ** 2  # 729
        self.num_positions = self.num_patches
        self.cache_position_embedding = dict()
        self.cache_position_count = dict()
        self.position_embedding = nn.Embedding(num_embeddings=self.num_positions, embedding_dim=self.embed_dim)

        self.register_buffer(
            "position_ids",
            paddle.arange(self.num_positions).unsqueeze(0),
            persistable=False,
        )

    def forward(
        self,
        pixel_values: paddle.Tensor,  # [B, L, C, H, W]
        position_ids: Optional[paddle.Tensor] = None,  # [B or 1, S]
        image_grid_thw: Optional[List[Union[Tuple[int, int, int], List[Tuple[int, int, int]]]]] = None,
        interpolate_pos_encoding: bool = False,
    ) -> paddle.Tensor:
        if pixel_values.dim() == 5:
            # assert position_ids is not None
            sqrt_num_positions = int(self.num_positions**0.5)
            patch_pos_embed = self.position_embedding.weight.reshape(
                (1, sqrt_num_positions, sqrt_num_positions, self.embed_dim)
            ).transpose((0, 3, 1, 2))

            batch_size, squence_len, channel, height, width = pixel_values.shape
            target_dtype = self.patch_embedding.weight.dtype
            pixel_values = pixel_values.reshape(batch_size * squence_len, channel, height, width)
            patch_embeds = self.patch_embedding(
                pixel_values.astype(dtype=target_dtype)
            )  # shape = [*, channel, grid, grid]
            embeddings = patch_embeds.flatten(-3)

            image_grid_thw = image_grid_thw.cpu().numpy()
            split_lengths = image_grid_thw.prod(axis=1).tolist()
            image_embeddings = paddle.split(embeddings, num_or_sections=split_lengths, axis=0)

            tmp_embeddings = []
            for (t, h, w), image_embedding in zip(image_grid_thw, image_embeddings):
                position_embedding = (
                    nn.functional.interpolate(
                        patch_pos_embed,
                        size=(h, w),
                        mode="bilinear",
                        align_corners=False,
                    )
                    .flatten(-2)
                    .squeeze(0)
                    .T.tile([t, 1])
                )

                tmp_embeddings.append(image_embedding + position_embedding)
            embeddings = paddle.concat(tmp_embeddings, axis=0).unsqueeze(0)
            return embeddings
        else:
            raise NotImplementedError(str(pixel_values.shape))


import paddle
import time
import numpy as np


def tensor_diff(a: paddle.Tensor, b: paddle.Tensor, name: str):
    da = (a - b).abs()
    maxd = float(da.max())
    meand = float(da.mean())
    print(f"[DIFF] {name:30s}  max_abs={maxd:.6e}  mean_abs={meand:.6e}")


def grad_of(layer, attr="weight"):
    p = getattr(layer, attr)
    return p.grad


def zero_grads(model, x=None):
    model.clear_gradients()
    if x is not None and x.grad is not None:
        x.clear_gradient()


def run_fwd_bwd(model, pixel_values, image_grid_thw_tensor, iters=200, warmup=20):
    model.train()

    # warmup
    for _ in range(warmup):
        zero_grads(model, pixel_values)
        out = model(pixel_values, None, image_grid_thw_tensor)
        loss = (out * out).mean()  # 简单稳定的 loss
        loss.backward(retain_graph=True)

    # timed
    start = time.perf_counter()
    for _ in range(iters):
        zero_grads(model, pixel_values)
        out = model(pixel_values, None, image_grid_thw_tensor)
        loss = (out * out).mean()
        loss.backward(retain_graph=True)
    end = time.perf_counter()

    ms_per_iter = (end - start) * 1000 / iters
    return out, ms_per_iter


def run_fwd_only(model, pixel_values, image_grid_thw_tensor, iters=500, warmup=50):
    model.eval()

    # warmup
    for _ in range(warmup):
        out = model(pixel_values, None, image_grid_thw_tensor)

    start = time.perf_counter()
    for _ in range(iters):
        out = model(pixel_values, None, image_grid_thw_tensor)
    end = time.perf_counter()

    ms_per_iter = (end - start) * 1000 / iters
    return out, ms_per_iter


if __name__ == "__main__":
    paddle.seed(2026)
    np.random.seed(2026)

    # ---- 固定权重 ----
    patch_embedding_weight_np = np.random.rand(1152, 3, 14, 14).astype("float32")
    patch_embedding_bias_np = np.random.rand(1152).astype("float32")
    position_embedding_weight_np = np.random.rand(729, 1152).astype("float32")

    # ---- 输入（需要梯度的话 stop_gradient=False）----
    pixel_values = paddle.rand([1, 9408, 3, 14, 14], dtype="float32")
    pixel_values.stop_gradient = False  # 让我们也能对比 input grad（可选）

    image_grid_thw = [
        [1, 28, 40],
        [1, 28, 36],
        [1, 20, 40],
        [1, 28, 60],
        [1, 12, 100],
        [1, 34, 40],
        [1, 16, 52],
        [1, 32, 44],
    ]
    image_grid_thw_tensor = paddle.to_tensor(image_grid_thw, dtype="int64")

    # ========= Model A =========
    model_a = PaddleOCRVisionEmbeddings(PaddleOCRVisionConfig())
    with paddle.no_grad():
        model_a.patch_embedding.weight.set_value(patch_embedding_weight_np)
        model_a.patch_embedding.bias.set_value(patch_embedding_bias_np)
        model_a.position_embedding.weight.set_value(position_embedding_weight_np)

    # ========= Model B =========
    model_b = PaddleOCRVisionEmbeddingsProMax(PaddleOCRVisionConfig())
    with paddle.no_grad():
        model_b.patch_embedding.weight.set_value(patch_embedding_weight_np)
        model_b.patch_embedding.bias.set_value(patch_embedding_bias_np)
        model_b.position_embedding.weight.set_value(position_embedding_weight_np)

    # ---- Forward-only timing ----
    out_a_f, fwd_ms_a = run_fwd_only(model_a, pixel_values, image_grid_thw_tensor, iters=300, warmup=50)
    out_b_f, fwd_ms_b = run_fwd_only(model_b, pixel_values, image_grid_thw_tensor, iters=300, warmup=50)

    print(f"\n[FWD]  A ms/iter={fwd_ms_a:.4f}   B ms/iter={fwd_ms_b:.4f}   speedup={fwd_ms_a/fwd_ms_b:.2f}x")
    tensor_diff(out_a_f, out_b_f, "output (forward-only)")

    # ---- Forward+Backward timing + grads ----
    # 注意：为了公平，对两边都用“新的”输入张量，避免梯度/状态干扰
    pixel_a = pixel_values.clone()
    pixel_a.stop_gradient = False
    pixel_b = pixel_values.clone()
    pixel_b.stop_gradient = False

    out_a, bwd_ms_a = run_fwd_bwd(model_a, pixel_a, image_grid_thw_tensor, iters=100, warmup=20)
    # 把梯度拎出来保存（反向后 grad 会留在参数上）
    ga_w = model_a.patch_embedding.weight.grad.clone()
    ga_b = model_a.patch_embedding.bias.grad.clone()
    ga_p = model_a.position_embedding.weight.grad.clone()
    ga_x = pixel_a.grad.clone() if pixel_a.grad is not None else None

    out_b, bwd_ms_b = run_fwd_bwd(model_b, pixel_b, image_grid_thw_tensor, iters=100, warmup=20)
    gb_w = model_b.patch_embedding.weight.grad.clone()
    gb_b = model_b.patch_embedding.bias.grad.clone()
    gb_p = model_b.position_embedding.weight.grad.clone()
    gb_x = pixel_b.grad.clone() if pixel_b.grad is not None else None

    print(f"\n[FWD+BWD] A ms/iter={bwd_ms_a:.4f}   B ms/iter={bwd_ms_b:.4f}   speedup={bwd_ms_a/bwd_ms_b:.2f}x")

    # ---- 精度对比：输出 + 梯度 ----
    tensor_diff(out_a, out_b, "output (after bwd run)")

    tensor_diff(ga_w, gb_w, "grad patch_embedding.weight")
    tensor_diff(ga_b, gb_b, "grad patch_embedding.bias")
    tensor_diff(ga_p, gb_p, "grad position_embedding.weight")

    if ga_x is not None and gb_x is not None:
        tensor_diff(ga_x, gb_x, "grad pixel_values (optional)")

    # 如果你还想要“严格一致断言”，建议用 allclose 而不是 ==
    a_np = out_a.numpy()
    b_np = out_b.numpy()
    print("\nallclose(out_a, out_b) =", np.allclose(a_np, b_np, rtol=1e-6, atol=1e-6))
```

测试结果比对，前向反向都对上了，前向加速比为 2.40x，前向+反向加速比为 1.21x
```
[FWD]  A ms/iter=4.5840   B ms/iter=1.9094   speedup=2.40x
[DIFF] output (forward-only)           max_abs=0.000000e+00  mean_abs=0.000000e+00

[FWD+BWD] A ms/iter=18.3944   B ms/iter=15.2365   speedup=1.21x
[DIFF] output (after bwd run)          max_abs=0.000000e+00  mean_abs=0.000000e+00
[DIFF] grad patch_embedding.weight     max_abs=0.000000e+00  mean_abs=0.000000e+00
[DIFF] grad patch_embedding.bias       max_abs=0.000000e+00  mean_abs=0.000000e+00
[DIFF] grad position_embedding.weight  max_abs=8.731149e-11  mean_abs=3.158938e-12

allclose(out_a, out_b) = True
```