### PR TITLE
Remove NumPy dependency for position_ids generation (PaddleOCREncoder)

### DIFF
--- a/paddleformers/transformers/paddleocr_vl/modeling.py
+++ b/paddleformers/transformers/paddleocr_vl/modeling.py
@@ -413,6 +413,34 @@ class PaddleOCREncoder(nn.Layer):
                 tmp_image_grid_thw.append(image_grid)
         return tmp_image_grid_thw
 
+    @staticmethod
+    def get_position_ids_vectorized(image_grid_thw):
+
+        t = image_grid_thw[:, 0]
+        h = image_grid_thw[:, 1]
+        w = image_grid_thw[:, 2]
+
+        hw = h * w
+        lengths = t * hw  # [N]
+        ends = paddle.cumsum(lengths)  # [N]
+        starts = ends - lengths  # [N]
+        total_len = ends[-1]
+
+        global_pids = paddle.arange(total_len, dtype="int64")
+        sample_ids = paddle.searchsorted(ends, global_pids, right=True)
+
+        start_g = paddle.gather(starts, sample_ids)  # [total_len]
+        w_g = paddle.gather(w, sample_ids)  # [total_len]
+        hw_g = paddle.gather(hw, sample_ids)  # [total_len]
+
+        local_pids = global_pids - start_g
+        rel_pids = local_pids % hw_g
+
+        width_position_ids = rel_pids % w_g
+        height_position_ids = rel_pids // w_g
+
+        return width_position_ids, height_position_ids
+
     def build_window_index(self, image_grid, window_size):
         """
         返回：
@@ -521,17 +549,7 @@ class PaddleOCREncoder(nn.Layer):
             )
 
             if width_position_ids is None or height_position_ids is None:
-                split_hids = list()
-                split_wids = list()
-                for t, h, w in flatten_image_grid_thw:
-                    t, h, w = map(int, (t, h, w))
-                    image_pids = paddle.arange(t * h * w) % (h * w)
-                    sample_hids = image_pids // w
-                    sample_wids = image_pids % w
-                    split_hids.append(sample_hids)
-                    split_wids.append(sample_wids)
-                width_position_ids = paddle.concat(split_wids, axis=0)
-                height_position_ids = paddle.concat(split_hids, axis=0)
+                width_position_ids, height_position_ids = self.get_position_ids_vectorized(image_grid_thw)
 
             window_indices, cu_seqlens_within_windows = None, None
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->

同 #3840，看 timeline 的时候发现了这个漏网之鱼

https://github.com/PaddlePaddle/PaddleFormers/blob/e223e2be2efd3e1acbdc0efcbd0c726c93f04293/paddleformers/transformers/paddleocr_vl/modeling.py#L524-L534

<img width="840" height="426" alt="image" src="https://github.com/user-attachments/assets/232e06a7-7713-4754-b598-a80f910bb1e9" />
<br/>

<img width="1036" height="427" alt="image" src="https://github.com/user-attachments/assets/a07e7575-c277-4be8-b07f-2c12c6df50fe" />


优化后单 step 平均降低 2ms

<img width="1143" height="455" alt="image" src="https://github.com/user-attachments/assets/07f13583-a0fc-49cc-8f1f-4aef388cc47a" />

测试代码：

```python
import paddle
import time
import random
import paddle.nn.functional as F


# --- 1. 原始 Loop 版本 ---
def get_position_ids_loop(image_grid_thw):
    split_hids = list()
    split_wids = list()

    for t, h, w in image_grid_thw:
        t, h, w = map(int, (t, h, w))
        image_pids = paddle.arange(t * h * w) % (h * w)
        sample_hids = image_pids // w
        sample_wids = image_pids % w
        split_hids.append(sample_hids)
        split_wids.append(sample_wids)

    width_position_ids = paddle.concat(split_wids, axis=0)
    height_position_ids = paddle.concat(split_hids, axis=0)

    return width_position_ids, height_position_ids


def get_position_ids_vectorized(image_grid_thw):

    t = image_grid_thw[:, 0]
    h = image_grid_thw[:, 1]
    w = image_grid_thw[:, 2]

    hw = h * w
    lengths = t * hw  # [N]
    ends = paddle.cumsum(lengths)  # [N]
    starts = ends - lengths  # [N]
    total_len = ends[-1]

    global_pids = paddle.arange(total_len, dtype="int64")
    sample_ids = paddle.searchsorted(ends, global_pids, right=True)

    # gather 每个位置对应 sample 的参数
    start_g = paddle.gather(starts, sample_ids)  # [total_len]
    w_g = paddle.gather(w, sample_ids)  # [total_len]
    hw_g = paddle.gather(hw, sample_ids)  # [total_len]

    local_pids = global_pids - start_g
    rel_pids = local_pids % hw_g

    width_position_ids = rel_pids % w_g
    height_position_ids = rel_pids // w_g

    return width_position_ids, height_position_ids


# --- 3. 辅助函数: 计时与验证 ---
def benchmark(name, func, data, iterations=10):
    # 预热 (Warm-up)
    for _ in range(3):
        _ = func(data)
    if paddle.device.is_compiled_with_cuda():
        paddle.device.cuda.synchronize()

    start_time = time.time()
    for _ in range(iterations):
        _ = func(data)
        # 如果在 GPU 上，必须同步等待计算完成才能测准时间
        if paddle.device.is_compiled_with_cuda():
            paddle.device.cuda.synchronize()
    end_time = time.time()

    avg_time = (end_time - start_time) / iterations * 1000  # 转换为毫秒
    print(f"[{name}] 平均耗时: {avg_time:.4f} ms")
    return avg_time


if __name__ == "__main__":

    small_data = paddle.to_tensor(
        [[1, 4, 5], [1, 14, 5], [1, 4, 15], [1, 24, 5], [1, 4, 25], [1, 24, 25]], dtype="int64"
    )

    w1, h1 = get_position_ids_loop(small_data)
    w2, h2 = get_position_ids_vectorized(small_data)

    assert paddle.allclose(w1, w2), "Width 结果不一致!"
    assert paddle.allclose(h1, h2), "Height 结果不一致!"
    print(">>> 正确性验证通过 ✅\n")

    # --- 性能压力测试 ---
    # 模拟真实场景：Batch Size = 6，各种尺寸的图片混在一起
    # 我们生成 128 个随机的 T, H, W 组合
    N = 5
    ts = [1] * N
    hs = [random.randint(10, 50) for _ in range(N)]
    ws = [random.randint(10, 50) for _ in range(N)]
    large_data_list = [[t, h, w] for t, h, w in zip(ts, hs, ws)]
    large_data_tensor = paddle.to_tensor(large_data_list, dtype="int64")

    print(f"开始性能测试 (Batch Size = {N}, Iterations = 20)...")

    # 测试 Loop 版本
    time_loop = benchmark("Loop Version", get_position_ids_loop, large_data_tensor, iterations=20)

    # 测试 Vectorized 版本
    time_vec = benchmark("Vectorized Version", get_position_ids_vectorized, large_data_tensor, iterations=20)

    # 总结
    speedup = time_loop / time_vec
    print(f"\n>>> 结论: 向量化版本比循环版本快 {speedup:.2f} 倍 🚀")

```


```
>>> 正确性验证通过 ✅

开始性能测试 (Batch Size = 5, Iterations = 20)...
[Loop Version] 平均耗时: 1.0164 ms
[Vectorized Version] 平均耗时: 0.1778 ms

>>> 结论: 向量化版本比循环版本快 5.72 倍 🚀
```

后续转静的话，速度会更快