### PR TITLE
[fix(datasets)]: fix missing return in mm_plugin

### DIFF
--- a/paddleformers/datasets/SFTDataset.py
+++ b/paddleformers/datasets/SFTDataset.py
@@ -342,9 +342,9 @@ class SFTDataSet(IterableDataset):
             while True:
                 yield from self.__iter_func()
 
-    def _encode_pretraining_example(self, example, actual_example_num):
+    def _encode_pretraining_messages(self, messages, actual_example_num):
         # tokens
-        content = example["messages"][0]["content"]
+        content = messages[0]["content"]
         tokens = self.tokenizer.convert_tokens_to_ids(self.tokenizer.tokenize(content))
         # Add an EOS token at the end of each sample
         tokens = tokens + [self.tokenizer.eos_token_id]
@@ -358,7 +358,7 @@ class SFTDataSet(IterableDataset):
         audios = example.get("audios", [])
 
         if len(images) == 0 and len(videos) == 0 and len(audios) == 0:
-            tokens = self._encode_pretraining_example(example, actual_example_num)
+            tokens = self._encode_pretraining_messages(messages, actual_example_num)
             if len(tokens) > self.max_seq_len + 1:
                 # Truncate the sequence to the maximum length
                 tokens = tokens[: self.max_seq_len + 1]
@@ -436,14 +436,6 @@ class SFTDataSet(IterableDataset):
                 audios=audios,
                 mm_inputs=mm_inputs,
             )
-
-    def _encode_pretraining_messages(self, messages, actual_example_num):
-        # tokens
-        content = messages[0]["content"]
-        tokens = self.tokenizer.convert_tokens_to_ids(self.tokenizer.tokenize(content))
-        # Add an EOS token at the end of each sample
-        tokens = tokens + [self.tokenizer.eos_token_id]
-        return tokens
 
     def _postprocess_sequence(self, example, actual_example_num):
         """Process code completion examples into token sequences.

--- a/paddleformers/datasets/template/mm_plugin.py
+++ b/paddleformers/datasets/template/mm_plugin.py
@@ -338,6 +338,8 @@ class BasePlugin(MMPluginMixin):
                 if token in masked_tokens_ids:
                     labels[i] = -100
 
+        return labels
+
     def get_mm_inputs(
         self,
         images,


### PR DESCRIPTION
…raining encoder

<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
1. mm_plugin.py: Add missing `return labels` statement in BasePlugin method to ensure labels are properly returned after masking.

2. SFTDataset.py: 
   - Rename `_encode_pretraining_example` to `_encode_pretraining_messages` with updated parameter signature (accept `messages` directly instead of `example`).
   - Remove duplicate `_encode_pretraining_messages` method definition to eliminate redundant code.