### PR TITLE
[Opt] Optimize image embeddings insertion by replacing masked_scatter with boolean indexing

### DIFF
--- a/paddleformers/transformers/paddleocr_vl/modeling.py
+++ b/paddleformers/transformers/paddleocr_vl/modeling.py
@@ -2005,21 +2005,8 @@ class PaddleOCRVLForConditionalGeneration(Ernie4_5PretrainedModel, GenerationMix
                 split_sections = image_grid_thw.prod(axis=1).cpu().numpy().tolist()
                 image_embeds = self.mlp_AR(image_embeds, image_grid_thw, split_sections)
 
-                n_image_tokens = (input_ids == self.config.image_token_id).sum().item()
-                n_image_features = image_embeds.shape[0]
-                if n_image_tokens != n_image_features:
-                    raise ValueError(
-                        f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
-                    )
-
                 mask = input_ids == self.config.image_token_id
-                mask_unsqueezed = mask.unsqueeze(-1)
-                mask_expanded = mask_unsqueezed.expand_as(inputs_embeds)
-                image_mask = mask_expanded
-
-                image_embeds = image_embeds.astype(inputs_embeds.dtype)
-
-                inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
+                inputs_embeds[mask] = image_embeds
 
         if attention_mask is not None and attention_mask.dtype != paddle.bool:
             attention_mask = paddle.cast(attention_mask, paddle.bool)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->

两处改动：

1. 由于 `.item()` 含有隐式的 D2H 操作，所以删掉此处的 DEBUG 代码

https://github.com/PaddlePaddle/PaddleFormers/blob/395f2e4a88cd9427d605a4649e1424aca8e6346a/paddleformers/transformers/paddleocr_vl/modeling.py#L2008-L2013

2. `masked_scatter` 的实现过于低效（具体可参考issue: [Paddle#78052](https://github.com/PaddlePaddle/Paddle/issues/78052)），这里直接用索引操作代替

https://github.com/PaddlePaddle/PaddleFormers/blob/395f2e4a88cd9427d605a4649e1424aca8e6346a/paddleformers/transformers/paddleocr_vl/modeling.py#L2016-L2022

`masked_scatter` 在反向过程中引入一个很大的空泡和 MEMCPY H2D

<img width="1337" height="438" alt="image" src="https://github.com/user-attachments/assets/ce906e01-e244-4a6e-8778-f28add5eadc1" />

修改完毕后，空泡消失，反向处于打满的状态：

<img width="1417" height="420" alt="image" src="https://github.com/user-attachments/assets/8f3ce00e-56df-454c-8639-0c9acb943ce2" />
