### PR TITLE
[Perf] Disable `preserve_external_rng_state` in recompute for better performance

### DIFF
--- a/paddleformers/transformers/paddleocr_vl/modeling.py
+++ b/paddleformers/transformers/paddleocr_vl/modeling.py
@@ -515,6 +515,7 @@ class PaddleOCREncoder(nn.Layer):
             cu_seqlens=cu_seqlens,
             attn_mask_startend_row_indices=attn_mask_startend_row_indices,
             rope_emb=rope_emb,
+            preserve_external_rng_state=False,
         )
         return hidden_states
 
@@ -1481,6 +1482,7 @@ class Ernie4_5Model(Ernie4_5PretrainedModel):
             output_attentions,
             past_key_values,
             use_cache,
+            preserve_external_rng_state=False,
         )
         return hidden_states
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what this PR does -->

在当前的 Transformer 层重计算逻辑中，默认可能会保存和恢复外部的随机数生成器（RNG）状态（例如 `numpy.random` 或 Python 原生的 `random`）。

由于在这些 `layer` 的前向传播中，通常只依赖框架原生的随机操作（如 Dropout，由 `preserve_rng_state` 控制），保存外部 RNG 状态不仅没有必要，还会带来额外的 CPU 状态读取/设置开销，影响训练吞吐量。

因此，在调用 `recompute` 时，显式地传入 `preserve_external_rng_state=False`。减少了重计算（Backward pass）期间不必要的状态保存和恢复开销。

Paddle 框架侧改动：https://github.com/PaddlePaddle/Paddle/pull/77899 ，要等该PR先合入