### PR TITLE
[Perf] Refactor vision position embedding construction with preallocation and caching

### DIFF
--- a/paddleformers/nn/norm.py
+++ b/paddleformers/nn/norm.py
@@ -50,6 +50,7 @@ class LayerNorm(nn.LayerNorm):
             mark_as_sequence_parallel_parameter(self.bias)
 
 
+@paddle.jit.marker.unified
 class RMSNorm(nn.Layer):
     def __init__(self, config: PretrainedConfig, hidden_size=None, norm_eps=None, input_is_parallel=False, **kwargs):
         super().__init__()
@@ -65,7 +66,6 @@ class RMSNorm(nn.Layer):
         if input_is_parallel:
             self.enable_sequence_parallel()
 
-    @paddle.jit.marker.unified
     def forward(self, hidden_states):
         current_device = detect_device()
         if self.config.get("fuse_rms_norm", True) and current_device != "iluvatar_gpu":

--- a/paddleformers/transformers/paddleocr_vl/modeling.py
+++ b/paddleformers/transformers/paddleocr_vl/modeling.py
@@ -226,8 +226,6 @@ class PaddleOCRVisionEmbeddings(nn.Layer):
 
         self.num_patches = (self.image_size // self.patch_size) ** 2  # 729
         self.num_positions = self.num_patches
-        self.cache_position_embedding = dict()
-        self.cache_position_count = dict()
         self.position_embedding = GeneralEmbedding.create(
             config=config, num_embeddings=self.num_positions, embedding_dim=self.embed_dim
         )
@@ -258,29 +256,33 @@ class PaddleOCRVisionEmbeddings(nn.Layer):
             patch_embeds = self.patch_embedding(
                 pixel_values.astype(dtype=target_dtype)
             )  # shape = [*, channel, grid, grid]
-            embeddings = patch_embeds.flatten(-3)
+            patch_embeds = patch_embeds.flatten(-3)
+            position_embeddings = paddle.empty_like(patch_embeds)
 
-            image_grid_thw = image_grid_thw.cpu().numpy()
-            split_lengths = image_grid_thw.prod(axis=1).tolist()
-            image_embeddings = paddle.split(embeddings, num_or_sections=split_lengths, axis=0)
-
-            tmp_embeddings = []
-            for (t, h, w), image_embedding in zip(image_grid_thw, image_embeddings):
-                position_embedding = (
-                    nn.functional.interpolate(
-                        patch_pos_embed,
-                        size=(h, w),
-                        mode="bilinear",
-                        align_corners=False,
+            intra_batch_cache = {}
+            start = 0
+            for t, h, w in image_grid_thw.tolist():
+                hw = (h, w)
+                if hw not in intra_batch_cache:
+                    position_embedding = (
+                        nn.functional.interpolate(
+                            patch_pos_embed,
+                            size=hw,
+                            mode="bilinear",
+                            align_corners=False,
+                        )
+                        .flatten(-2)
+                        .squeeze(0)
+                        .T
                     )
-                    .flatten(-2)
-                    .squeeze(0)
-                    .T.tile([t, 1])
+                    intra_batch_cache[hw] = position_embedding
+                end = start + t * h * w
+                position_embeddings[start:end] = (
+                    intra_batch_cache[hw] if t == 1 else intra_batch_cache[hw].tile([t, 1])
                 )
-
-                tmp_embeddings.append(image_embedding + position_embedding)
-            embeddings = paddle.concat(tmp_embeddings, axis=0).unsqueeze(0)
-            return embeddings
+                start = end
+            embeddings = position_embeddings + patch_embeds
+            return embeddings.unsqueeze(0)
         else:
             raise NotImplementedError(str(pixel_values.shape))
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->

使用预分配 buffer + 切片写入替代 split + concat（之后类似的都可以用 empty 替代 concat），并增加 intra-batch 插值缓存以避免重复 interpolate。
在 bs=64 场景下约可缓存 1/4 插值结果，提升 forward 性能并降低显存占用。数值结果保持一致。

原 timeline，大概 13.8 ms

<img width="1090" height="593" alt="image" src="https://github.com/user-attachments/assets/e93f7f20-ee6c-4322-a702-139bab8a9dd9" />


优化后，大概 11.6ms，提升15.9%

<img width="1067" height="557" alt="image" src="https://github.com/user-attachments/assets/de09aed0-0749-4f68-856c-965491f4ef13" />



