### PR TITLE
[Perf] Fix `F.interpolate` output dtype under AMP for PaddleOCR-VL vision embeddings

### DIFF
--- a/paddleformers/transformers/paddleocr_vl/modeling.py
+++ b/paddleformers/transformers/paddleocr_vl/modeling.py
@@ -273,7 +273,7 @@ class PaddleOCRVisionEmbeddings(nn.Layer):
                         )
                         .flatten(-2)
                         .squeeze(0)
-                        .T
+                        .T.astype(target_dtype)
                     )
                     intra_batch_cache[hw] = position_embedding
                 end = start + t * h * w


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization 

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->

在 AMP (Automatic Mixed Precision) 环境下，框架并非对所有算子都会主动进行类型检查和转换。算子的类型流转遵循“白、黑、灰”名单机制：

* **黑名单算子**（如 `bilinear_interp_v2 `）：出于数值稳定性考虑，强制将数据提升并输出为 `fp32`。
* **灰名单算子**（如 `add`, `ReLU` 等元素级操作）：遵循“随波逐流”原则，输出类型与输入保持一致。若输入含有 `fp32`（或 `bf16`+`fp32`），则输出必然为 `fp32`，不会主动降级。
* **白名单算子**（如 `conv2d`, `matmul`）：计算密集型的主力军，遇到时才会强制将输入截断回 `bf16`/`fp16` 执行。

由于 `bilinear_interp_v2` 位于 Paddle 主框架的 `EXTRA_BLACK_LIST` ([amp_lists.py](https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/amp/amp_lists.py)) 中，作为黑名单算子，它会强制输出 `float32`。

这导致如下的 `position_embedding` 返回值精度为 `float32`，未能遵循配置中指定的 `bf16` 精度。
https://github.com/PaddlePaddle/PaddleFormers/blob/350749f7f0b8eebd500328b724578c05aba7de6a/paddleformers/transformers/paddleocr_vl/modeling.py#L266-L273

导致后续灰名单算子的随波逐流效应：带有 `fp32` 的输入直接将后续 `PaddleOCREncoderLayer` 中的运算部分拉回 `fp32`。这不仅导致核心计算在低效的 `fp32` 下运行，还引发了大量冗余的 `fp32 <-> bf16` Cast 转换。

---

因此，在插值计算之后，手动转化一下数据类型即可。

这是之前版本的 timeline，LayerNorm 计算精度是 fp32，且LN之后有 cast 
<img width="1612" height="304" alt="image" src="https://github.com/user-attachments/assets/8df7000a-643d-4d39-ae28-769c58e23ef6" />

这是修改之后的 timeline，LayerNorm 计算精度是 bf16，且LN之后无 cast 
<img width="1389" height="428" alt="image" src="https://github.com/user-attachments/assets/da40bd97-ebeb-44ea-ba72-e0cf8cad5b59" />


以下 Timeline 耗时对比基于 **单 step 的 PaddleOCREncoder**：

1. 减少冗余的类型转换 (Cast Kernels) **降低约 27.7 ms**

修复后减少了 `float32` 和 `bfloat16` 之间的来回转换

* **旧版 Cast 总耗时**：约 45.8 ms，共计 **378 次**调用（162次 `bf16->fp32` + 216次 `fp32->bf16`）。
* **新版 Cast 总耗时**：约 18.1 ms，共计 **108 次**调用（54次 `bf16->fp32` + 54次 `fp32->bf16`）。

2. Broadcast Add 算子拆分与降级 **降低约 9.3 ms**

消除了全局强制的 `fp32` 广播加法，降低了内存带宽压力

* **旧版**：**108次** `AddFunctor<float>`，耗时 35.705 ms。
* **新版**：拆分为 **54次** `AddFunctor<float>` (17.597 ms) + **54次** `AddFunctor<bfloat16>` (8.725 ms)，总耗时降至 26.322 ms。

3. LayerNorm 精度优化 **降低约2.0 ms**

核心计算和输入输出类型恢复至预期的 `bfloat16`。避免了 LayerNorm 前后的数据类型强转，这也是上面 Cast 耗时大幅下降的核心原因。

* **旧版**：**54次** `LayerNormForward<float, float...>`，耗时 32.420 ms (均值 600 μs)。
* **新版**：**54次** `LayerNormForward<phi::dtype::bfloat16, float...>`，耗时 30.413 ms (均值 563 μs)。