### PR TITLE
[export]fix _gen_aoa_config bug for vl model

### DIFF
--- a/paddleformers/mergekit/merge_model.py
+++ b/paddleformers/mergekit/merge_model.py
@@ -28,7 +28,7 @@ from tqdm.auto import tqdm
 
 from ..peft import LoRAConfig
 from ..quantization.quantization_utils import convert_to_quantize_dequantize_state_dict
-from ..transformers import PretrainedConfig
+from ..transformers import AutoConfig, PretrainedConfig
 from ..transformers.auto.modeling import get_name_mapping
 from ..transformers.configuration_utils import QuantizationConfig
 from ..transformers.conversion_utils import ConversionMixin
@@ -695,7 +695,7 @@ class MergeModel:
 
         # get transpose_weight_keys
         if self.merge_config.convert_from_hf:
-            base_model_config = PretrainedConfig.from_pretrained(self.merge_config.base_model_path)
+            base_model_config = AutoConfig.from_pretrained(self.merge_config.base_model_path)
             name_mapping = get_name_mapping()
             model_class_name = None
             for key, value in name_mapping.items():


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
原代码将获取的PretrainedConfig类的base_model_config传入_gen_aoa_config，导致报错：
```
f"{llm_prefix)layers, SLAYER_ID, self atn, q_proj,weightT, {lm prefix}layers, SLAYER ID.self attn, proj, weightT, (llm_prefix)}layers. LAVER_ID.self_atn, proj,weight"T> {llm prefix}laye
rs. SLAYER ID. self_attn. qkv proj. weight, fused_okv, num_heads={config.text_config. num attention heads}, num key_ value groups={config.text conig.num key_ value_ heads}",
AttributeError: 'dict' object has no attribute 'num_attention_heads'
```