### PR TITLE
update benchmark_yaml

### DIFF
--- a/tests/config/benchmark/config/pt/Qwen3-30B-A3B-Base.yaml
+++ b/tests/config/benchmark/config/pt/Qwen3-30B-A3B-Base.yaml
@@ -79,6 +79,7 @@ moe_grouped_gemm: true
 moe_ep_barrier: false
 moe_router_fusion: true
 moe_router_force_load_balancing: false
+router_aux_loss_coef: 0.0
 
 # pp
 pp_delay_scale_loss: true

--- a/tests/config/benchmark/config/sft/Qwen3-30B-A3B-Base.yaml
+++ b/tests/config/benchmark/config/sft/Qwen3-30B-A3B-Base.yaml
@@ -79,6 +79,7 @@ moe_grouped_gemm: true
 moe_ep_barrier: false
 moe_router_fusion: true
 moe_router_force_load_balancing: false
+router_aux_loss_coef: 0.0
 
 # pp
 pp_delay_scale_loss: true


### PR DESCRIPTION
改动：
Merged in dev: #3969 
给qwen3的benchmark yaml固定 router_aux_loss_coef，避免从config文件里读入