### PR TITLE
[release/1.1] Fix(training): Fallback to slow processor for VL models with num_workers > 0

### DIFF
--- a/paddleformers/cli/train/dpo/workflow.py
+++ b/paddleformers/cli/train/dpo/workflow.py
@@ -218,6 +218,16 @@ def run_dpo(
     if tokenizer.pad_token_id is None:
         tokenizer.pad_token_id = tokenizer.eos_token_id
 
+    if "VL" in model_args.stage and training_args.dataloader_num_workers > 0:
+        data_args.processor_use_fast = False
+        logger.warning_once(
+            f"Detected dataloader_num_workers={training_args.dataloader_num_workers} (>0). "
+            "Since the CPU version of the 'interpolate' operator is currently unsupported, "
+            "some models may use a fast image processor which can cause errors in dataloader workers. "
+            "Temporarily fallback to the slow image processor (`use_fast=False`) by default to avoid potential issues. "
+            "You can also explicitly set `processor_use_fast=False` or `dataloader_num_workers=0` to avoid this warning."
+        )
+
     processor = AutoProcessor.from_pretrained(model_args.model_name_or_path, use_fast=data_args.processor_use_fast)
 
     logger.info("Loading model & tokenizer successfully !")

--- a/paddleformers/cli/train/sft/workflow.py
+++ b/paddleformers/cli/train/sft/workflow.py
@@ -352,6 +352,16 @@ def run_sft(
     if isinstance(tokenizer, LlamaTokenizer) or isinstance(tokenizer, Llama3Tokenizer):
         tokenizer.pad_token_id = tokenizer.eos_token_id
 
+    if "VL" in model_args.stage and training_args.dataloader_num_workers > 0:
+        data_args.processor_use_fast = False
+        logger.warning_once(
+            f"Detected dataloader_num_workers={training_args.dataloader_num_workers} (>0). "
+            "Since the CPU version of the 'interpolate' operator is currently unsupported, "
+            "some models may use a fast image processor which can cause errors in dataloader workers. "
+            "Temporarily fallback to the slow image processor (`use_fast=False`) by default to avoid potential issues. "
+            "You can also explicitly set `processor_use_fast=False` or `dataloader_num_workers=0` to avoid this warning."
+        )
+
     processor = AutoProcessor.from_pretrained(model_args.model_name_or_path, use_fast=data_args.processor_use_fast)
 
     dataset_config = {


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
新增多模训练`dataloader_num_workers > 0`时回退Image Processor(slow)，避免因`interpolate`算子不支持CPU运算导致部分错误

Cherry-pick of #3966 to `release/1.1`.

Merged in dev: #3966  <!-- For pass CI -->