### PR TITLE
[Perf]: Optimize PaddleOCR-VL vision encoder preprocessing (3.3ms → 2.1ms)

### DIFF
--- a/paddleformers/transformers/paddleocr_vl/modeling.py
+++ b/paddleformers/transformers/paddleocr_vl/modeling.py
@@ -422,7 +422,7 @@ class PaddleOCREncoder(nn.Layer):
         return tmp_image_grid_thw
 
     @staticmethod
-    def get_position_ids_vectorized(image_grid_thw):
+    def get_position_ids_vectorized(image_grid_thw, dtype="int64"):
 
         t = image_grid_thw[:, 0]
         h = image_grid_thw[:, 1]
@@ -430,11 +430,11 @@ class PaddleOCREncoder(nn.Layer):
 
         hw = h * w
         lengths = t * hw  # [N]
-        ends = paddle.cumsum(lengths)  # [N]
+        ends = paddle.cumsum(lengths, dtype=dtype)  # [N]
         starts = ends - lengths  # [N]
         total_len = ends[-1]
 
-        global_pids = paddle.arange(total_len, dtype="int64")
+        global_pids = paddle.arange(total_len, dtype=dtype)
         sample_ids = paddle.searchsorted(ends, global_pids, right=True)
 
         start_g = paddle.gather(starts, sample_ids)  # [total_len]
@@ -550,58 +550,45 @@ class PaddleOCREncoder(nn.Layer):
         hidden_states = inputs_embeds
         attention_mask = attention_mask.to(inputs_embeds.dtype) if attention_mask is not None else None
 
-        if use_rope:
-            flatten_image_grid_thw = self.flatten_list(image_grid_thw)
-
-            if width_position_ids is None or height_position_ids is None:
-                width_position_ids, height_position_ids = self.get_position_ids_vectorized(image_grid_thw)
-
-            window_indices, cu_seqlens_within_windows = None, None
-
-            if use_window_attn:
-                window_indices, cu_seqlens_within_windows = self.build_window_index(
-                    flatten_image_grid_thw, window_size
-                )
-                reversed_window_indices = window_indices.argsort()
-                height_position_ids = height_position_ids[window_indices]
-                width_position_ids = width_position_ids[window_indices]
-
-            pids = paddle.stack([height_position_ids, width_position_ids], axis=-1).astype(paddle.int64)
-            max_grid_size = pids.max() + 1
-            rope_emb_max_grid = self.rotary_pos_emb(max_grid_size)
-
-            rope_emb = rope_emb_max_grid[pids].flatten(1)
-
-            rope_emb = rope_emb.tile((1, 2))
-            rope_emb = (rope_emb.cos(), rope_emb.sin())
-
-        else:
-            rope_emb = None
-
-            window_indices, cu_seqlens_within_windows = None, None
-
-            if use_window_attn:
-                flatten_image_grid_thw = self.flatten_list(image_grid_thw)
-                window_indices, cu_seqlens_within_windows = self.build_window_index(
-                    flatten_image_grid_thw, window_size
-                )
-                reversed_window_indices = window_indices.argsort()
-
+        window_indices = None
         if use_window_attn:
-            assert cu_seqlens_within_windows is not None
+            flatten_image_grid_thw = self.flatten_list(image_grid_thw)
+            window_indices, cu_seqlens_within_windows = self.build_window_index(flatten_image_grid_thw, window_size)
+            assert cu_seqlens_within_windows
+            reversed_window_indices = window_indices.argsort()
             attn_cu_seqlens = cu_seqlens_within_windows
             hidden_states = hidden_states[:, window_indices, :]
         else:
             attn_cu_seqlens = cu_seqlens
 
-        if cu_seqlens is not None and attention_mask is None:
-            cu_seqlens_rm_first = cu_seqlens[1:]
-            cu_seqlens_rm_last = cu_seqlens[:-1]
-            repeats = cu_seqlens_rm_first - cu_seqlens_rm_last
+        rope_emb = None
+        if use_rope:
+            if width_position_ids is None or height_position_ids is None:
+                width_position_ids, height_position_ids = self.get_position_ids_vectorized(
+                    image_grid_thw, dtype="int64"
+                )
 
-            startend_row_indices_lts = paddle.repeat_interleave(cu_seqlens_rm_first, repeats).reshape([1, 1, -1, 1])
-            startend_row_indices_ute = paddle.repeat_interleave(cu_seqlens_rm_last, repeats).reshape([1, 1, -1, 1])
-            startend_row_indices = paddle.concat([startend_row_indices_lts, startend_row_indices_ute], axis=-1)
+            if use_window_attn:
+                height_position_ids = height_position_ids[window_indices]
+                width_position_ids = width_position_ids[window_indices]
+
+            pids = paddle.stack([height_position_ids, width_position_ids], axis=-1)
+            max_grid_size = image_grid_thw[:, 1:].max()
+            rope_emb_max_grid = self.rotary_pos_emb(
+                max_grid_size
+            )  # TODO: Pre-compute RoPE embeddings by specifying a static `max_grid_size` during initialization to avoid redundant computation on the fly.
+
+            rope_emb = rope_emb_max_grid[pids].flatten(1)
+            rope_emb = (rope_emb.cos().tile((1, 2)), rope_emb.sin().tile((1, 2)))
+
+        if cu_seqlens is not None and attention_mask is None:
+            seq_ends = cu_seqlens[1:]
+            seq_starts = cu_seqlens[:-1]
+            repeats = seq_ends - seq_starts
+
+            start_end_stacked = paddle.stack([seq_ends, seq_starts], axis=-1)
+            startend_row_indices = paddle.repeat_interleave(start_end_stacked, repeats, axis=0)
+            startend_row_indices = startend_row_indices.reshape([1, 1, -1, 2])
 
         for encoder_layer in self.layers:
             if output_hidden_states:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->

笨PR改动：

1. **重构窗口注意力计算逻辑**：将 `window_indices` 的计算提前到 RoPE 嵌入之前，避免重复计算和条件分支开销。
2. **简化 RoPE 嵌入计算**：
   - 使用 `image_grid_thw[:, 1:].max()` 直接计算最大网格尺寸，避免动态计算 `pids.max() + 1`。
   - 交换 `sin/cos` 计算与 `tile` 操作的顺序，提高内存效率。
3. **优化位置 ID 生成**：在 `get_position_ids_vectorized` 方法中添加 `dtype` 参数，确保数据类型一致性，并优化累积求和操作。
4. **简化注意力掩码计算**：重构 `startend_row_indices` 的生成逻辑，减少张量 `repeat_interleave` 操作开销。


在 timeline 上测试显示，这部分前处理时间从 3.3ms 下降至 2.1ms，提升约 36% 的处理速度

优化前：3.3ms
<img width="1540" height="521" alt="image" src="https://github.com/user-attachments/assets/ac552c5b-8bfb-4c23-ae84-d03e81650046" />


优化后，2.1ms
<img width="1524" height="518" alt="image" src="https://github.com/user-attachments/assets/2d5b8979-3f8c-4a5e-8527-b4f5759740f8" />
