### PR TITLE
Feature(triton): Add Triton RoPE kernel for vision models

### DIFF
--- a/paddleformers/transformers/paddleocr_vl/modeling.py
+++ b/paddleformers/transformers/paddleocr_vl/modeling.py
@@ -92,7 +92,7 @@ def apply_multimodal_rotary_pos_emb(q, k, cos, sin, mrope_section, unsqueeze_dim
     return q_embed, k_embed
 
 
-@dispatch_to(apply_rotary_pos_emb_vision_triton, cond=lambda *arg: True)  # TODO: update this condtion function
+@dispatch_to(apply_rotary_pos_emb_vision_triton, cond=apply_rotary_pos_emb_vision_triton.is_available)
 def apply_rotary_pos_emb_vision(q, k, cos, sin):
     """Applies Rotary Position Embedding to the query and key tensors."""
     orig_q_dtype = q.dtype

--- a/paddleformers/transformers/paddleocr_vl/modeling.py
+++ b/paddleformers/transformers/paddleocr_vl/modeling.py
@@ -585,7 +585,7 @@ class PaddleOCREncoder(nn.Layer):
             )  # TODO: Pre-compute RoPE embeddings by specifying a static `max_grid_size` during initialization to avoid redundant computation on the fly.
 
             rope_emb = rope_emb_max_grid[pids].flatten(1)
-            rope_emb = (rope_emb.cos().tile((1, 2)), rope_emb.sin().tile((1, 2)))
+            rope_emb = (rope_emb.cos(), rope_emb.sin())
 
         if cu_seqlens is not None and attention_mask is None:
             seq_ends = cu_seqlens[1:]

--- a/paddleformers/transformers/paddleocr_vl/modeling.py
+++ b/paddleformers/transformers/paddleocr_vl/modeling.py
@@ -29,6 +29,11 @@ from paddle.distributed.fleet.utils.sequence_parallel_utils import (
 )
 from paddle.incubate.nn.functional import fused_rotary_position_embedding as fused_rope
 
+from paddleformers.triton_kernels import (
+    apply_rotary_pos_emb_vision as apply_rotary_pos_emb_vision_triton,
+)
+from paddleformers.utils.tools import dispatch_to
+
 from ...generation import GenerationMixin
 from ...nn.activation import ACT2FN
 from ...nn.attention.interface import ALL_ATTENTION_FUNCTIONS
@@ -87,17 +92,18 @@ def apply_multimodal_rotary_pos_emb(q, k, cos, sin, mrope_section, unsqueeze_dim
     return q_embed, k_embed
 
 
-@paddle.jit.marker.unified
+@dispatch_to(apply_rotary_pos_emb_vision_triton, cond=lambda *arg: True)  # TODO: update this condtion function
 def apply_rotary_pos_emb_vision(q, k, cos, sin):
     """Applies Rotary Position Embedding to the query and key tensors."""
     orig_q_dtype = q.dtype
     orig_k_dtype = k.dtype
-    with paddle.amp.auto_cast(False):
-        q, k = q.astype(dtype="float32"), k.astype(dtype="float32")
-        cos, sin = cos.unsqueeze(-2).astype(dtype="float32"), sin.unsqueeze(-2).astype(dtype="float32")
-        q_embed = (q * cos) + (rotate_half(q) * sin)
-        k_embed = (k * cos) + (rotate_half(k) * sin)
-        return q_embed.astype(orig_q_dtype), k_embed.astype(orig_k_dtype)
+    cos = cos.tile((1, 2))
+    sin = sin.tile((1, 2))
+    q, k = q.astype(dtype="float32"), k.astype(dtype="float32")
+    cos, sin = cos.unsqueeze(-2).astype(dtype="float32"), sin.unsqueeze(-2).astype(dtype="float32")
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed.astype(orig_q_dtype), k_embed.astype(orig_k_dtype)
 
 
 def apply_fused_rope(query_states, key_states, rope_theta):

--- a/paddleformers/triton_kernels/__init__.py
+++ b/paddleformers/triton_kernels/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Triton kernels for PaddleFormers."""
+
+from .rope_triton import apply_rotary_emb, apply_rotary_pos_emb_vision
+
+__all__ = ["apply_rotary_emb", "apply_rotary_pos_emb_vision"]

--- a/paddleformers/triton_kernels/rope_triton.py
+++ b/paddleformers/triton_kernels/rope_triton.py
@@ -290,3 +290,34 @@ def apply_rotary_pos_emb_vision(q, k, cos, sin):
         q_out, k_out: Same shape and dtype as input
     """
     return ApplyRotaryPosEmbVision.apply(q, k, cos, sin)
+
+
+def _run_once(fn):
+    """Decorator that caches the result of a function after first call."""
+    result = None
+    has_run = False
+
+    def wrapper(*args, **kwargs):
+        nonlocal result, has_run
+        if not has_run:
+            result = fn(*args, **kwargs)
+            has_run = True
+        return result
+
+    return wrapper
+
+
+@_run_once
+def _check_triton_available(*args, **kwargs):
+    """Check if triton is available and version >= 3.0.0"""
+    try:
+        import triton
+
+        version = getattr(triton, "__version__")
+        major = int(version.split(".")[0])
+        return major >= 3
+    except ImportError:
+        return False
+
+
+apply_rotary_pos_emb_vision.is_available = _check_triton_available

--- a/paddleformers/triton_kernels/rope_triton.py
+++ b/paddleformers/triton_kernels/rope_triton.py
@@ -1,0 +1,292 @@
+# Copyright (c) 2025, Tri Dao.
+# Ported from Flash Attention: https://github.com/Dao-AILab/flash-attention/blob/main/flash_attn/ops/triton/rotary.py
+# Original code licensed under BSD-3-Clause license.
+
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Triton Rotary Position Embedding for PaddlePaddle."""
+
+import paddle
+
+paddle.enable_compat(scope={"triton"})
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _rotary_kernel(
+    OUT,
+    X,
+    COS,
+    SIN,
+    # Dimensions
+    seqlen,
+    nheads,
+    seqlen_ro,
+    # Strides
+    stride_out_batch,
+    stride_out_seqlen,
+    stride_out_nheads,
+    stride_out_headdim,
+    stride_x_batch,
+    stride_x_seqlen,
+    stride_x_nheads,
+    stride_x_headdim,
+    # Meta-parameters
+    ROTARY_DIM: tl.constexpr,
+    CONJUGATE: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+):
+    """
+    Triton kernel for rotary position embedding.
+    Ported directly from Flash Attention's rotary_kernel.
+
+    Grid: (cdiv(nheads, BLOCK_H), cdiv(seqlen, BLOCK_M), batch)
+
+    cos/sin shape: [seqlen, rotary_dim/2]
+
+    Forward:
+        o0 = x0 * cos - x1 * sin
+        o1 = x0 * sin + x1 * cos
+
+    Backward (conjugate=True, sin = -sin):
+        o0 = x0 * cos + x1 * sin
+        o1 = x0 * (-sin) + x1 * cos = -x0 * sin + x1 * cos
+    """
+    BLOCK_K: tl.constexpr = triton.next_power_of_2(ROTARY_DIM)
+    ROTARY_DIM_HALF = ROTARY_DIM // 2
+
+    pid_head = tl.program_id(axis=0)
+    pid_m = tl.program_id(axis=1)
+    pid_batch = tl.program_id(axis=2)
+
+    # Apply batch offset
+    X = X + pid_batch * stride_x_batch
+    OUT = OUT + pid_batch * stride_out_batch
+
+    # Early exit if out of bounds
+    if pid_m * BLOCK_M >= seqlen:
+        return
+
+    # Head and sequence indices
+    rh = pid_head * BLOCK_H + tl.arange(0, BLOCK_H)
+    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    rk_half = tl.arange(0, BLOCK_K // 2)
+
+    # Load cos and sin: [seqlen, rotary_dim/2]
+    COS = COS + (rm[:, None] * ROTARY_DIM_HALF + rk_half[None, :])
+    SIN = SIN + (rm[:, None] * ROTARY_DIM_HALF + rk_half[None, :])
+    mask_cs = (rm[:, None] < seqlen_ro) & (rk_half[None, :] < ROTARY_DIM_HALF)
+    cos = tl.load(COS, mask=mask_cs, other=1.0).to(tl.float32)
+    sin = tl.load(SIN, mask=mask_cs, other=0.0).to(tl.float32)
+
+    if CONJUGATE:
+        sin = -sin
+
+    # Compute pointers for X and OUT
+    X = X + (
+        rh[:, None, None] * stride_x_nheads
+        + rm[None, :, None] * stride_x_seqlen
+        + rk_half[None, None, :] * stride_x_headdim
+    )
+    OUT = OUT + (
+        rh[:, None, None] * stride_out_nheads
+        + rm[None, :, None] * stride_out_seqlen
+        + rk_half[None, None, :] * stride_out_headdim
+    )
+
+    mask = (rh[:, None, None] < nheads) & (rm[None, :, None] < seqlen) & (rk_half[None, None, :] < ROTARY_DIM_HALF)
+
+    # Load first half (x0) and second half (x1)
+    x0 = tl.load(X, mask=mask, other=0.0).to(tl.float32)
+    x1 = tl.load(X + ROTARY_DIM_HALF * stride_x_headdim, mask=mask, other=0.0).to(tl.float32)
+
+    # Apply rotation (same formula as Flash Attention)
+    o0 = x0 * cos - x1 * sin
+    o1 = x0 * sin + x1 * cos
+
+    # Store results
+    tl.store(OUT, o0, mask=mask)
+    tl.store(OUT + ROTARY_DIM_HALF * stride_out_headdim, o1, mask=mask)
+
+
+def apply_rotary(
+    x: paddle.Tensor,
+    cos: paddle.Tensor,
+    sin: paddle.Tensor,
+    conjugate: bool = False,
+) -> paddle.Tensor:
+    """
+    Apply rotary position embedding to input tensor.
+    Matches Flash Attention's apply_rotary interface.
+
+    Args:
+        x: (batch, seqlen, nheads, headdim) or (seqlen, nheads, headdim)
+        cos: (seqlen_ro, rotary_dim/2)
+        sin: (seqlen_ro, rotary_dim/2)
+        conjugate: If True, negate sin (used for backward pass)
+
+    Returns:
+        out: Same shape and dtype as x
+    """
+    orig_dtype = x.dtype
+    is_3d = x.ndim == 3
+    if is_3d:
+        x = x.unsqueeze(0)
+
+    batch, seqlen, nheads, headdim = x.shape
+    seqlen_ro, rotary_dim_half = cos.shape
+    rotary_dim = rotary_dim_half * 2
+
+    assert sin.shape == cos.shape
+    assert rotary_dim <= headdim, "rotary_dim must be <= headdim"
+    assert seqlen_ro >= seqlen, "seqlen_ro must be >= seqlen"
+
+    x = x.contiguous()
+    cos = cos.contiguous()
+    sin = sin.contiguous()
+
+    out = paddle.empty_like(x)
+
+    # Copy non-rotary dimensions if needed
+    if rotary_dim < headdim:
+        out[..., rotary_dim:] = x[..., rotary_dim:]
+
+    BLOCK_M = 8 if rotary_dim <= 128 else 4
+    BLOCK_H = 2
+
+    grid = (triton.cdiv(nheads, BLOCK_H), triton.cdiv(seqlen, BLOCK_M), batch)
+
+    _rotary_kernel[grid](
+        out,
+        x,
+        cos,
+        sin,
+        seqlen,
+        nheads,
+        seqlen_ro,
+        out.strides[0],
+        out.strides[1],
+        out.strides[2],
+        out.strides[3],
+        x.strides[0],
+        x.strides[1],
+        x.strides[2],
+        x.strides[3],
+        ROTARY_DIM=rotary_dim,
+        CONJUGATE=conjugate,
+        BLOCK_H=BLOCK_H,
+        BLOCK_M=BLOCK_M,
+        num_warps=4,
+    )
+
+    # Convert back to original dtype
+    out = out.astype(orig_dtype)
+
+    if is_3d:
+        out = out.squeeze(0)
+
+    return out
+
+
+class ApplyRotaryEmb(paddle.autograd.PyLayer):
+    """
+    Autograd wrapper for rotary position embedding.
+    Matches Flash Attention's ApplyRotaryEmb.
+    """
+
+    @staticmethod
+    def forward(ctx, x, cos, sin):
+        """
+        Forward pass.
+
+        Args:
+            x: (batch, seqlen, nheads, headdim)
+            cos, sin: (seqlen, rotary_dim/2)
+        """
+        out = apply_rotary(x, cos, sin, conjugate=False)
+        ctx.save_for_backward(cos, sin)
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        """
+        Backward pass uses conjugate rotation (sin = -sin).
+        """
+        cos, sin = ctx.saved_tensor()
+        grad_x = apply_rotary(grad_output, cos, sin, conjugate=True)
+        return grad_x, None, None
+
+
+def apply_rotary_emb(x, cos, sin):
+    """
+    Apply rotary embedding with autograd support.
+    Matches Flash Attention's apply_rotary_emb interface.
+
+    Args:
+        x: (batch, seqlen, nheads, headdim) or (seqlen, nheads, headdim)
+        cos, sin: (seqlen, rotary_dim/2)
+
+    Returns:
+        out: Same shape and dtype as x
+    """
+    return ApplyRotaryEmb.apply(x, cos, sin)
+
+
+class ApplyRotaryPosEmbVision(paddle.autograd.PyLayer):
+    """
+    Apply rotary position embedding to q and k tensors together.
+    """
+
+    @staticmethod
+    def forward(ctx, q, k, cos, sin):
+        """
+        Forward pass for q and k.
+
+        Args:
+            q, k: (batch, seqlen, nheads, headdim) or (seqlen, nheads, headdim)
+            cos, sin: (seqlen, rotary_dim/2)
+        """
+        q_out = apply_rotary(q, cos, sin, conjugate=False)
+        k_out = apply_rotary(k, cos, sin, conjugate=False)
+        ctx.save_for_backward(cos, sin)
+        return q_out, k_out
+
+    @staticmethod
+    def backward(ctx, grad_q, grad_k):
+        """
+        Backward pass for q and k.
+        """
+        cos, sin = ctx.saved_tensor()
+        grad_q_out = apply_rotary(grad_q, cos, sin, conjugate=True)
+        grad_k_out = apply_rotary(grad_k, cos, sin, conjugate=True)
+        return grad_q_out, grad_k_out, None, None
+
+
+def apply_rotary_pos_emb_vision(q, k, cos, sin):
+    """
+    Apply rotary position embedding to q and k tensors.
+
+    Args:
+        q, k: (batch, seqlen, nheads, headdim) or (seqlen, nheads, headdim)
+               Any dtype (bf16/fp16/fp32), output preserves input dtype
+        cos, sin: (seqlen, rotary_dim/2)
+
+    Returns:
+        q_out, k_out: Same shape and dtype as input
+    """
+    return ApplyRotaryPosEmbVision.apply(q, k, cos, sin)

--- a/paddleformers/triton_kernels/rope_triton.py
+++ b/paddleformers/triton_kernels/rope_triton.py
@@ -20,10 +20,24 @@
 
 import paddle
 
-paddle.enable_compat(scope={"triton"})
+# NOTE: Currently, global enabling is NOT supported.
+# paddle.enable_compat(scope={"triton"})
 
-import triton
-import triton.language as tl
+try:
+    import triton
+    import triton.language as tl
+except:
+    raise RuntimeError("Triton is not installed" "Please run 'python -m pip install triton>=3.1' to install Triton.")
+
+try:
+    import use_triton_in_paddle
+
+    use_triton_in_paddle.make_triton_compatible_with_paddle()
+except:
+    raise RuntimeError(
+        "Triton is installed, but not yet compatible with Paddle. "
+        "Please run 'python -m pip install use-triton-in-paddle' to enable Triton support in Paddle."
+    )
 
 
 @triton.jit

--- a/paddleformers/utils/tools.py
+++ b/paddleformers/utils/tools.py
@@ -19,6 +19,23 @@ from .import_utils import is_paddle_available
 from .log import logger
 
 
+def dispatch_to(dispatch_fn, *, cond=None):
+
+    if cond is None:
+        cond = lambda self, *args, **kwargs: True  # noqa: E731
+
+    def decorator(fn):
+        def wrapper(*args, **kwargs):
+            if cond(*args, **kwargs):
+                return dispatch_fn(*args, **kwargs)
+            return fn(*args, **kwargs)
+
+        wrapper.__original_fn__ = fn
+        return wrapper
+
+    return decorator
+
+
 def static_params_to_dygraph(model, static_tensor_dict):
     """Simple tool for convert static parameters to dygraph parameters dict.
 

--- a/tests/triton/test_rope_triton.py
+++ b/tests/triton/test_rope_triton.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import paddle
+
+
+def apply_rotary_ref(x, cos, sin, conjugate=False):
+
+    orig_dtype = x.dtype
+    x = x.astype("float32")
+    cos = cos.astype("float32")
+    sin = sin.astype("float32")
+
+    if conjugate:
+        sin = -sin
+
+    rotary_dim = cos.shape[-1] * 2
+    x0 = x[..., : rotary_dim // 2]
+    x1 = x[..., rotary_dim // 2 : rotary_dim]
+
+    cos = cos.unsqueeze(-2)
+    sin = sin.unsqueeze(-2)
+
+    o0 = x0 * cos - x1 * sin
+    o1 = x0 * sin + x1 * cos
+
+    out = paddle.concat([o0, o1], axis=-1)
+    if rotary_dim < x.shape[-1]:
+        out = paddle.concat([out, x[..., rotary_dim:]], axis=-1)
+
+    return out.astype(orig_dtype)
+
+
+def apply_rotary_pos_emb_vision_ref(q, k, cos, sin):
+    """Reference implementation for q, k pair."""
+    q_out = apply_rotary_ref(q, cos, sin, conjugate=False)
+    k_out = apply_rotary_ref(k, cos, sin, conjugate=False)
+    return q_out, k_out
+
+
+class TestTritonRoPE(unittest.TestCase):
+    """Test cases for Triton Rotary Position Embedding."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.test_shapes = [
+            (1, 1024, 16, 72),  # Standard shape
+            (2, 512, 16, 72),  # Batch > 1
+        ]
+        self.dtype = "bfloat16"
+
+    def test_forward_correctness(self):
+        """Test forward pass correctness against reference implementation."""
+        from paddleformers.triton_kernels import apply_rotary_pos_emb_vision
+
+        for batch, seq_len, num_heads, head_dim in self.test_shapes:
+            with self.subTest(shape=(batch, seq_len, num_heads, head_dim)):
+                q = paddle.randn([batch, seq_len, num_heads, head_dim], dtype=self.dtype)
+                k = paddle.randn([batch, seq_len, num_heads, head_dim], dtype=self.dtype)
+                cos = paddle.randn([seq_len, head_dim // 2], dtype=self.dtype)
+                sin = paddle.randn([seq_len, head_dim // 2], dtype=self.dtype)
+
+                # Reference
+                q_ref, k_ref = apply_rotary_pos_emb_vision_ref(q, k, cos, sin)
+
+                # Triton
+                q_tri, k_tri = apply_rotary_pos_emb_vision(q, k, cos, sin)
+
+                # Check correctness
+                q_close = paddle.allclose(
+                    q_ref.astype("float32"), q_tri.astype("float32"), rtol=1e-2, atol=1e-2
+                ).item()
+                k_close = paddle.allclose(
+                    k_ref.astype("float32"), k_tri.astype("float32"), rtol=1e-2, atol=1e-2
+                ).item()
+
+                self.assertTrue(q_close, f"Q mismatch for shape {(batch, seq_len, num_heads, head_dim)}")
+                self.assertTrue(k_close, f"K mismatch for shape {(batch, seq_len, num_heads, head_dim)}")
+
+    def test_backward_correctness(self):
+        """Test backward pass correctness."""
+        from paddleformers.triton_kernels import apply_rotary_pos_emb_vision
+
+        batch, seq_len, num_heads, head_dim = 1, 1024, 16, 72
+
+        q = paddle.randn([batch, seq_len, num_heads, head_dim], dtype=self.dtype)
+        k = paddle.randn([batch, seq_len, num_heads, head_dim], dtype=self.dtype)
+        cos = paddle.randn([seq_len, head_dim // 2], dtype=self.dtype)
+        sin = paddle.randn([seq_len, head_dim // 2], dtype=self.dtype)
+
+        # Triton forward + backward
+        q_tri = q.clone()
+        k_tri = k.clone()
+        q_tri.stop_gradient = False
+        k_tri.stop_gradient = False
+
+        q_embed, k_embed = apply_rotary_pos_emb_vision(q_tri, k_tri, cos, sin)
+        loss = q_embed.sum() + k_embed.sum()
+        loss.backward()
+
+        # Reference gradient (conjugate=True means sin = -sin)
+        grad_output = paddle.ones_like(q)
+        grad_ref = apply_rotary_ref(grad_output, cos, sin, conjugate=True)
+
+        # Compare
+        grad_q_close = paddle.allclose(
+            grad_ref.astype("float32"), q_tri.grad.astype("float32"), rtol=1e-2, atol=1e-2
+        ).item()
+        grad_k_close = paddle.allclose(
+            grad_ref.astype("float32"), k_tri.grad.astype("float32"), rtol=1e-2, atol=1e-2
+        ).item()
+
+        self.assertTrue(grad_q_close, "grad_q mismatch")
+        self.assertTrue(grad_k_close, "grad_k mismatch")
+
+    def test_dtype_preservation(self):
+        """Test that output dtype matches input dtype."""
+        from paddleformers.triton_kernels import apply_rotary_pos_emb_vision
+
+        batch, seq_len, num_heads, head_dim = 1, 1024, 16, 72
+        dtypes = ["bfloat16", "float16", "float32"]
+
+        for dtype in dtypes:
+            with self.subTest(dtype=dtype):
+                q = paddle.randn([batch, seq_len, num_heads, head_dim], dtype=dtype)
+                k = paddle.randn([batch, seq_len, num_heads, head_dim], dtype=dtype)
+                cos = paddle.randn([seq_len, head_dim // 2], dtype=dtype)
+                sin = paddle.randn([seq_len, head_dim // 2], dtype=dtype)
+
+                q_out, k_out = apply_rotary_pos_emb_vision(q, k, cos, sin)
+
+                self.assertEqual(q_out.dtype, q.dtype, f"Q dtype not preserved for {dtype}")
+                self.assertEqual(k_out.dtype, k.dtype, f"K dtype not preserved for {dtype}")
+
+    def test_3d_input(self):
+        """Test that 3D input (without batch dim) works correctly."""
+        from paddleformers.triton_kernels import apply_rotary_pos_emb_vision
+
+        seq_len, num_heads, head_dim = 1024, 16, 72
+
+        q = paddle.randn([seq_len, num_heads, head_dim], dtype=self.dtype)
+        k = paddle.randn([seq_len, num_heads, head_dim], dtype=self.dtype)
+        cos = paddle.randn([seq_len, head_dim // 2], dtype=self.dtype)
+        sin = paddle.randn([seq_len, head_dim // 2], dtype=self.dtype)
+
+        q_out, k_out = apply_rotary_pos_emb_vision(q, k, cos, sin)
+
+        # Check output shape is same as input
+        self.assertEqual(q_out.shape, q.shape)
+        self.assertEqual(k_out.shape, k.shape)
+
+        # Check correctness
+        q_ref, k_ref = apply_rotary_pos_emb_vision_ref(q.unsqueeze(0), k.unsqueeze(0), cos, sin)
+        q_ref = q_ref.squeeze(0)
+        k_ref = k_ref.squeeze(0)
+
+        q_close = paddle.allclose(q_ref.astype("float32"), q_out.astype("float32"), rtol=1e-2, atol=1e-2).item()
+        k_close = paddle.allclose(k_ref.astype("float32"), k_out.astype("float32"), rtol=1e-2, atol=1e-2).item()
+
+        self.assertTrue(q_close, "Q mismatch for 3D input")
+        self.assertTrue(k_close, "K mismatch for 3D input")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->

使用 flash attention 仓库的 triton kernel 来优化 `apply_rotary_pos_emb_vision` 这部分碎算子

https://github.com/PaddlePaddle/PaddleFormers/blob/13f5d7f710664c98ce2cb51ba19cc4bd997575d1/paddleformers/transformers/paddleocr_vl/modeling.py#L90-L100

优化前的 TIMELINE，3个矩阵乘和 FlashMask 之间有 4ms 的碎算子：

<img width="1583" height="448" alt="image" src="https://github.com/user-attachments/assets/ea4650cc-2a5c-4de6-8955-84464694490d" />

优化后的 TIMELINE，3个矩阵乘和 FlashMask 之间只有不到 1ms 的融合 triton Kernel：
<img width="1573" height="451" alt="image" src="https://github.com/user-attachments/assets/95fa1f57-552f-4200-be1f-45ef4adad537" />

Visual Encode 单 STEP 时间从 320ms 下降至 290ms

以下是验证结果：

8卡，2epoch，BS=64 loss下降曲线，优化前后对比
<img width="3600" height="2400" alt="loss_comparison_multi" src="https://github.com/user-attachments/assets/4db51d58-e9a3-45dd-9da0-5757f0c1116d" />

单卡，2epoch，BS=8 loss 下降曲线，优化前后对比
<img width="3600" height="2400" alt="loss_comparison_single" src="https://github.com/user-attachments/assets/44de76f0-14aa-40b3-9bed-58af460f8b02" />


由于单卡训练每个 Batch 吃进的数据少，所以波动更大