### PR TITLE
[release/1.1] Fix numpy2 bug

### DIFF
--- a/paddleformers/transformers/qwen3_vl/modeling_fleet.py
+++ b/paddleformers/transformers/qwen3_vl/modeling_fleet.py
@@ -683,9 +683,11 @@ class Qwen3VLVisionModel(VisionLayer):
         patch_pos_embeds_permute = []
         merge_size = self.spatial_merge_size
         for pos_embed, t, h, w in zip(patch_pos_embeds, grid_ts, grid_hs, grid_ws):
-            pos_embed = pos_embed.repeat([t, 1])
+            # Convert to Python int to avoid NumPy 2.x compatibility issues
+            h_merged = int(h) // int(merge_size)
+            w_merged = int(w) // int(merge_size)
             pos_embed = (
-                pos_embed.view([t, h // merge_size, merge_size, w // merge_size, merge_size, -1])
+                pos_embed.view([t, h_merged, merge_size, w_merged, merge_size, -1])
                 .permute(0, 1, 3, 2, 4, 5)
                 .flatten(0, 4)
             )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
paddlefleet CE发现paddle release分支在numpy2.x下报错
<img width="1530" height="930" alt="db944c079166f602b042a72ad8af969e" src="https://github.com/user-attachments/assets/e9e48a46-9c9b-4c7a-8dee-2026640529d6" />

定位发现：h // merge_size 返回的是 paddle.Tensor（shape=[1], value=7），而不是 Python int。

Paddle 的 view() 函数在解析 shape 列表时，无法正确提取 paddle.Tensor 元素的值，而是将其错误地解析为 -1。以下是最小可复现case
```
import paddle

# h 是 paddle.Tensor，不是 Python int
h = paddle.to_tensor([14])
merge_size = 2

# 问题：h // merge_size 返回 paddle.Tensor，不是 int
result = h // merge_size
print(type(result))  # <class 'paddle.Tensor'>

# view() 无法正确处理 shape 中的 Tensor 元素
x = paddle.randn([1, 14, 2, 14, 2, 16])
shape = [1, h // merge_size, 2, h // merge_size, 2, -1]  # Tensor 在 shape 中
x.view(shape)  # 报错：shape = [1, -1, 2, -1, 2, -1]
```

底层原因应该是NumPy 2.x 重构了 C API，@wanghuancoder安排同学看看


Cherry-pick of #4004 to `release/1.1`.

Merged in dev: #4004  <!-- For pass CI -->