### PR TITLE
[release/1.1] Fix numpy

### DIFF
--- a/paddleformers/cli/train/dpo/dpo_trainer.py
+++ b/paddleformers/cli/train/dpo/dpo_trainer.py
@@ -652,7 +652,8 @@ class DPOTrainer(Trainer):
                         tensor = paddle.zeros([1])
                     else:
                         tensor = paddle.cat(getattr(infohub, key), axis=0).detach()
-                    tensor_shape = paddle.to_tensor(tensor.shape, dtype="int64")
+                    # Convert shape to list of Python ints for NumPy 2.x compatibility
+                    tensor_shape = paddle.to_tensor([int(dim) for dim in tensor.shape], dtype="int64")
                     paddle.distributed.broadcast(
                         tensor_shape, src=self.model_wrapped.global_rank, group=self.model_wrapped.pp_group
                     )
@@ -671,7 +672,11 @@ class DPOTrainer(Trainer):
                         src=self.model_wrapped._hcg.get_rank_from_stage(self.model_wrapped.num_stages - 1),
                         group=self.model_wrapped.pp_group,
                     )
-                    tensor = paddle.zeros(tensor_shape, "float32")
+                    # Convert to Python int and validate for NumPy 2.x compatibility
+                    actual_shape = int(tensor_shape[0])
+                    if actual_shape < 0:
+                        actual_shape = 1  # Fallback to valid shape
+                    tensor = paddle.zeros([actual_shape], "float32")
                 else:
                     raise ValueError(f"Invalid key: {key}")
                 paddle.distributed.broadcast(

--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -4938,8 +4938,9 @@ class Trainer:
 
         if len(tensor.shape) < 2:
             return tensor
-        # Gather all sizes
-        size = paddle.to_tensor(tensor.shape)[None]
+        # Gather all sizes - convert shape to list of Python ints for NumPy 2.x compatibility
+        tensor_shape_list = [int(dim) for dim in tensor.shape]
+        size = paddle.to_tensor(tensor_shape_list)[None]
         sizes = self._nested_gather(size).cpu()
 
         max_size = max(s[1] for s in sizes)

--- a/paddleformers/utils/upcast_downcast_triton.py
+++ b/paddleformers/utils/upcast_downcast_triton.py
@@ -524,12 +524,12 @@ def downcast_to_mxfp_paddle(
 
     # For mxfp4 conversion, we assume the contiguous axis length is even.
     if is_fp4:
-        axis_shape = src_tensor.shape[axis]
+        axis_shape = int(src_tensor.shape[axis])
         assert axis_shape % 2 == 0, "For mxfp4 conversion the contiguous axis length must be even."
 
     # Permute the tensor so that the contiguous axis becomes the last dimension.
     src = src_tensor.transpose(axis, src_tensor.ndim - 1).to(paddle.float32)
-    axis_shape = src.shape[-1]
+    axis_shape = int(src.shape[-1])
 
     # Pad the axis to be divisible by 32, in case it is not.
     next_multiple = triton.cdiv(axis_shape, MXFP_BLOCK_SIZE) * MXFP_BLOCK_SIZE
@@ -669,12 +669,12 @@ def upcast_from_mxfp_paddle(tensor: paddle.Tensor, scale: paddle.Tensor, target_
         fp32_tensor = cvt_e2m1_to_fp32(tensor)
     else:
         fp32_tensor = tensor.to(paddle.float32)
-    logical_quant_dim = tensor.shape[-1] * (2 if tensor.dtype == paddle.uint8 else 1)
-    axis_shape = fp32_tensor.shape[-1]
+    logical_quant_dim = int(tensor.shape[-1]) * (2 if tensor.dtype == paddle.uint8 else 1)
+    axis_shape = int(fp32_tensor.shape[-1])
     padded_axis_shape = triton.cdiv(logical_quant_dim, MXFP_BLOCK_SIZE) * MXFP_BLOCK_SIZE
     pad_size = padded_axis_shape - axis_shape
     padded_tensor = F.pad(fp32_tensor, (0, int(pad_size)))
-    new_axis_shape = padded_tensor.shape[-1]
+    new_axis_shape = int(padded_tensor.shape[-1])
     new_shape = padded_tensor.shape[:-1] + [int(new_axis_shape // MXFP_BLOCK_SIZE), int(MXFP_BLOCK_SIZE)]
 
     padded_tensor = padded_tensor.view(*new_shape)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
问题描述
NumPy 2.x 环境下，tensor.shape 返回的元素类型从 Python int 变为了 Paddle Tensor，导致以下问题：

tensor.shape 直接用于 paddle.to_tensor() 时会产生错误的形状值（如 -1）
tensor // int 或 tensor.shape[i] 用于除法运算时返回 Tensor 而非 Python int
修复内容

paddleformers/cli/train/dpo/dpo_trainer.py
修复 broadcast_last_stage_infohub_tensor 函数中的 shape 转换问题
将 tensor.shape 显式转换为 Python int 列表后再传给 paddle.to_tensor()
添加负数 shape 的 fallback 保护逻辑
2. paddleformers/trainer/trainer.py

修复 _nested_gather 函数中的 shape 转换问题
3. paddleformers/transformers/qwen3_vl/modeling_fleet.py

修复位置编码计算中的除法运算，使用 int() 显式转换
4. paddleformers/utils/upcast_downcast_triton.py

修复多处 tensor.shape[i] 用于除法运算的问题，统一使用 int() 转换


Cherry-pick of #4030 to `release/1.1`.

Merged in dev: #4030  <!-- For pass CI -->