### PR TITLE
fix(generate): replace bit-wise NOT with subtraction for logic NOT

### DIFF
--- a/paddleformers/generation/utils.py
+++ b/paddleformers/generation/utils.py
@@ -377,8 +377,8 @@ class GenerationMixin(object):
         can_infer_attention_mask = is_pad_token_in_inputs_ids * is_pad_token_not_equal_to_eos_token_id
         attention_mask_from_padding = (inputs_tensor != pad_token_id).astype(paddle.get_default_dtype())
 
-        attention_mask = (
-            attention_mask_from_padding * can_infer_attention_mask + default_attention_mask * ~can_infer_attention_mask
+        attention_mask = attention_mask_from_padding * can_infer_attention_mask + default_attention_mask * (
+            1 - can_infer_attention_mask
         )
         return attention_mask
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
Python 中 `~` 表示按位取反，对于整数 `n`，`~n=-(n+1)`，因此有 `~0=-1` 和 `~1=-2`
此处 `can_infer_attention_mask` 为整数 `0` 或者 `1`，用减法 `1-can_infer_attention_mask` 才是正确的逻辑取反