### PR TITLE
Update download.py comment error

### DIFF
--- a/paddleformers/utils/download/download.py
+++ b/paddleformers/utils/download/download.py
@@ -126,7 +126,7 @@ def resolve_file_path(
         subfolder('str'): Some repos will exist subfolder.
         repo_type('str'): The default is model.
         cache_dir('str' or Path): Where to save or load the file after downloading.
-        download_hub (DownloadSource): The source for model downloading, options include `huggingface`, `aistudio`, `modelscope`, default `aistudio`.
+        download_hub (DownloadSource): The source for model downloading, options include `huggingface`, `aistudio`, `modelscope`, default `huggingface`.
         force_return (Optional[bool]): If True, the function will return None instead of raising an error
             when none of the specified `filenames` can be found or downloaded. Defaults to False (raises error).
 


### PR DESCRIPTION
`paddleformers/utils/download/download.py` 的  146行

```python
    # check repo id
    if download_hub is None:
        download_hub = os.environ.get("DOWNLOAD_SOURCE", "huggingface")
        logger.info(f"Using download source: {download_hub}")
```

跟实际的注释不符，注释引起了误导