### PR TITLE
Revert "[Perf] Disable `preserve_external_rng_state` in recompute for better performance"

### DIFF
--- a/paddleformers/transformers/paddleocr_vl/modeling.py
+++ b/paddleformers/transformers/paddleocr_vl/modeling.py
@@ -523,7 +523,6 @@ class PaddleOCREncoder(nn.Layer):
             cu_seqlens=cu_seqlens,
             attn_mask_startend_row_indices=attn_mask_startend_row_indices,
             rope_emb=rope_emb,
-            preserve_external_rng_state=False,
         )
         return hidden_states
 
@@ -1556,7 +1555,6 @@ class Ernie4_5Model(Ernie4_5PretrainedModel):
             output_attentions,
             past_key_values,
             use_cache,
-            preserve_external_rng_state=False,
         )
         return hidden_states
 


### PR DESCRIPTION
Reverts PaddlePaddle/PaddleFormers#3936
由于 Paddle3.3.1 发版不会带上 https://github.com/PaddlePaddle/Paddle/pull/77899
所以暂时将该 PR revert
在实际训练场景下，建议用当前的 develop 版本训练，且设定 `preserve_external_rng_state=False`
后续需要再 revert 回来

cc @forBlank 