### PR TITLE
[release/1.1] Fix protobuf 7 bug

### DIFF
--- a/paddleformers/trainer/integrations.py
+++ b/paddleformers/trainer/integrations.py
@@ -131,7 +131,11 @@ class VisualDLCallback(TrainerCallback):
                 #    self.vdl_writer.add_text("model_config", model_config_json)
 
             if hasattr(self.vdl_writer, "add_hparams"):
-                self.vdl_writer.add_hparams(args.to_sanitized_dict(), metrics_list=[])
+                # Convert bool to int for protobuf 7.x compatibility
+                # protobuf 7.x is stricter about type validation and won't auto-convert bool to int
+                sanitized_dict = args.to_sanitized_dict()
+                sanitized_dict = {k: int(v) if isinstance(v, bool) else v for k, v in sanitized_dict.items()}
+                self.vdl_writer.add_hparams(sanitized_dict, metrics_list=[])
 
     def on_log(self, args, state, control, logs=None, **kwargs):
         if not state.is_world_process_zero:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
修复protobuf 7 下 的bug，此PR 关注于修复visudal中protobu 7的问题，彻底修复依赖于paddle仓库PR升级prootbuf的PR：(https://github.com/PaddlePaddle/Paddle/pull/78236)

```
# visualdl/component/base_component.py 第343-344行
if isinstance(v, int):
    hparamInfo.int_value = v  # ❌ 当 v 是 True/False 时报错
```

Protobuf 7.x 类型验证变严格
    * Protobuf 6.x：较宽松，自动处理类型转换
    * Protobuf 7.x：严格验证，不自动将 bool 转为 int
   
鉴于visudal仓库无人维护，且需要重新发包，代价太大，所以在paddleformers层绕过，对数据类型进行转换
```
# 转换前
{
    "use_gpu": True,        # bool
    "use_amp": False,       # bool
    "batch_size": 32,       # int
    "learning_rate": 0.001  # float
}

# 转换后
{
    "use_gpu": 1,           # int (True -> 1)
    "use_amp": 0,           # int (False -> 0)
    "batch_size": 32,       # int (不变)
    "learning_rate": 0.001  # float (不变)
}
```


Cherry-pick of #4013 to `release/1.1`.

Merged in dev: #4013  <!-- For pass CI -->