### PR TITLE
[XPU][Fix] ernie_45_vl_28b_a3b_thinking_sft_32k: sync config with removed/renamed params in PR #4108

### DIFF
--- a/examples/config/xpu/ERNIE-4.5-VL-28B-A3B-Thinking/sft/full_32k.yaml
+++ b/examples/config/xpu/ERNIE-4.5-VL-28B-A3B-Thinking/sft/full_32k.yaml
@@ -13,7 +13,7 @@ dataloader_num_workers: 4
 
 ### model
 model_name_or_path: baidu/ERNIE-4.5-VL-28B-A3B-Thinking
-attn_impl: flashmask
+_attn_implementation: flashmask
 
 ### finetuning
 # base
@@ -41,7 +41,7 @@ learning_rate: 1.0e-5
 tensor_model_parallel_size: 4
 pipeline_model_parallel_size: 2
 sharding: stage1
-use_sparse_head_and_loss_fn: true
+# use_sparse_head_and_loss_fn: true
 bf16: true
 fp16_opt_level: O2
 save_checkpoint_format: "flex_checkpoint"
@@ -49,14 +49,14 @@ load_checkpoint_format: "flex_checkpoint"
 freeze_config: freeze_vision
 
 # recompute
-recompute: true
+# recompute: true
 recompute_granularity: full
 recompute_method: uniform
 recompute_num_layers: 1
 recompute_modules: ["loss_fn"]
 recompute_use_reentrant: true
 
-use_flash_attention: true
+# use_flash_attention: true
 sequence_parallel: true
 pp_seg_method: layer:Ernie4_5_DecoderLayer|ErnieDecoderLayer|EmptyLayer
 offload_queue: true


### PR DESCRIPTION
## 问题描述

PR #4108 在 `paddleformers/trainer/training_args.py` 中删除/重命名了若干参数，但 `examples/config/xpu/ERNIE-4.5-VL-28B-A3B-Thinking/sft/full_32k.yaml` 未同步更新，导致 CE case `ernie_45_vl_28b_a3b_thinking_sft_32k` 报错：

\`\`\`
ValueError: Some specified arguments are not used by the PdArgumentParser:
{'recompute', 'use_flash_attention', 'attn_impl', 'use_sparse_head_and_loss_fn'}
\`\`\`

## 修改内容

同步 `examples/config/xpu/ERNIE-4.5-VL-28B-A3B-Thinking/sft/full_32k.yaml`：

- `attn_impl` → 重命名为 `_attn_implementation`
- `use_sparse_head_and_loss_fn` → 注释掉（参数已删除）
- `recompute` → 注释掉（参数已删除）
- `use_flash_attention` → 注释掉（参数已删除）