### PR TITLE
[Qwen3_VL] Enable bias_activation_fusion and apply_rope_fusion

### DIFF
--- a/paddleformers/transformers/qwen3_vl/modeling_fleet.py
+++ b/paddleformers/transformers/qwen3_vl/modeling_fleet.py
@@ -898,10 +898,6 @@ class Qwen3VLProvider(TransformerConfig):
             for attr in config_attrs:
                 setattr(config, attr, getattr(self, attr))
 
-        # VIT uses 2D spatial RoPE which is incompatible with fused_rope kernel,
-        # force disable regardless of global setting.
-        self.vision_config.apply_rope_fusion = False
-
         self.text_config.tp_comm_overlap = self.tp_comm_overlap
         self.vision_config.tp_comm_overlap = False
         # self.vision_projection_config.tp_comm_overlap = False

--- a/paddleformers/transformers/qwen3_vl/modeling_fleet.py
+++ b/paddleformers/transformers/qwen3_vl/modeling_fleet.py
@@ -379,6 +379,7 @@ class Qwen3VLTextProvider(GPTModelProvider):
     rms_norm_eps: float = 1e-6
     rotary_base: float = 1000000.0
     position_embedding_type: str = "rope"
+    bias_activation_fusion: bool = True
     use_qk_norm: bool = True
     specific_layer: type = Qwen3VLTextTransformerLayer
     max_sequence_length: int = 262144


### PR DESCRIPTION
## Summary
- Enable `bias_activation_fusion` (`True` by default) in `Qwen3VLTextProvider` to leverage fused bias+activation kernels for better performance
- Remove the forced `apply_rope_fusion = False` override for vision model, allowing it to use the fused RoPE kernel (`fused_apply_rotary_pos_emb_vision`) which supports 2D spatial RoPE with fp32 precision

## Test plan
- [ ] Verify Qwen3_VL pretrain/SFT training runs correctly with the new defaults
- [ ] Confirm no regression in training loss