### PR TITLE
[release/1.1] optimize qwen3_vl fleet vision positional embedding computation

### DIFF
--- a/paddleformers/transformers/qwen3_vl/modeling_fleet.py
+++ b/paddleformers/transformers/qwen3_vl/modeling_fleet.py
@@ -601,118 +601,147 @@ class Qwen3VLVisionModel(VisionLayer):
             post_process=True,
         )
 
-    def rot_pos_emb(self, grid_thw):
+    def _build_token_image_mapping(self, grid_thw):
+        """Build token-to-image mapping, shared by rot_pos_emb and fast_pos_embed_interpolate"""
+        heights = grid_thw[:, 1]
+        widths = grid_thw[:, 2]
+        frames = grid_thw[:, 0]
+
+        num_tokens = frames * heights * widths  # [N]
+
+        total_tokens = num_tokens.sum().item()  # 1 D2H
+        max_hw = paddle.max(paddle.maximum(heights, widths)).item()  # 1 D2H
+
+        # token-to-image mapping: image_id[j] = i, where cu_tokens[i] <= j < cu_tokens[i+1]
+        cu_tokens = paddle.concat([paddle.zeros([1], dtype="int64"), num_tokens.cumsum(0)])
+        global_idx = paddle.arange(total_tokens, dtype="int64")
+        image_id = (global_idx.unsqueeze(-1) >= cu_tokens[:-1].unsqueeze(0)).astype("int64").sum(-1) - 1
+
+        local_idx = global_idx - cu_tokens[image_id]
+
+        # frame-local index
+        token_hw = (heights * widths)[image_id]
+        frame_local_idx = local_idx % token_hw
+
+        return image_id, frame_local_idx, total_tokens, max_hw
+
+    def rot_pos_emb(self, grid_thw, image_id=None, frame_local_idx=None, total_tokens=None, max_hw=None):
         m = self.spatial_merge_size
-        grid_thw_list = grid_thw.tolist()
+        widths = grid_thw[:, 2]
+        merged_w = widths // m
 
-        max_hw = max(max(h, w) for _, h, w in grid_thw_list)
-        freq_table = self.rotary_pos_emb(max_hw)  # [max_hw, dim//2]
+        if image_id is None:
+            image_id, frame_local_idx, total_tokens, max_hw = self._build_token_image_mapping(grid_thw)
 
-        total_tokens = sum(int(t * h * w) for t, h, w in grid_thw_list)
-        pos_ids = paddle.empty([total_tokens, 2], dtype="int64")
+        freq_table = self.rotary_pos_emb(max_hw)
 
-        offset = 0
-        for num_frames, height, width in grid_thw_list:
-            num_frames, height, width = int(num_frames), int(height), int(width)
-            merged_h, merged_w = height // m, width // m
+        token_mw = merged_w[image_id]  # [total_tokens]
 
-            block_rows = paddle.arange(merged_h)
-            block_cols = paddle.arange(merged_w)
-            intra_row = paddle.arange(m)
-            intra_col = paddle.arange(m)
+        # Decompose linear index to coordinates: layout [merged_h, merged_w, m, m]
+        mm = m * m
+        mw_mm = token_mw * mm
+        block_row = frame_local_idx // mw_mm
+        r1 = frame_local_idx % mw_mm
+        block_col = r1 // mm
+        r2 = r1 % mm
+        intra_row = r2 // m
+        intra_col = r2 % m
 
-            # Compute full-resolution positions via broadcasting
-            row_idx = block_rows[:, None, None, None] * m + intra_row[None, None, :, None]
-            col_idx = block_cols[None, :, None, None] * m + intra_col[None, None, None, :]
+        row_idx = block_row * m + intra_row
+        col_idx = block_col * m + intra_col
 
-            row_idx = row_idx.expand([merged_h, merged_w, m, m]).reshape([-1])
-            col_idx = col_idx.expand([merged_h, merged_w, m, m]).reshape([-1])
+        pos_ids = paddle.stack([row_idx, col_idx], axis=-1)  # [total_tokens, 2]
 
-            coords = paddle.stack([row_idx, col_idx], axis=-1)  # [h*w, 2]
-
-            if num_frames > 1:
-                coords = coords.tile([num_frames, 1])
-
-            num_tokens = coords.shape[0]
-            pos_ids[offset : offset + num_tokens] = coords
-            offset += num_tokens
-
-        embeddings = freq_table[pos_ids]  # [total_tokens, 2, dim//2]
-        embeddings = embeddings.flatten(start_axis=1)  # [total_tokens, dim]
+        embeddings = freq_table[pos_ids]
+        embeddings = embeddings.flatten(start_axis=1)
         return embeddings
 
-    def fast_pos_embed_interpolate(self, grid_thw):
-        grid_ts, grid_hs, grid_ws = grid_thw[:, 0], grid_thw[:, 1], grid_thw[:, 2]
-        device = paddle.get_device()
+    def fast_pos_embed_interpolate(
+        self, grid_thw, image_id=None, frame_local_idx=None, total_tokens=None, max_hw=None
+    ):
+        N = self.num_grid_per_side
+        m = self.spatial_merge_size
+        heights = grid_thw[:, 1]
+        widths = grid_thw[:, 2]
+        merged_w = widths // m
 
-        idx_list = [[] for _ in range(4)]
-        weight_list = [[] for _ in range(4)]
+        if image_id is None:
+            image_id, frame_local_idx, total_tokens, max_hw = self._build_token_image_mapping(grid_thw)
 
-        for t, h, w in zip(grid_ts, grid_hs, grid_ws):
-            h_idxs = paddle.linspace(0, self.num_grid_per_side - 1, int(h))
-            w_idxs = paddle.linspace(0, self.num_grid_per_side - 1, int(w))
+        token_mw = merged_w[image_id]
 
-            h_idxs_floor = h_idxs.int()
-            w_idxs_floor = w_idxs.int()
-            h_idxs_ceil = (h_idxs.int() + 1).clip(max=self.num_grid_per_side - 1)
-            w_idxs_ceil = (w_idxs.int() + 1).clip(max=self.num_grid_per_side - 1)
+        # Decompose linear index to coordinates (same layout as rot_pos_emb)
+        mm = m * m
+        mw_mm = token_mw * mm
+        block_row = frame_local_idx // mw_mm
+        r1 = frame_local_idx % mw_mm
+        block_col = r1 // mm
+        r2 = r1 % mm
+        intra_row = r2 // m
+        intra_col = r2 % m
 
-            dh = h_idxs - h_idxs_floor.astype("float32")
-            dw = w_idxs - w_idxs_floor.astype("float32")
+        # Pixel coordinates
+        j_h = (block_row * m + intra_row).astype("float32")
+        j_w = (block_col * m + intra_col).astype("float32")
 
-            base_h = h_idxs_floor * self.num_grid_per_side
-            base_h_ceil = h_idxs_ceil * self.num_grid_per_side
+        # Bilinear interpolation: h_idx = j_h * (N-1) / (h-1)
+        token_h = heights[image_id].astype("float32")
+        token_w = widths[image_id].astype("float32")
+        h_denom = (token_h - 1).clip(min=1.0)
+        w_denom = (token_w - 1).clip(min=1.0)
+        h_idx = j_h * (N - 1) / h_denom
+        w_idx = j_w * (N - 1) / w_denom
 
-            indices = [
-                (base_h[None].T + w_idxs_floor[None]).flatten(),
-                (base_h[None].T + w_idxs_ceil[None]).flatten(),
-                (base_h_ceil[None].T + w_idxs_floor[None]).flatten(),
-                (base_h_ceil[None].T + w_idxs_ceil[None]).flatten(),
+        h_floor = h_idx.astype("int32")
+        w_floor = w_idx.astype("int32")
+        h_ceil = (h_floor + 1).clip(max=N - 1)
+        w_ceil = (w_floor + 1).clip(max=N - 1)
+
+        dh = h_idx - h_floor.astype("float32")
+        dw = w_idx - w_floor.astype("float32")
+
+        base_h = h_floor * N
+        base_h_ceil = h_ceil * N
+
+        idx_tensor = paddle.stack(
+            [
+                (base_h + w_floor).astype("int64"),
+                (base_h + w_ceil).astype("int64"),
+                (base_h_ceil + w_floor).astype("int64"),
+                (base_h_ceil + w_ceil).astype("int64"),
             ]
+        )  # [4, total_tokens]
 
-            weights = [
-                ((1 - dh)[None].T * (1 - dw)[None]).flatten(),
-                ((1 - dh)[None].T * dw[None]).flatten(),
-                (dh[None].T * (1 - dw)[None]).flatten(),
-                (dh[None].T * dw[None]).flatten(),
-            ]
+        weight_tensor = paddle.stack([(1 - dh) * (1 - dw), (1 - dh) * dw, dh * (1 - dw), dh * dw]).astype(
+            self.pos_embed.weight.dtype
+        )  # [4, total_tokens]
 
-            for i in range(4):
-                idx_list[i].extend(indices[i].tolist())
-                weight_list[i].extend(weights[i].tolist())
-
-        idx_tensor = paddle.tensor(idx_list, dtype=paddle.long, device=device)
-        weight_tensor = paddle.tensor(weight_list, dtype=self.pos_embed.weight.dtype)
         pos_embeds = self.pos_embed(idx_tensor) * weight_tensor[:, :, None]
         patch_pos_embeds = pos_embeds[0] + pos_embeds[1] + pos_embeds[2] + pos_embeds[3]
-
-        patch_pos_embeds = patch_pos_embeds.split([h * w for h, w in zip(grid_hs, grid_ws)])
-
-        patch_pos_embeds_permute = []
-        merge_size = self.spatial_merge_size
-        for pos_embed, t, h, w in zip(patch_pos_embeds, grid_ts, grid_hs, grid_ws):
-            # Convert to Python int to avoid NumPy 2.x compatibility issues
-            h_merged = int(h) // int(merge_size)
-            w_merged = int(w) // int(merge_size)
-            pos_embed = (
-                pos_embed.reshape([t, h_merged, merge_size, w_merged, merge_size, -1])
-                .permute(0, 1, 3, 2, 4, 5)
-                .flatten(0, 4)
-            )
-            patch_pos_embeds_permute.append(pos_embed)
-        patch_pos_embeds = paddle.cat(patch_pos_embeds_permute)
+        # Already in (block_h, block_w, intra_h, intra_w) order, no merge_reshape needed
         return patch_pos_embeds
 
     def get_packed_seq_params(
         self,
         grid_thw: paddle.Tensor,
     ):
-        seqlens = safe_repeat_interleave_values(grid_thw[:, 1] * grid_thw[:, 2], grid_thw[:, 0])
-        cu_seqlens = seqlens.cumsum(axis=0, dtype=paddle.int32)
-        cu_seqlens = F.pad(cu_seqlens, (1, 0), value=0).contiguous()
-        cu_seqlens = cu_seqlens.squeeze().contiguous()
+        hw = grid_thw[:, 1] * grid_thw[:, 2]
+        frames = grid_thw[:, 0]
 
-        max_seqlen = seqlens.max().item()
+        # Build seqlens: repeat hw[i] by frames[i]
+        total_seqs = frames.sum().item()  # 1 D2H
+        cu_frames = paddle.concat([paddle.zeros([1], dtype="int64"), frames.cumsum(0)])
+        seq_idx = paddle.arange(total_seqs, dtype="int64")
+        seq_image_id = (seq_idx.unsqueeze(-1) >= cu_frames[:-1].unsqueeze(0)).astype("int64").sum(-1) - 1
+        seqlens = hw[seq_image_id]
+
+        cu_seqlens = paddle.concat(
+            [
+                paddle.zeros([1], dtype="int32"),
+                seqlens.cumsum(0).astype("int32"),
+            ]
+        )
+        max_seqlen = seqlens.max().item()  # 1 D2H (flash attention requires Python int)
 
         return PackedSeqParams(
             cu_seqlens_q=cu_seqlens,
@@ -731,14 +760,22 @@ class Qwen3VLVisionModel(VisionLayer):
     ) -> paddle.Tensor:
         # Pathed embedding
         hidden_states = self.patch_embed(hidden_states).view(-1, self.embed_dim)
-        pos_embeds = self.fast_pos_embed_interpolate(grid_thw)
+
+        # Share token-to-image mapping to avoid redundant computation
+        image_id, frame_local_idx, total_tokens, max_hw = self._build_token_image_mapping(grid_thw)
+
+        pos_embeds = self.fast_pos_embed_interpolate(
+            grid_thw, image_id=image_id, frame_local_idx=frame_local_idx, total_tokens=total_tokens, max_hw=max_hw
+        )
         hidden_states = hidden_states + pos_embeds
 
         seq_len, _ = hidden_states.size()
         hidden_states = hidden_states.reshape([seq_len, -1])
         hidden_states = hidden_states.unsqueeze(0)
 
-        rotary_pos_emb = self.rot_pos_emb(grid_thw)
+        rotary_pos_emb = self.rot_pos_emb(
+            grid_thw, image_id=image_id, frame_local_idx=frame_local_idx, total_tokens=total_tokens, max_hw=max_hw
+        )
         rotary_pos_emb = rotary_pos_emb.reshape(seq_len, -1)
         rotary_pos_emb = paddle.cat((rotary_pos_emb, rotary_pos_emb), axis=-1)
         # Cast freqs to float32 and compute cos/sin inside auto_cast(False) to match the

--- a/tests/transformers/qwen3_vl/test_modeling_fleet.py
+++ b/tests/transformers/qwen3_vl/test_modeling_fleet.py
@@ -1,0 +1,217 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import types
+import unittest
+
+import paddle
+import paddle.nn as nn
+import paddle.nn.functional as F
+
+_FLEET_IMPORT_ERROR = None
+
+try:
+    from paddleformers.transformers.qwen3_vl.modeling import (
+        Qwen3VLVisionRotaryEmbedding,
+    )
+    from paddleformers.transformers.qwen3_vl.modeling_fleet import (
+        Qwen3VLVisionModel,
+        safe_repeat_interleave_values,
+    )
+except Exception as error:
+    Qwen3VLVisionModel = None
+    Qwen3VLVisionRotaryEmbedding = None
+    safe_repeat_interleave_values = None
+    _FLEET_IMPORT_ERROR = error
+
+
+@unittest.skipUnless(Qwen3VLVisionModel is not None, f"paddlefleet import failed: {_FLEET_IMPORT_ERROR}")
+class Qwen3VLFleetPositionalEncodingTest(unittest.TestCase):
+    FAST_POS_EMBED_ATOL = 2e-5
+
+    def setUp(self):
+        paddle.seed(2026)
+        self.model = self._build_dummy_model()
+
+    def _build_dummy_model(self):
+        class DummyVisionModel:
+            pass
+
+        model = DummyVisionModel()
+        model.spatial_merge_size = 2
+        model.num_grid_per_side = 70
+        model.pos_embed = nn.Embedding(model.num_grid_per_side**2, 8)
+        weight = paddle.arange(model.num_grid_per_side**2 * 8, dtype="float32").reshape([-1, 8]) / 1000.0
+        model.pos_embed.weight.set_value(weight)
+        model.rotary_pos_emb = Qwen3VLVisionRotaryEmbedding(4)
+
+        for name in [
+            "_build_token_image_mapping",
+            "rot_pos_emb",
+            "fast_pos_embed_interpolate",
+            "get_packed_seq_params",
+        ]:
+            setattr(model, name, types.MethodType(getattr(Qwen3VLVisionModel, name), model))
+
+        return model
+
+    def _legacy_rot_pos_emb(self, grid_thw):
+        merge_size = self.model.spatial_merge_size
+        grid_thw_list = grid_thw.tolist()
+
+        max_hw = max(max(height, width) for _, height, width in grid_thw_list)
+        freq_table = self.model.rotary_pos_emb(max_hw)
+
+        total_tokens = sum(int(frames * height * width) for frames, height, width in grid_thw_list)
+        pos_ids = paddle.empty([total_tokens, 2], dtype="int64")
+
+        offset = 0
+        for num_frames, height, width in grid_thw_list:
+            num_frames, height, width = int(num_frames), int(height), int(width)
+            merged_h, merged_w = height // merge_size, width // merge_size
+
+            block_rows = paddle.arange(merged_h)
+            block_cols = paddle.arange(merged_w)
+            intra_row = paddle.arange(merge_size)
+            intra_col = paddle.arange(merge_size)
+
+            row_idx = block_rows[:, None, None, None] * merge_size + intra_row[None, None, :, None]
+            col_idx = block_cols[None, :, None, None] * merge_size + intra_col[None, None, None, :]
+
+            row_idx = row_idx.expand([merged_h, merged_w, merge_size, merge_size]).reshape([-1])
+            col_idx = col_idx.expand([merged_h, merged_w, merge_size, merge_size]).reshape([-1])
+
+            coords = paddle.stack([row_idx, col_idx], axis=-1)
+            if num_frames > 1:
+                coords = coords.tile([num_frames, 1])
+
+            num_tokens = coords.shape[0]
+            pos_ids[offset : offset + num_tokens] = coords
+            offset += num_tokens
+
+        embeddings = freq_table[pos_ids]
+        return embeddings.flatten(start_axis=1)
+
+    def _legacy_fast_pos_embed_interpolate(self, grid_thw):
+        grid_ts, grid_hs, grid_ws = grid_thw[:, 0], grid_thw[:, 1], grid_thw[:, 2]
+
+        idx_list = [[] for _ in range(4)]
+        weight_list = [[] for _ in range(4)]
+
+        for t, h, w in zip(grid_ts, grid_hs, grid_ws):
+            t, h, w = int(t), int(h), int(w)
+            self.assertEqual(t, 1)
+
+            h_idxs = paddle.linspace(0, self.model.num_grid_per_side - 1, h)
+            w_idxs = paddle.linspace(0, self.model.num_grid_per_side - 1, w)
+
+            h_floor = h_idxs.astype("int32")
+            w_floor = w_idxs.astype("int32")
+            h_ceil = (h_floor + 1).clip(max=self.model.num_grid_per_side - 1)
+            w_ceil = (w_floor + 1).clip(max=self.model.num_grid_per_side - 1)
+
+            dh = h_idxs - h_floor.astype("float32")
+            dw = w_idxs - w_floor.astype("float32")
+
+            base_h = h_floor * self.model.num_grid_per_side
+            base_h_ceil = h_ceil * self.model.num_grid_per_side
+
+            indices = [
+                (base_h[None].T + w_floor[None]).flatten(),
+                (base_h[None].T + w_ceil[None]).flatten(),
+                (base_h_ceil[None].T + w_floor[None]).flatten(),
+                (base_h_ceil[None].T + w_ceil[None]).flatten(),
+            ]
+            weights = [
+                ((1 - dh)[None].T * (1 - dw)[None]).flatten(),
+                ((1 - dh)[None].T * dw[None]).flatten(),
+                (dh[None].T * (1 - dw)[None]).flatten(),
+                (dh[None].T * dw[None]).flatten(),
+            ]
+
+            for i in range(4):
+                idx_list[i].extend(indices[i].tolist())
+                weight_list[i].extend(weights[i].tolist())
+
+        idx_tensor = paddle.to_tensor(idx_list, dtype="int64")
+        weight_tensor = paddle.to_tensor(weight_list, dtype=self.model.pos_embed.weight.dtype)
+        pos_embeds = self.model.pos_embed(idx_tensor) * weight_tensor[:, :, None]
+        patch_pos_embeds = pos_embeds[0] + pos_embeds[1] + pos_embeds[2] + pos_embeds[3]
+
+        patch_pos_embeds = patch_pos_embeds.split([int(h) * int(w) for h, w in zip(grid_hs, grid_ws)])
+
+        patch_pos_embeds_permute = []
+        merge_size = self.model.spatial_merge_size
+        for pos_embed, t, h, w in zip(patch_pos_embeds, grid_ts, grid_hs, grid_ws):
+            h_merged = int(h) // merge_size
+            w_merged = int(w) // merge_size
+            pos_embed = (
+                pos_embed.reshape([int(t), h_merged, merge_size, w_merged, merge_size, -1])
+                .permute(0, 1, 3, 2, 4, 5)
+                .flatten(0, 4)
+            )
+            patch_pos_embeds_permute.append(pos_embed)
+
+        return paddle.cat(patch_pos_embeds_permute)
+
+    def test_fast_pos_embed_interpolate_matches_legacy_reference_with_expected_tolerance(self):
+        for grid_thw in (
+            paddle.to_tensor([[1, 6, 8], [1, 14, 14]], dtype="int64"),
+            paddle.to_tensor([[1, 8, 6], [1, 4, 8]], dtype="int64"),
+        ):
+            with self.subTest(grid_thw=grid_thw.tolist()):
+                actual = self.model.fast_pos_embed_interpolate(grid_thw)
+                expected = self._legacy_fast_pos_embed_interpolate(grid_thw)
+
+                self.assertEqual(list(actual.shape), list(expected.shape))
+                self.assertTrue(
+                    bool(
+                        paddle.allclose(
+                            actual,
+                            expected,
+                            rtol=0.0,
+                            atol=self.FAST_POS_EMBED_ATOL,
+                        )
+                    )
+                )
+
+    def test_rot_pos_emb_matches_legacy_reference(self):
+        for grid_thw in (
+            paddle.to_tensor([[2, 4, 4], [1, 6, 8]], dtype="int64"),
+            paddle.to_tensor([[1, 8, 6], [2, 4, 8]], dtype="int64"),
+        ):
+            with self.subTest(grid_thw=grid_thw.tolist()):
+                actual = self.model.rot_pos_emb(grid_thw)
+                expected = self._legacy_rot_pos_emb(grid_thw)
+
+                self.assertTrue(bool(paddle.equal_all(actual, expected)))
+
+    def test_get_packed_seq_params_matches_legacy_reference(self):
+        grid_thw = paddle.to_tensor([[2, 4, 4], [1, 6, 8], [3, 2, 2]], dtype="int64")
+
+        actual = self.model.get_packed_seq_params(grid_thw)
+
+        seqlens = safe_repeat_interleave_values(grid_thw[:, 1] * grid_thw[:, 2], grid_thw[:, 0])
+        expected_cu_seqlens = F.pad(seqlens.cumsum(axis=0, dtype=paddle.int32), (1, 0), value=0).contiguous()
+
+        self.assertEqual(actual.max_seqlen_q, seqlens.max().item())
+        self.assertEqual(actual.max_seqlen_kv, seqlens.max().item())
+        self.assertEqual(actual.qkv_format, "thd")
+        self.assertTrue(bool(paddle.equal_all(actual.cu_seqlens_q, expected_cu_seqlens)))
+        self.assertTrue(bool(paddle.equal_all(actual.cu_seqlens_kv, expected_cu_seqlens)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.
- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
Function optimization

### PR changes
Models

### Description
本 PR 主要优化 `qwen3_vl/modeling_fleet.py` 中视觉位置编码相关的计算路径，减少重复计算，并补充对应回归测试。

具体改动如下：
- 将 `rot_pos_emb` 和 `fast_pos_embed_interpolate` 共享的 token-to-image / frame-local 映射抽出，避免两条路径重复构建同一套索引关系。
- 将 `rot_pos_emb` 的坐标展开逻辑张量化，减少逐样本 Python 循环。
- 将 `fast_pos_embed_interpolate` 的插值索引和权重构建张量化，保留当前实现允许的微小数值差异。
- 将 `get_packed_seq_params` 的 `seqlens` / `cu_seqlens` 构建改为张量化实现，避免重复展开。
- 新增 `tests/transformers/qwen3_vl/test_modeling_fleet.py`，覆盖：
  - `rot_pos_emb` 与 legacy/reference 实现严格一致。
  - `get_packed_seq_params` 与 legacy/reference 实现严格一致。
  - `fast_pos_embed_interpolate` 在代表性 `grid_thw` 上与 legacy/reference 保持预期范围内的一致性（带容差校验）。

### Regression Validation (first 50 steps)

关键结果：
- loss step 1: baseline `1.189706` vs patched `1.189489`
- loss step 50: baseline `0.575090` vs patched `0.571413`
- loss max abs diff: `0.017059` at step `31`
- global_norm step 1: baseline `23.326054` vs patched `22.457565`
- global_norm step 50: baseline `1.690692` vs patched `1.906793`
- global_norm max abs diff: `2.807811` at step `45`

<img width="1106" height="798" alt="image" src="https://github.com/user-attachments/assets/c63852a1-6577-405b-86b7-0ec8e2a18752" />



Cherry-pick of #4161 to `release/1.1`.

Merged in dev: #4161  <!-- For pass CI -->