### PR TITLE
[feat(sampler)]: support consumed data skip for mapping sampler

### DIFF
--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -94,7 +94,7 @@ from paddle.distributed.fleet.utils.hybrid_parallel_util import (
 from paddle.distributed.fleet.utils.sequence_parallel_utils import (
     register_sequence_parallel_allreduce_hooks,
 )
-from paddle.io import DataLoader, Dataset, DistributedBatchSampler
+from paddle.io import DataLoader, Dataset
 from tqdm.auto import tqdm
 
 from ..data import (
@@ -137,7 +137,7 @@ from ..transformers.segment_parallel_utils import (
     split_inputs_sequence_dim,
 )
 from ..utils import empty_device_cache, perf_utils
-from ..utils.batch_sampler import DistributedBatchSampler as NlpDistributedBatchSampler
+from ..utils.batch_sampler import MappingBatchSampler, MappingDistributedBatchSampler
 from ..utils.download import resolve_file_path
 from ..utils.env import (
     EMA_STATE_DIC,
@@ -1873,6 +1873,7 @@ class Trainer:
         self.state.epoch = 0
         epochs_trained = 0
         steps_trained_in_current_epoch = 0
+        consumed_samples = 0
         steps_trained_progress_bar = None
 
         # Check if continuing training from a checkpoint
@@ -1915,16 +1916,13 @@ class Trainer:
                     steps_trained_progress_bar.set_description("Skipping the first batches")
             if not args.ignore_data_skip:
                 if isinstance(train_dataloader, paddle.io.DataLoader) and isinstance(
-                    train_dataloader.batch_sampler, NlpDistributedBatchSampler
+                    train_dataloader.batch_sampler, (MappingBatchSampler, MappingDistributedBatchSampler)
                 ):
-                    consumed_samples = (
-                        self.state.global_step
-                        * args.train_batch_size
-                        * args.gradient_accumulation_steps
-                        * args.dataset_world_size
-                    )
+                    consumed_samples = steps_trained_in_current_epoch * args.train_batch_size * args.dataset_world_size
                     train_dataloader.batch_sampler.set_epoch(consumed_samples=consumed_samples)
-                    logger.info(f"Set DistributedBatchSampler consumed_samples to {consumed_samples}")
+                    logger.info(
+                        f"Set MappingBatchSampler/MappingDistributedBatchSampler consumed_samples to {consumed_samples}"
+                    )
 
         epoch_iterator = train_dataloader
         # Use len_dataloader directly instead of len(epoch_iterator) to avoid
@@ -1971,9 +1969,9 @@ class Trainer:
             if (
                 not args.enable_auto_parallel
                 and isinstance(train_dataloader, paddle.io.DataLoader)
-                and isinstance(train_dataloader.batch_sampler, DistributedBatchSampler)
+                and isinstance(train_dataloader.batch_sampler, (MappingBatchSampler, MappingDistributedBatchSampler))
             ):
-                train_dataloader.batch_sampler.set_epoch(epoch)
+                train_dataloader.batch_sampler.set_epoch(epoch, consumed_samples)
 
             step_control = 0  # used in loop control, reset to 0 after every step
             self.control = self.callback_handler.on_epoch_begin(args, self.state, self.control)
@@ -2000,14 +1998,14 @@ class Trainer:
                 self.callback_handler.on_load_data_end(args, self.state, self.control, inputs=inputs)
 
                 # Skip past any already trained steps if resuming training
-                # for paddleformers.utils.batch_sampler.DistributedBatchSampler
+                # for paddleformers.utils.batch_sampler.(MappingBatchSampler & MappingDistributedBatchSampler)
                 # We use consumed_samples to reset the status
                 dataloader = train_dataloader
                 if self.args.enable_auto_parallel:
                     dataloader = train_dataloader._dataloader
 
                 if isinstance(dataloader, paddle.io.DataLoader) and isinstance(
-                    dataloader.batch_sampler, NlpDistributedBatchSampler
+                    dataloader.batch_sampler, (MappingBatchSampler, MappingDistributedBatchSampler)
                 ):
                     if step == 0:
                         if steps_trained_progress_bar is not None:
@@ -2320,6 +2318,8 @@ class Trainer:
             if self.control.should_training_stop:
                 break
 
+            consumed_samples = 0
+
         if args.past_index and hasattr(self, "_past"):
             # Clean the state at the end of training
             delattr(self, "_past")
@@ -2441,7 +2441,7 @@ class Trainer:
             total_batch_size = total_batch_size * self.args.dataset_world_size
 
         if self.args.enable_auto_parallel or self.args.world_size <= 1:
-            batch_sampler = paddle.io.BatchSampler(
+            batch_sampler = MappingBatchSampler(
                 dataset=self.train_dataset,
                 shuffle=shuffle,
                 batch_size=total_batch_size,
@@ -2454,7 +2454,7 @@ class Trainer:
                 batch_sampler._acc_steps = self.args.gradient_accumulation_steps
             return batch_sampler
 
-        return DistributedBatchSampler(
+        return MappingDistributedBatchSampler(
             self.train_dataset,
             batch_size=total_batch_size,
             shuffle=shuffle,
@@ -2795,7 +2795,7 @@ class Trainer:
         if eval_dataset is None or not has_length(eval_dataset):
             return None
         if self.args.world_size <= 1:
-            return paddle.io.BatchSampler(
+            return MappingBatchSampler(
                 eval_dataset,
                 batch_size=self.args.per_device_eval_batch_size,
                 shuffle=False,
@@ -2818,7 +2818,7 @@ class Trainer:
                     drop_last=False,
                 )
             else:
-                return DistributedBatchSampler(
+                return MappingDistributedBatchSampler(
                     eval_dataset,
                     num_replicas=self.args.dataset_world_size,
                     rank=self.args.dataset_rank,
@@ -4644,7 +4644,7 @@ class Trainer:
             # on eval limit steps
             num_samples = batch_size * self.args.dataset_world_size * max_eval_iters
             if isinstance(dataloader, _DataLoaderIterBase) and isinstance(
-                dataloader._batch_sampler, NlpDistributedBatchSampler
+                dataloader._batch_sampler, (MappingBatchSampler, MappingDistributedBatchSampler)
             ):
                 consumed_samples = (
                     ((self.state.global_step) // args.eval_steps)

--- a/paddleformers/utils/batch_sampler.py
+++ b/paddleformers/utils/batch_sampler.py
@@ -22,14 +22,47 @@ import paddle
 __all__ = ["MappingBatchSampler", "MappingDistributedBatchSampler", "DistributedBatchSampler"]
 
 
+class RandomSamplerWithSeed(paddle.io.RandomSampler):
+    def __init__(self, data_source, replacement=False, num_samples=None, generator=None) -> None:
+        super().__init__(data_source, replacement=replacement, num_samples=num_samples, generator=generator)
+        self.epoch = 0
+
+    def set_epoch(self, epoch=0):
+        self.epoch = epoch
+
+    def __iter__(self):
+        n = len(self.data_source)
+        num_samples = self.num_samples if self.num_samples is not None else n
+        if self.generator:
+            for i in range(num_samples):
+                try:
+                    index = next(self.generator)
+                except StopIteration:
+                    return
+                yield index
+        else:
+            for index in (
+                np.random.RandomState(self.epoch).choice(np.arange(n), num_samples, replace=self.replacement).tolist()
+            ):
+                yield index
+
+
 class MappingBatchSampler(paddle.io.BatchSampler):
     def __init__(self, dataset, batch_size, shuffle=False, drop_last=False, consumed_samples=0):
-        super().__init__(dataset, batch_size=batch_size, shuffle=shuffle, drop_last=drop_last)
+
+        if shuffle:
+            sampler = RandomSamplerWithSeed(dataset)
+        else:
+            sampler = paddle.io.SequenceSampler(dataset)
+
+        super().__init__(sampler=sampler, batch_size=batch_size, drop_last=drop_last)
         self.consumed_samples = consumed_samples
 
     def set_epoch(self, epoch=0, consumed_samples=0):
         self.epoch = epoch
         self.consumed_samples = consumed_samples
+        if isinstance(self.sampler, RandomSamplerWithSeed):
+            self.sampler.set_epoch(epoch=epoch)
 
     def __iter__(self):
 

--- a/paddleformers/utils/batch_sampler.py
+++ b/paddleformers/utils/batch_sampler.py
@@ -14,9 +14,117 @@
 
 from __future__ import division, print_function
 
+import math
+
+import numpy as np
 import paddle
 
-__all__ = ["DistributedBatchSampler"]
+__all__ = ["MappingBatchSampler", "MappingDistributedBatchSampler", "DistributedBatchSampler"]
+
+
+class MappingBatchSampler(paddle.io.BatchSampler):
+    def __init__(self, dataset, batch_size, shuffle=False, drop_last=False, consumed_samples=0):
+        super().__init__(dataset, batch_size=batch_size, shuffle=shuffle, drop_last=drop_last)
+        self.consumed_samples = consumed_samples
+
+    def set_epoch(self, epoch=0, consumed_samples=0):
+        self.epoch = epoch
+        self.consumed_samples = consumed_samples
+
+    def __iter__(self):
+
+        # Yield in batches
+        local_batch_size = self.batch_size * self._acc_steps
+        batch_indices = []
+        for idx in self.sampler:
+            # Skip consumed samples for resume
+            if self.consumed_samples > 0:
+                self.consumed_samples -= 1
+                continue
+            batch_indices.append(idx)
+            if len(batch_indices) == local_batch_size:
+                yield batch_indices
+                batch_indices = []
+        if not self.drop_last and len(batch_indices) > 0:
+            yield batch_indices
+
+
+class MappingDistributedBatchSampler(paddle.io.DistributedBatchSampler):
+    def __init__(
+        self, dataset, batch_size, num_replicas=None, rank=None, shuffle=False, drop_last=False, consumed_samples=0
+    ):
+        super().__init__(
+            dataset, batch_size, num_replicas=num_replicas, rank=rank, shuffle=shuffle, drop_last=drop_last
+        )
+        self.consumed_samples = consumed_samples
+
+    def set_epoch(self, epoch=0, consumed_samples=0):
+        self.epoch = epoch
+        self.consumed_samples = consumed_samples
+
+    def __iter__(self):
+        num_samples = len(self.dataset)
+        indices = np.arange(num_samples).tolist()
+
+        # Add extra samples to make it evenly divisible
+        padding_size = self.total_size - len(indices)
+        if padding_size <= len(indices):
+            indices += indices[:padding_size]
+        else:
+            indices += (indices * math.ceil(padding_size / len(indices)))[:padding_size]
+
+        assert len(indices) == self.total_size
+
+        if self.shuffle:
+            np.random.RandomState(self.epoch).shuffle(indices)
+            self.epoch += 1
+
+        # Subsample for local rank
+        def _get_indices_by_batch_size(indices):
+            subsampled_indices = []
+            last_batch_size = self.total_size % (self.batch_size * self.nranks)
+            assert last_batch_size % self.nranks == 0
+            last_local_batch_size = last_batch_size // self.nranks
+
+            for i in range(
+                self.local_rank * self.batch_size,
+                len(indices) - last_batch_size,
+                self.batch_size * self.nranks,
+            ):
+                subsampled_indices.extend(indices[i : i + self.batch_size])
+
+            indices = indices[len(indices) - last_batch_size :]
+            subsampled_indices.extend(
+                indices[self.local_rank * last_local_batch_size : (self.local_rank + 1) * last_local_batch_size]
+            )
+            return subsampled_indices
+
+        if self.nranks > 1:
+            indices = _get_indices_by_batch_size(indices)
+
+        assert len(indices) == self.num_samples
+
+        assert (
+            self.consumed_samples % self.nranks == 0
+        ), "The consumed_samples should be divided by nranks. consumed_samples=%d, nranks=%s" % (
+            self.consumed_samples,
+            self.nranks,
+        )
+
+        # Skip consumed samples for resume (per-rank)
+        consumed_per_rank = self.consumed_samples // self.nranks
+        indices = indices[consumed_per_rank:]
+
+        # Yield in batches
+        local_batch_size = self.batch_size * self._acc_steps
+        batch_indices = []
+        for idx in indices:
+            batch_indices.append(idx)
+            if len(batch_indices) == local_batch_size:
+                yield batch_indices
+                batch_indices = []
+        if not self.drop_last and len(batch_indices) > 0:
+            yield batch_indices
 
 
 class DistributedBatchSampler(paddle.io.BatchSampler):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->

为 Mapping 数据集 `paddle.io.Dataset` 的断点续训添加精确的数据跳过能力。
                                                                                                                                                                                                                                                            
原有实现使用原生 `paddle.io.BatchSampler/DistributedBatchSampler`，不支持 consumed_samples 机制，resume 后会从数据集头部重新消费，导致数据重复。                                                                                                                                                                                    
                  
Changes:
  - 新增 `MappingBatchSampler`：继承 `paddle.io.BatchSampler`，支持通过 consumed_samples 在迭代时跳过已消费样本，适用于单机及 auto_parallel 场景
  - 新增 `MappingDistributedBatchSampler`：继承 `paddle.io.DistributedBatchSampler`，将全局 consumed_samples 均摊到各 rank（consumed_per_rank = consumed_samples // nranks），通过索引切片跳过，适用于多卡分布式场景
  - 两类均实现 `set_epoch(epoch, consumed_samples)` 接口，epoch 结束后 consumed_samples 自动重置为 0，后续 epoch 从头开始
  - Trainer 中替换 train/eval sampler 为新类，并修正 consumed_samples 计算公式为：`steps_trained_in_current_epoch * train_batch_size * dataset_world_size`
  - resume 时 sampler 层完成数据跳过，DataLoader 迭代直接从第一个未消费 batch 开始，无额外迭代开销