### PR TITLE
[codex] fix legacy context parallel HCG selection

### DIFF
--- a/paddleformers/trainer/training_args.py
+++ b/paddleformers/trainer/training_args.py
@@ -75,6 +75,69 @@ def default_logdir() -> str:
     return os.path.join("runs", current_time + "_" + socket.gethostname())
 
 
+def ensure_context_parallel_hcg():
+    """
+    Rebuild Fleet HCG with the CP-capable implementation on legacy Paddle
+    releases where `fleet.init` still creates `HybridCommunicateGroup` even
+    when `cp_degree > 1`.
+    """
+
+    fleet_env = getattr(fleet, "fleet", None)
+    if fleet_env is None or not hasattr(fleet_env, "_hcg"):
+        return
+
+    hcg = fleet_env.get_hybrid_communicate_group()
+    if hasattr(hcg, "get_context_parallel_world_size"):
+        return
+
+    cp_degree = max(getattr(fleet_env, "cp_degree", 1), 1)
+    if cp_degree <= 1:
+        return
+
+    from paddle.distributed.fleet.base import topology as tp
+
+    if not hasattr(tp, "EPHybridCommunicateGroup"):
+        return
+
+    order = list(fleet_env._user_defined_strategy.hybrid_parallel_order)
+    if "ep" not in order:
+        order.insert(-1, "ep")
+    if "sharding" in order and "moe_sharding" not in order:
+        order.insert(order.index("sharding"), "moe_sharding")
+    if cp_degree > 1 and "cp" not in order:
+        insert_idx = order.index("sharding") if "sharding" in order else max(len(order) - 1, 0)
+        order.insert(insert_idx, "cp")
+    fleet_env._user_defined_strategy.hybrid_parallel_order = order
+    degree_mapping = {
+        "dp": ["data", max(getattr(fleet_env, "dp_degree", 1), 1)],
+        "pp": ["pipe", max(getattr(fleet_env, "pp_degree", 1), 1)],
+        "sharding": ["sharding", max(getattr(fleet_env, "sharding_degree", 1), 1)],
+        "mp": ["model", max(getattr(fleet_env, "mp_degree", 1), 1)],
+        "sep": ["sep", max(getattr(fleet_env, "sep_degree", 1), 1)],
+        "cp": ["context", cp_degree],
+        "ep": ["expert", max(getattr(fleet_env, "ep_degree", 1), 1)],
+        "moe_sharding": [
+            "moe_sharding",
+            max(getattr(fleet_env, "moe_sharding_degree", 1), getattr(fleet_env, "sharding_degree", 1), 1),
+        ],
+    }
+
+    hybrid_group_names = []
+    dims = []
+    for key in order:
+        name, degree = degree_mapping[key]
+        hybrid_group_names.append(name)
+        dims.append(degree)
+
+    logger.warning(
+        "Detected legacy Fleet HCG without context parallel APIs. "
+        f"Rebuilding HCG with EPHybridCommunicateGroup for cp_degree={cp_degree}."
+    )
+    new_hcg = tp.EPHybridCommunicateGroup(hybrid_group_names, dims, fleet_env.hybrid_configs)
+    fleet_env._topology = new_hcg._dense_topo
+    fleet_env._hcg = new_hcg
+
+
 @dataclass
 class TrainingArguments:
     """
@@ -1988,6 +2051,9 @@ class TrainingArguments:
                         logger.warning("context parallel is not supported!!! Ignore it.")
                     return support_cp
 
+                support_cp = is_context_parallel_supported()
+                enable_context_parallel = self.context_parallel_size > 1 and support_cp
+
                 if self.hybrid_parallel_topo_order == "pp_first":
                     if is_segment_parallel_supported():
                         order = ["dp", "pp", "sharding", "sep", "mp"]
@@ -1998,6 +2064,12 @@ class TrainingArguments:
                         order = ["dp", "sharding", "pp", "sep", "mp"]
                     else:
                         order = ["dp", "sharding", "pp", "mp"]
+                if not self.use_expert_parallel and enable_context_parallel:
+                    order.insert(-1, "ep")
+                    sd_idx = order.index("sharding")
+                    order.insert(sd_idx, "moe_sharding")
+                    sd_idx = order.index("sharding")
+                    order.insert(sd_idx, "cp")
                 if self.use_expert_parallel:
                     if not self.reorder_pipeline_priority:
                         if self.moe_sharding_parallel_size >= 1 and self.expert_model_parallel_size > 1:
@@ -2006,19 +2078,19 @@ class TrainingArguments:
                             # if pp_first, the order = ["dp", "pp", "moe_sharding", "sharding", "sep", "ep", "mp"]
                             # if sharding_first, the order is ["dp", "moe_sharding", "sharding", "pp", "sep", "ep", "mp"]
                             order.insert(sd_idx, "moe_sharding")
-                            if is_context_parallel_supported():
+                            if enable_context_parallel:
                                 sd_idx = order.index("sharding")
                                 order.insert(sd_idx, "cp")
                     else:
                         if self.moe_sharding_parallel_size >= 1 and self.expert_model_parallel_size > 1:
-                            if is_context_parallel_supported():
+                            if enable_context_parallel:
                                 order = ["sharding", "moe_sharding", "pp", "sep", "cp", "dp", "ep", "mp"]
                             else:
                                 order = ["sharding", "moe_sharding", "pp", "sep", "dp", "ep", "mp"]
                         else:
                             order = ["sharding", "pp", "sep", "dp", "mp"]
 
-                if is_context_parallel_supported():
+                if support_cp:
                     hybrid_configs = {
                         "dp_degree": self.data_parallel_size,
                         "mp_degree": self.tensor_model_parallel_size,
@@ -2028,6 +2100,9 @@ class TrainingArguments:
                         "cp_degree": self.context_parallel_size,
                         "order": order,
                     }
+                    if not self.use_expert_parallel and enable_context_parallel:
+                        hybrid_configs["ep_degree"] = 1
+                        hybrid_configs["moe_sharding_degree"] = self.sharding_parallel_size
                 elif is_segment_parallel_supported():
                     hybrid_configs = {
                         "dp_degree": self.data_parallel_size,
@@ -2177,6 +2252,7 @@ class TrainingArguments:
                     strategy = init_nccl_config(self.nccl_comm_group_config, strategy)
 
                 fleet.init(is_collective=True, strategy=strategy)
+                ensure_context_parallel_hcg()
 
                 # In PaddleFleet, we should use the following code to initialize.
                 if (

--- a/paddleformers/trainer/training_args.py
+++ b/paddleformers/trainer/training_args.py
@@ -2101,7 +2101,9 @@ class TrainingArguments:
                         "order": order,
                     }
                     if not self.use_expert_parallel and enable_context_parallel:
-                        hybrid_configs["ep_degree"] = 1
+                        hybrid_configs["ep_degree"] = (
+                            self.data_parallel_size * self.sep_parallel_size * self.tensor_model_parallel_size
+                        )
                         hybrid_configs["moe_sharding_degree"] = self.sharding_parallel_size
                 elif is_segment_parallel_supported():
                     hybrid_configs = {

--- a/paddleformers/utils/paddle_patch.py
+++ b/paddleformers/utils/paddle_patch.py
@@ -154,3 +154,53 @@ if enable_paddleformers_monkey_patch:
 
 if not hasattr(paddle, "cat"):
     paddle.cat = paddle.concat
+
+
+def _patch_fleet_create_hcg_for_context_parallel():
+    """
+    Older Paddle releases expose context parallel support only on
+    EPHybridCommunicateGroup, but Fleet still instantiates the legacy
+    HybridCommunicateGroup unless expert parallel is enabled. That breaks
+    non-MoE CP jobs during argument parsing and HCG access.
+    """
+
+    try:
+        from paddle.distributed import fleet as dist_fleet
+        from paddle.distributed.fleet.base import topology as tp
+    except Exception:
+        return
+
+    if not hasattr(tp, "EPHybridCommunicateGroup"):
+        return
+
+    # Newer Paddle releases already expose CP APIs on the default HCG path.
+    if hasattr(tp.HybridCommunicateGroup, "get_context_parallel_world_size"):
+        return
+    if not hasattr(tp.EPHybridCommunicateGroup, "get_context_parallel_world_size"):
+        return
+
+    fleet_obj = getattr(dist_fleet, "fleet", None)
+    if fleet_obj is None:
+        return
+
+    fleet_cls = type(fleet_obj)
+    if getattr(fleet_cls, "_paddleformers_cp_hcg_patched", False):
+        return
+
+    original_create_hcg = fleet_cls._create_hcg
+
+    def patched_create_hcg(self, hybrid_group_names, dims):
+        dim_dict = dict(zip(hybrid_group_names, dims))
+        use_ep_hcg = dim_dict.get("expert", 1) > 1 or dim_dict.get("context", 1) > 1
+        if use_ep_hcg:
+            hcg = tp.EPHybridCommunicateGroup(hybrid_group_names, dims, self.hybrid_configs)
+            self._topology = hcg._dense_topo
+            return hcg
+        return original_create_hcg(self, hybrid_group_names, dims)
+
+    fleet_cls._create_hcg = patched_create_hcg
+    fleet_cls._paddleformers_cp_hcg_patched = True
+
+
+if enable_paddleformers_monkey_patch:
+    _patch_fleet_create_hcg_for_context_parallel()


### PR DESCRIPTION
## 修改内容

这个 PR 修复了Paddle 在混合并行初始化阶段对 Context Parallel 的兼容性问题，使非 MoE 任务也能安全开启 CP。

- patch `Fleet._create_hcg`，在 `context > 1` 时选择 `EPHybridCommunicateGroup`
- 在 `fleet.init()` 之后补做一次 HCG 校正，兼容旧版 Paddle 仍然错误创建非 CP HCG 的情况
- 为非 expert parallel 的 CP 任务补齐缺失的 `cp / ep / moe_sharding` 拓扑项和 degree 配置
- 将这套额外拓扑逻辑严格限制在 `context_parallel_size > 1` 的场景，避免影响只开 TP 的任务
- 修复 `tp > 1` 且 `cp > 1` 时 legacy `EPHybridCommunicateGroup` 的 degree 组合问题，使 dense/moe/cp world size 保持一致

## 问题原因

在 Paddle 中，Context Parallel 相关接口只存在于 `EPHybridCommunicateGroup`，而默认的 Fleet 初始化路径在未开启 expert parallel 时仍会创建普通 `HybridCommunicateGroup`。

这会导致配置解析阶段允许 `context_parallel_size > 1`，但后续 PaddleFormers 在读取 CP sharding 信息时，拿到的 HCG 实例并不具备对应的 CP 接口，最终在训练初始化阶段报错。

## 影响范围

- 修复 Paddle 下非 MoE 任务的 CP 初始化问题
- 保持 `context_parallel_size == 1` 的原有行为不变
- 避免 TP-only 配置误走 CP 拓扑补丁逻辑
- 支持 `tp > 1` 和 `cp > 1` 同时开启的 legacy CP 初始化路径

## 根因补充

之前的逻辑把“当前环境支持 CP”与“当前任务实际开启了 CP”混为一谈。

这对单纯修复 CP 初始化来说还不够准确，在非 CP 任务中会导致 TP-only 配置也被错误注入 CP 相关拓扑，进而在进程组创建阶段触发额外错误。

另外，在 `tp > 1` 且 `cp > 1` 的非 expert 场景下，如果 synthetic `ep_degree` 没有吸收 TP 维度，旧版 `EPHybridCommunicateGroup` 会出现 dense/moe 拓扑 world size 不一致的问题。

