### PR TITLE
Add GLM4 support to PaddleFormers

### DIFF
--- a/paddleformers/transformers/__init__.py
+++ b/paddleformers/transformers/__init__.py
@@ -299,6 +299,8 @@ import_structure = {
     "qwen2_vl": [],
     "qwen3_moe": [],
     "qwen3_next": [],
+    "glm4.configuration": ["Glm4Config"],
+    "glm4.modeling": ["Glm4Model", "Glm4ForCausalLM"],
     "glm4_moe.configuration": ["Glm4MoeConfig"],
     "whisper.processor": ["WhisperFeatureExtractor"],
     "glm4_moe": ["Glm4MoeForCausalLMPipe", "Glm4MoeModel", "Glm4MoeForCausalLM", "Glm4MoeForCausalLMDeprecated"],
@@ -404,6 +406,8 @@ if TYPE_CHECKING:
     from .phi3 import *
     from .gemma3_text import *
     from .glm_ocr import *
+    from .glm4.configuration import *
+    from .glm4.modeling import *
 else:
     sys.modules[__name__] = _LazyModule(
         __name__,

--- a/paddleformers/transformers/__init__.py
+++ b/paddleformers/transformers/__init__.py
@@ -76,6 +76,7 @@ import_structure = {
         "AutoModelForQuestionAnswering",
         "AutoModelForMultipleChoice",
         "AutoModelForMaskedLM",
+        "AutoModelForCausalLM",
         "AutoModelForCausalLMPipe",
         "AutoEncoder",
         "AutoDecoder",

--- a/paddleformers/transformers/auto/configuration.py
+++ b/paddleformers/transformers/auto/configuration.py
@@ -86,6 +86,7 @@ MODEL_NAMES_MAPPING = OrderedDict(
         ("qwen3_vl_moe", "Qwen3VLMoe"),
         ("qwen3_vl_moe_text", "Qwen3VLMoeText"),
         ("glm_ocr", "GlmOcrForConditionalGeneration"),
+        ("glm4", "Glm4"),
         ("qwen3_5_moe", "Qwen3_5MoEForConditionalGeneration"),
     ]
 )

--- a/paddleformers/transformers/auto/configuration.py
+++ b/paddleformers/transformers/auto/configuration.py
@@ -52,6 +52,7 @@ CONFIG_MAPPING_NAMES = OrderedDict(
         ("qwen3_vl_moe", "Qwen3VLMoeConfig"),
         ("qwen3_vl_moe_text", "Qwen3VLMoeTextConfig"),
         ("glm4_moe", "Glm4MoeConfig"),
+        ("glm4", "Glm4Config"),
         ("gpt_oss", "GptOssConfig"),
         ("phi3", "Phi3Config"),
         ("gemma3_text", "Gemma3TextConfig"),

--- a/paddleformers/transformers/auto/modeling.py
+++ b/paddleformers/transformers/auto/modeling.py
@@ -70,6 +70,7 @@ MAPPING_NAMES = OrderedDict(
         ("Qwen3VLMoe", "qwen3_vl_moe"),
         ("Qwen3_5Moe", "qwen3_5"),
         ("Glm4Moe", "glm4_moe"),
+        ("Glm4", "glm4"),
         ("GptOss", "gpt_oss"),
         ("Phi3", "phi3"),
         ("Gemma3", "gemma3_text"),

--- a/paddleformers/transformers/auto/tokenizer.py
+++ b/paddleformers/transformers/auto/tokenizer.py
@@ -42,7 +42,12 @@ from transformers.models.encoder_decoder.configuration_encoder_decoder import (
     EncoderDecoderConfig,
 )
 from transformers.tokenization_utils_base import TOKENIZER_CONFIG_FILE
-from transformers.tokenization_utils_tokenizers import TokenizersBackend
+try:
+    from transformers.tokenization_utils_tokenizers import TokenizersBackend
+except ImportError:
+    # Transformers < 5 does not expose TokenizersBackend; its fast tokenizer
+    # provides the compatible from_pretrained interface used below.
+    from transformers import PreTrainedTokenizerFast as TokenizersBackend
 from transformers.utils import cached_file
 
 from ...utils.download import DownloadSource, resolve_file_path

--- a/paddleformers/transformers/glm4/__init__.py
+++ b/paddleformers/transformers/glm4/__init__.py
@@ -1,0 +1,9 @@
+from .configuration import Glm4Config
+from .modeling import Glm4PretrainedModel, Glm4Model, Glm4ForCausalLM
+
+__all__ = [
+    "Glm4Config",
+    "Glm4PretrainedModel",
+    "Glm4Model",
+    "Glm4ForCausalLM",
+]

--- a/paddleformers/transformers/glm4/__init__.py
+++ b/paddleformers/transformers/glm4/__init__.py
@@ -1,5 +1,19 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from .configuration import Glm4Config
-from .modeling import Glm4PretrainedModel, Glm4Model, Glm4ForCausalLM
+from .modeling import Glm4ForCausalLM, Glm4Model, Glm4PretrainedModel
 
 __all__ = [
     "Glm4Config",

--- a/paddleformers/transformers/glm4/configuration.py
+++ b/paddleformers/transformers/glm4/configuration.py
@@ -1,4 +1,16 @@
-# paddleformers/transformers/glm4/configuration.py
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from __future__ import annotations
 

--- a/paddleformers/transformers/glm4/configuration.py
+++ b/paddleformers/transformers/glm4/configuration.py
@@ -1,0 +1,83 @@
+# paddleformers/transformers/glm4/configuration.py
+
+from __future__ import annotations
+
+from ..configuration_utils import PretrainedConfig
+
+__all__ = ["Glm4Config"]
+
+
+class Glm4Config(PretrainedConfig):
+    r"""
+    Minimal GLM-4 dense config for GLM-4-9B-0414 compatibility.
+
+    This is intentionally kept close to the HF glm4 config / checkpoint fields,
+    so AutoConfig can recognize `model_type="glm4"` and later modeling.py can
+    consume the same attributes directly.
+    """
+
+    model_type = "glm4"
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        vocab_size: int = 151552,
+        hidden_size: int = 4096,
+        intermediate_size: int = 13696,
+        num_hidden_layers: int = 40,
+        num_attention_heads: int = 32,
+        num_key_value_heads: int = 2,
+        head_dim: int = 128,
+        hidden_act: str = "silu",
+        max_position_embeddings: int = 131072,
+        initializer_range: float = 0.02,
+        rms_norm_eps: float = 1e-5,
+        use_cache: bool = True,
+        tie_word_embeddings: bool = False,
+        rope_theta: float = 10000.0,
+        rope_scaling=None,
+        partial_rotary_factor: float = 0.5,
+        attention_bias: bool = True,
+        attention_dropout: float = 0.0,
+        bos_token_id=None,
+        eos_token_id=None,
+        pad_token_id: int = 151329,
+        torch_dtype: str | None = None,
+        architectures=None,
+        **kwargs,
+    ):
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.head_dim = head_dim
+        self.hidden_act = hidden_act
+        self.max_position_embeddings = max_position_embeddings
+        self.initializer_range = initializer_range
+        self.rms_norm_eps = rms_norm_eps
+        self.use_cache = use_cache
+        self.tie_word_embeddings = tie_word_embeddings
+        self.rope_theta = rope_theta
+        self.rope_scaling = rope_scaling
+        self.partial_rotary_factor = partial_rotary_factor
+        self.attention_bias = attention_bias
+        self.attention_dropout = attention_dropout
+        self.torch_dtype = torch_dtype
+
+        if eos_token_id is None:
+            eos_token_id = [151329, 151336, 151338]
+
+        if architectures is None:
+            architectures = ["Glm4ForCausalLM"]
+
+        self.architectures = architectures
+
+        super().__init__(
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            pad_token_id=pad_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )

--- a/paddleformers/transformers/glm4/modeling.py
+++ b/paddleformers/transformers/glm4/modeling.py
@@ -109,10 +109,7 @@ class Glm4RotaryEmbedding(nn.Layer):
         if self.rotary_dim % 2 != 0:
             self.rotary_dim -= 1
 
-        inv_freq = 1.0 / (
-            self.base
-            ** (paddle.arange(0, self.rotary_dim, 2, dtype="float32") / self.rotary_dim)
-        )
+        inv_freq = 1.0 / (self.base ** (paddle.arange(0, self.rotary_dim, 2, dtype="float32") / self.rotary_dim))
         self.register_buffer("inv_freq", inv_freq, persistable=False)
 
     def forward(self, position_ids):
@@ -193,15 +190,11 @@ class Glm4Attention(nn.Layer):
         key_states = self.k_proj(hidden_states)
         value_states = self.v_proj(hidden_states)
 
-        query_states = query_states.reshape(
-            [bsz, q_len, self.num_heads, self.head_dim]
-        ).transpose([0, 2, 1, 3])
-        key_states = key_states.reshape(
-            [bsz, q_len, self.num_key_value_heads, self.head_dim]
-        ).transpose([0, 2, 1, 3])
-        value_states = value_states.reshape(
-            [bsz, q_len, self.num_key_value_heads, self.head_dim]
-        ).transpose([0, 2, 1, 3])
+        query_states = query_states.reshape([bsz, q_len, self.num_heads, self.head_dim]).transpose([0, 2, 1, 3])
+        key_states = key_states.reshape([bsz, q_len, self.num_key_value_heads, self.head_dim]).transpose([0, 2, 1, 3])
+        value_states = value_states.reshape([bsz, q_len, self.num_key_value_heads, self.head_dim]).transpose(
+            [0, 2, 1, 3]
+        )
 
         if position_ids is None:
             position_ids = paddle.arange(q_len, dtype="int64").unsqueeze(0).tile([bsz, 1])
@@ -211,9 +204,7 @@ class Glm4Attention(nn.Layer):
         else:
             cos, sin = position_embeddings
 
-        query_states, key_states = apply_rotary_pos_emb(
-            query_states, key_states, cos, sin, unsqueeze_dim=1
-        )
+        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, unsqueeze_dim=1)
 
         if past_key_value is not None and past_key_value[0] is not None:
             past_k, past_v = past_key_value
@@ -229,9 +220,7 @@ class Glm4Attention(nn.Layer):
             key_states = paddle.repeat_interleave(key_states, repeat_factor, axis=1)
             value_states = paddle.repeat_interleave(value_states, repeat_factor, axis=1)
 
-        attn_weights = paddle.matmul(
-            query_states, key_states, transpose_y=True
-        ) / (self.head_dim ** 0.5)
+        attn_weights = paddle.matmul(query_states, key_states, transpose_y=True) / (self.head_dim**0.5)
 
         kv_len = key_states.shape[2]
         cur_q_len = query_states.shape[2]
@@ -257,14 +246,10 @@ class Glm4Attention(nn.Layer):
             else:
                 attn_weights = attn_weights + attention_mask
 
-        attn_weights = F.softmax(attn_weights.astype("float32"), axis=-1).astype(
-            query_states.dtype
-        )
+        attn_weights = F.softmax(attn_weights.astype("float32"), axis=-1).astype(query_states.dtype)
         attn_output = paddle.matmul(attn_weights, value_states)
 
-        attn_output = attn_output.transpose([0, 2, 1, 3]).reshape(
-            [bsz, cur_q_len, self.num_heads * self.head_dim]
-        )
+        attn_output = attn_output.transpose([0, 2, 1, 3]).reshape([bsz, cur_q_len, self.num_heads * self.head_dim])
         attn_output = self.o_proj(attn_output)
 
         return attn_output, present
@@ -376,9 +361,7 @@ class Glm4Model(Glm4PretrainedModel):
             config.hidden_size,
             padding_idx=self.padding_idx,
         )
-        self.layers = nn.LayerList(
-            [Glm4DecoderLayer(config) for _ in range(config.num_hidden_layers)]
-        )
+        self.layers = nn.LayerList([Glm4DecoderLayer(config) for _ in range(config.num_hidden_layers)])
         self.norm = Glm4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.rotary_emb = Glm4RotaryEmbedding(config)
 
@@ -416,9 +399,7 @@ class Glm4Model(Glm4PretrainedModel):
             past_length = past_key_values[0][0].shape[2]
 
         if position_ids is None:
-            position_ids = paddle.arange(
-                past_length, past_length + seq_len, dtype="int64"
-            ).unsqueeze(0).tile([bsz, 1])
+            position_ids = paddle.arange(past_length, past_length + seq_len, dtype="int64").unsqueeze(0).tile([bsz, 1])
 
         position_embeddings = self.rotary_emb(position_ids)
 
@@ -491,9 +472,7 @@ class Glm4ForCausalLM(Glm4PretrainedModel):
                 paddle.zeros_like(position_ids),
             )
         else:
-            position_ids = paddle.arange(
-                input_ids.shape[1], dtype="int64"
-            ).unsqueeze(0).tile([input_ids.shape[0], 1])
+            position_ids = paddle.arange(input_ids.shape[1], dtype="int64").unsqueeze(0).tile([input_ids.shape[0], 1])
 
         if (
             past_key_values is not None

--- a/paddleformers/transformers/glm4/modeling.py
+++ b/paddleformers/transformers/glm4/modeling.py
@@ -1,0 +1,553 @@
+from __future__ import annotations
+
+import paddle
+import paddle.nn as nn
+import paddle.nn.functional as F
+
+from ..model_utils import PretrainedModel
+from ..model_outputs import CausalLMOutputWithPast
+from .configuration import Glm4Config
+
+__all__ = [
+    "Glm4PretrainedModel",
+    "Glm4Model",
+    "Glm4ForCausalLM",
+]
+
+
+def _normalize_config_dtype(config: Glm4Config):
+    """
+    Normalize HF-style torch_dtype to Paddle runtime dtype.
+
+    Priority:
+    1. keep config.dtype if already explicitly set
+    2. infer from config.torch_dtype
+    3. fallback to float32
+    """
+    cur_dtype = getattr(config, "dtype", None)
+    if cur_dtype is not None and str(cur_dtype).lower() not in ["none", "null", ""]:
+        return config
+
+    torch_dtype = getattr(config, "torch_dtype", None)
+    if torch_dtype is not None:
+        torch_dtype = str(torch_dtype).lower()
+
+    if torch_dtype in ["bfloat16", "bf16"]:
+        config.dtype = "bfloat16"
+    elif torch_dtype in ["float16", "fp16", "half"]:
+        config.dtype = "float16"
+    elif torch_dtype in ["float32", "fp32"]:
+        config.dtype = "float32"
+    else:
+        config.dtype = "float32"
+
+    return config
+
+
+class Glm4RMSNorm(nn.Layer):
+    def __init__(self, hidden_size, eps=1e-6):
+        super().__init__()
+        self.weight = self.create_parameter(
+            shape=[hidden_size],
+            default_initializer=nn.initializer.Constant(1.0),
+        )
+        self.eps = eps
+
+    def forward(self, hidden_states):
+        variance = paddle.mean(hidden_states * hidden_states, axis=-1, keepdim=True)
+        hidden_states = hidden_states * paddle.rsqrt(variance + self.eps)
+        return self.weight * hidden_states
+
+
+def rotate_half(x):
+    x1 = x[..., 0::2]
+    x2 = x[..., 1::2]
+    return paddle.stack([-x2, x1], axis=-1).flatten(start_axis=-2)
+
+
+def apply_rotary_pos_emb(q, k, cos, sin, unsqueeze_dim=1):
+    cos = paddle.unsqueeze(cos, axis=unsqueeze_dim)
+    sin = paddle.unsqueeze(sin, axis=unsqueeze_dim)
+    cos = paddle.repeat_interleave(cos, repeats=2, axis=-1)
+    sin = paddle.repeat_interleave(sin, repeats=2, axis=-1)
+
+    rotary_dim = cos.shape[-1]
+    q_rot, q_pass = q[..., :rotary_dim], q[..., rotary_dim:]
+    k_rot, k_pass = k[..., :rotary_dim], k[..., rotary_dim:]
+
+    q_embed = (q_rot * cos) + (rotate_half(q_rot) * sin)
+    k_embed = (k_rot * cos) + (rotate_half(k_rot) * sin)
+
+    q_embed = paddle.concat([q_embed, q_pass], axis=-1)
+    k_embed = paddle.concat([k_embed, k_pass], axis=-1)
+    return q_embed, k_embed
+
+
+class Glm4RotaryEmbedding(nn.Layer):
+    def __init__(self, config: Glm4Config):
+        super().__init__()
+        self.max_position_embeddings = config.max_position_embeddings
+        self.base = config.rope_theta
+        self.head_dim = config.head_dim
+        self.partial_rotary_factor = getattr(config, "partial_rotary_factor", 0.5)
+
+        self.rotary_dim = int(self.head_dim * self.partial_rotary_factor)
+        if self.rotary_dim % 2 != 0:
+            self.rotary_dim -= 1
+
+        inv_freq = 1.0 / (
+            self.base
+            ** (paddle.arange(0, self.rotary_dim, 2, dtype="float32") / self.rotary_dim)
+        )
+        self.register_buffer("inv_freq", inv_freq, persistable=False)
+
+    def forward(self, position_ids):
+        freqs = paddle.einsum("bs,d->bsd", position_ids.astype("float32"), self.inv_freq)
+        cos = paddle.cos(freqs)
+        sin = paddle.sin(freqs)
+        return cos, sin
+
+
+class Glm4MLP(nn.Layer):
+    def __init__(self, config: Glm4Config):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.intermediate_size
+
+        self.gate_up_proj = nn.Linear(
+            self.hidden_size,
+            self.intermediate_size * 2,
+            bias_attr=False,
+        )
+        self.down_proj = nn.Linear(
+            self.intermediate_size,
+            self.hidden_size,
+            bias_attr=False,
+        )
+
+    def forward(self, hidden_states):
+        gate_up = self.gate_up_proj(hidden_states)
+        gate, up = paddle.chunk(gate_up, chunks=2, axis=-1)
+        hidden_states = F.silu(gate) * up
+        hidden_states = self.down_proj(hidden_states)
+        return hidden_states
+
+
+class Glm4Attention(nn.Layer):
+    def __init__(self, config: Glm4Config):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.num_key_value_heads = config.num_key_value_heads
+        self.head_dim = config.head_dim
+        self.attention_dropout = config.attention_dropout
+
+        self.q_proj = nn.Linear(
+            self.hidden_size,
+            self.num_heads * self.head_dim,
+            bias_attr=config.attention_bias,
+        )
+        self.k_proj = nn.Linear(
+            self.hidden_size,
+            self.num_key_value_heads * self.head_dim,
+            bias_attr=config.attention_bias,
+        )
+        self.v_proj = nn.Linear(
+            self.hidden_size,
+            self.num_key_value_heads * self.head_dim,
+            bias_attr=config.attention_bias,
+        )
+        self.o_proj = nn.Linear(
+            self.num_heads * self.head_dim,
+            self.hidden_size,
+            bias_attr=False,
+        )
+        self.rotary_emb = Glm4RotaryEmbedding(config)
+
+    def forward(
+        self,
+        hidden_states,
+        attention_mask=None,
+        position_ids=None,
+        position_embeddings=None,
+        past_key_value=None,
+        use_cache=False,
+    ):
+        bsz, q_len, _ = hidden_states.shape
+
+        query_states = self.q_proj(hidden_states)
+        key_states = self.k_proj(hidden_states)
+        value_states = self.v_proj(hidden_states)
+
+        query_states = query_states.reshape(
+            [bsz, q_len, self.num_heads, self.head_dim]
+        ).transpose([0, 2, 1, 3])
+        key_states = key_states.reshape(
+            [bsz, q_len, self.num_key_value_heads, self.head_dim]
+        ).transpose([0, 2, 1, 3])
+        value_states = value_states.reshape(
+            [bsz, q_len, self.num_key_value_heads, self.head_dim]
+        ).transpose([0, 2, 1, 3])
+
+        if position_ids is None:
+            position_ids = paddle.arange(q_len, dtype="int64").unsqueeze(0).tile([bsz, 1])
+
+        if position_embeddings is None:
+            cos, sin = self.rotary_emb(position_ids)
+        else:
+            cos, sin = position_embeddings
+
+        query_states, key_states = apply_rotary_pos_emb(
+            query_states, key_states, cos, sin, unsqueeze_dim=1
+        )
+
+        if past_key_value is not None and past_key_value[0] is not None:
+            past_k, past_v = past_key_value
+            key_states = paddle.concat([past_k, key_states], axis=2)
+            value_states = paddle.concat([past_v, value_states], axis=2)
+
+        present = None
+        if use_cache:
+            present = (key_states, value_states)
+
+        if self.num_key_value_heads != self.num_heads:
+            repeat_factor = self.num_heads // self.num_key_value_heads
+            key_states = paddle.repeat_interleave(key_states, repeat_factor, axis=1)
+            value_states = paddle.repeat_interleave(value_states, repeat_factor, axis=1)
+
+        attn_weights = paddle.matmul(
+            query_states, key_states, transpose_y=True
+        ) / (self.head_dim ** 0.5)
+
+        kv_len = key_states.shape[2]
+        cur_q_len = query_states.shape[2]
+        past_kv_len = kv_len - cur_q_len
+
+        q_pos = paddle.arange(cur_q_len, dtype="int64").unsqueeze(-1) + past_kv_len
+        k_pos = paddle.arange(kv_len, dtype="int64").unsqueeze(0)
+        causal = (q_pos >= k_pos).astype(attn_weights.dtype)
+        causal = causal.unsqueeze(0).unsqueeze(0)
+        attn_weights = attn_weights + (1.0 - causal) * -1e4
+
+        if attention_mask is not None:
+            if attention_mask.ndim == 2:
+                mask = attention_mask[:, None, None, :].astype(attn_weights.dtype)
+                if mask.shape[-1] != kv_len:
+                    pad_len = kv_len - mask.shape[-1]
+                    if pad_len > 0:
+                        pad = paddle.ones([mask.shape[0], 1, 1, pad_len], dtype=mask.dtype)
+                        mask = paddle.concat([pad, mask], axis=-1)
+                    else:
+                        mask = mask[:, :, :, -kv_len:]
+                attn_weights = attn_weights + (1.0 - mask) * -1e4
+            else:
+                attn_weights = attn_weights + attention_mask
+
+        attn_weights = F.softmax(attn_weights.astype("float32"), axis=-1).astype(
+            query_states.dtype
+        )
+        attn_output = paddle.matmul(attn_weights, value_states)
+
+        attn_output = attn_output.transpose([0, 2, 1, 3]).reshape(
+            [bsz, cur_q_len, self.num_heads * self.head_dim]
+        )
+        attn_output = self.o_proj(attn_output)
+
+        return attn_output, present
+
+
+class Glm4DecoderLayer(nn.Layer):
+    def __init__(self, config: Glm4Config):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+
+        self.input_layernorm = Glm4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.self_attn = Glm4Attention(config)
+
+        self.post_self_attn_layernorm = Glm4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = Glm4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+        self.mlp = Glm4MLP(config)
+
+        self.post_mlp_layernorm = Glm4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        hidden_states,
+        attention_mask=None,
+        position_ids=None,
+        position_embeddings=None,
+        past_key_value=None,
+        use_cache=False,
+    ):
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        attn_output, present = self.self_attn(
+            hidden_states,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            position_embeddings=position_embeddings,
+            past_key_value=past_key_value,
+            use_cache=use_cache,
+        )
+        attn_output = self.post_self_attn_layernorm(attn_output)
+        hidden_states = residual + attn_output
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        mlp_output = self.mlp(hidden_states)
+        mlp_output = self.post_mlp_layernorm(mlp_output)
+        hidden_states = residual + mlp_output
+
+        return hidden_states, present
+
+
+class Glm4PretrainedModel(PretrainedModel):
+    config_class = Glm4Config
+    base_model_prefix = "model"
+    supports_gradient_checkpointing = False
+
+    _hf_linear_weight_suffixes = (
+        "q_proj.weight",
+        "k_proj.weight",
+        "v_proj.weight",
+        "o_proj.weight",
+        "gate_up_proj.weight",
+        "down_proj.weight",
+        "lm_head.weight",
+    )
+
+    def _init_weights(self, layer):
+        return
+
+    def init_weights(self):
+        return
+
+    @classmethod
+    def _convert_hf_state_dict(cls, state_dict):
+        """
+        HF/PyTorch Linear weight: [out_features, in_features]
+        Paddle nn.Linear weight:  [in_features, out_features]
+
+        这里必须按名字强制转置，不能依赖 shape mismatch。
+        因为 q_proj/o_proj 这类 4096x4096 方阵 shape 一样，但语义仍然相反。
+        """
+        new_state_dict = {}
+        for k, v in state_dict.items():
+            if (
+                isinstance(v, paddle.Tensor)
+                and v.ndim == 2
+                and any(k.endswith(suffix) for suffix in cls._hf_linear_weight_suffixes)
+            ):
+                v = v.transpose([1, 0])
+            new_state_dict[k] = v
+        return new_state_dict
+
+    def set_state_dict(self, state_dict, *args, **kwargs):
+        already_converted = kwargs.pop("already_converted", False)
+        if not already_converted:
+            state_dict = self._convert_hf_state_dict(state_dict)
+        return super().set_state_dict(state_dict, *args, **kwargs)
+
+
+class Glm4Model(Glm4PretrainedModel):
+    def __init__(self, config: Glm4Config):
+        config = _normalize_config_dtype(config)
+        super().__init__(config)
+        self.config = config
+
+        self.padding_idx = config.pad_token_id
+        self.embed_tokens = nn.Embedding(
+            config.vocab_size,
+            config.hidden_size,
+            padding_idx=self.padding_idx,
+        )
+        self.layers = nn.LayerList(
+            [Glm4DecoderLayer(config) for _ in range(config.num_hidden_layers)]
+        )
+        self.norm = Glm4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = Glm4RotaryEmbedding(config)
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        position_ids=None,
+        inputs_embeds=None,
+        past_key_values=None,
+        use_cache=None,
+        return_dict=True,
+        **kwargs,
+    ):
+        if input_ids is None and inputs_embeds is None:
+            raise ValueError("You must provide either input_ids or inputs_embeds.")
+
+        if use_cache is None:
+            use_cache = self.config.use_cache
+
+        if inputs_embeds is None:
+            hidden_states = self.embed_tokens(input_ids)
+        else:
+            hidden_states = inputs_embeds
+
+        bsz, seq_len, _ = hidden_states.shape
+
+        past_length = 0
+        if (
+            past_key_values is not None
+            and len(past_key_values) > 0
+            and past_key_values[0] is not None
+            and past_key_values[0][0] is not None
+        ):
+            past_length = past_key_values[0][0].shape[2]
+
+        if position_ids is None:
+            position_ids = paddle.arange(
+                past_length, past_length + seq_len, dtype="int64"
+            ).unsqueeze(0).tile([bsz, 1])
+
+        position_embeddings = self.rotary_emb(position_ids)
+
+        if past_key_values is None:
+            past_key_values = [None] * len(self.layers)
+
+        next_past_key_values = [] if use_cache else None
+
+        for layer, past_key_value in zip(self.layers, past_key_values):
+            hidden_states, present = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                position_embeddings=position_embeddings,
+                past_key_value=past_key_value,
+                use_cache=use_cache,
+            )
+            if use_cache:
+                next_past_key_values.append(present)
+
+        hidden_states = self.norm(hidden_states)
+
+        if not return_dict:
+            if use_cache:
+                return hidden_states, next_past_key_values
+            return (hidden_states,)
+
+        return {
+            "last_hidden_state": hidden_states,
+            "past_key_values": next_past_key_values,
+        }
+
+
+class Glm4ForCausalLM(Glm4PretrainedModel):
+    _tied_weights_keys = ["lm_head.weight"]
+
+    def __init__(self, config: Glm4Config):
+        config = _normalize_config_dtype(config)
+        super().__init__(config)
+        self.config = config
+        self.model = Glm4Model(config)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias_attr=False)
+
+    def get_input_embeddings(self):
+        return self.model.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.model.embed_tokens = value
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings):
+        self.lm_head = new_embeddings
+
+    def prepare_inputs_for_generation(
+        self,
+        input_ids,
+        past_key_values=None,
+        attention_mask=None,
+        inputs_embeds=None,
+        use_cache=True,
+        **kwargs,
+    ):
+        if attention_mask is not None:
+            position_ids = attention_mask.astype("int64").cumsum(axis=-1) - 1
+            position_ids = paddle.where(
+                attention_mask > 0,
+                position_ids,
+                paddle.zeros_like(position_ids),
+            )
+        else:
+            position_ids = paddle.arange(
+                input_ids.shape[1], dtype="int64"
+            ).unsqueeze(0).tile([input_ids.shape[0], 1])
+
+        if (
+            past_key_values is not None
+            and len(past_key_values) > 0
+            and past_key_values[0] is not None
+            and past_key_values[0][0] is not None
+        ):
+            input_ids = input_ids[:, -1:]
+            position_ids = position_ids[:, -1:]
+
+        model_inputs = {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "position_ids": position_ids,
+            "past_key_values": past_key_values,
+            "use_cache": use_cache,
+        }
+
+        if inputs_embeds is not None and past_key_values is None:
+            model_inputs["inputs_embeds"] = inputs_embeds
+
+        return model_inputs
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        position_ids=None,
+        inputs_embeds=None,
+        labels=None,
+        past_key_values=None,
+        use_cache=None,
+        return_dict=True,
+        **kwargs,
+    ):
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            return_dict=True,
+        )
+
+        hidden_states = outputs["last_hidden_state"]
+        logits = self.lm_head(hidden_states)
+
+        loss = None
+        if labels is not None:
+            shift_logits = logits[:, :-1, :]
+            shift_labels = labels[:, 1:]
+            loss = F.cross_entropy(
+                shift_logits.reshape([-1, shift_logits.shape[-1]]),
+                shift_labels.reshape([-1]),
+                reduction="mean",
+            )
+
+        if not return_dict:
+            result = (logits, outputs.get("past_key_values", None))
+            if loss is not None:
+                result = (loss,) + result
+            return result
+
+        return CausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.get("past_key_values", None),
+            hidden_states=None,
+            attentions=None,
+        )

--- a/paddleformers/transformers/glm4/modeling.py
+++ b/paddleformers/transformers/glm4/modeling.py
@@ -19,7 +19,7 @@ import paddle.nn as nn
 import paddle.nn.functional as F
 
 from ..model_outputs import CausalLMOutputWithPast
-from ..model_utils import PretrainedModel
+from ..model_utils import PretrainedModel, register_base_model
 from .configuration import Glm4Config
 
 __all__ = [
@@ -85,12 +85,17 @@ def apply_rotary_pos_emb(q, k, cos, sin, unsqueeze_dim=1):
     cos = paddle.repeat_interleave(cos, repeats=2, axis=-1)
     sin = paddle.repeat_interleave(sin, repeats=2, axis=-1)
 
+    # RoPE frequencies are calculated in fp32.  Cast each copy at its point of
+    # use so mixed-precision Q/K projections retain their respective dtypes.
+    q_cos, q_sin = cos.astype(q.dtype), sin.astype(q.dtype)
+    k_cos, k_sin = cos.astype(k.dtype), sin.astype(k.dtype)
+
     rotary_dim = cos.shape[-1]
     q_rot, q_pass = q[..., :rotary_dim], q[..., rotary_dim:]
     k_rot, k_pass = k[..., :rotary_dim], k[..., rotary_dim:]
 
-    q_embed = (q_rot * cos) + (rotate_half(q_rot) * sin)
-    k_embed = (k_rot * cos) + (rotate_half(k_rot) * sin)
+    q_embed = (q_rot * q_cos) + (rotate_half(q_rot) * q_sin)
+    k_embed = (k_rot * k_cos) + (rotate_half(k_rot) * k_sin)
 
     q_embed = paddle.concat([q_embed, q_pass], axis=-1)
     k_embed = paddle.concat([k_embed, k_pass], axis=-1)
@@ -305,16 +310,7 @@ class Glm4PretrainedModel(PretrainedModel):
     config_class = Glm4Config
     base_model_prefix = "model"
     supports_gradient_checkpointing = False
-
-    _hf_linear_weight_suffixes = (
-        "q_proj.weight",
-        "k_proj.weight",
-        "v_proj.weight",
-        "o_proj.weight",
-        "gate_up_proj.weight",
-        "down_proj.weight",
-        "lm_head.weight",
-    )
+    transpose_weight_keys = ["q_proj", "k_proj", "v_proj", "o_proj", "gate_up_proj", "down_proj", "lm_head"]
 
     def _init_weights(self, layer):
         return
@@ -323,32 +319,48 @@ class Glm4PretrainedModel(PretrainedModel):
         return
 
     @classmethod
-    def _convert_hf_state_dict(cls, state_dict):
-        """
-        HF/PyTorch Linear weight: [out_features, in_features]
-        Paddle nn.Linear weight:  [in_features, out_features]
+    def _gen_aoa_config(cls, config: Glm4Config):
+        """Describe the GLM-4-9B-0414 HF checkpoint layout for flex loading."""
+        model_prefix = "" if cls == cls.base_model_class else "model."
+        aoa_statements = [
+            f"model.embed_tokens.weight -> {model_prefix}embed_tokens.weight",
+            f"model.norm.weight -> {model_prefix}norm.weight",
+        ]
+        # The base model has no lm_head.  The causal model target is deliberately
+        # unprefixed even though its transformer weights are under ``model.``.
+        if cls != cls.base_model_class:
+            aoa_statements.append("lm_head.weight^T -> lm_head.weight")
 
-        这里必须按名字强制转置，不能依赖 shape mismatch。
-        因为 q_proj/o_proj 这类 4096x4096 方阵 shape 一样，但语义仍然相反。
-        """
-        new_state_dict = {}
-        for k, v in state_dict.items():
-            if (
-                isinstance(v, paddle.Tensor)
-                and v.ndim == 2
-                and any(k.endswith(suffix) for suffix in cls._hf_linear_weight_suffixes)
-            ):
-                v = v.transpose([1, 0])
-            new_state_dict[k] = v
-        return new_state_dict
+        layer_prefix = "model.layers.$LAYER_ID"
+        target_prefix = f"{model_prefix}layers.$LAYER_ID"
+        aoa_statements.extend(
+            [
+                f"{layer_prefix}.input_layernorm.weight -> {target_prefix}.input_layernorm.weight",
+                f"{layer_prefix}.post_self_attn_layernorm.weight -> {target_prefix}.post_self_attn_layernorm.weight",
+                f"{layer_prefix}.post_attention_layernorm.weight -> {target_prefix}.post_attention_layernorm.weight",
+                f"{layer_prefix}.post_mlp_layernorm.weight -> {target_prefix}.post_mlp_layernorm.weight",
+                f"{layer_prefix}.self_attn.q_proj.weight^T -> {target_prefix}.self_attn.q_proj.weight",
+                f"{layer_prefix}.self_attn.k_proj.weight^T -> {target_prefix}.self_attn.k_proj.weight",
+                f"{layer_prefix}.self_attn.v_proj.weight^T -> {target_prefix}.self_attn.v_proj.weight",
+                # GLM-4-9B-0414 has no o_proj.bias; Glm4Attention deliberately
+                # creates the O projection without bias, so no AOA rule may name it.
+                f"{layer_prefix}.self_attn.o_proj.weight^T -> {target_prefix}.self_attn.o_proj.weight",
+                f"{layer_prefix}.mlp.gate_up_proj.weight^T -> {target_prefix}.mlp.gate_up_proj.weight",
+                f"{layer_prefix}.mlp.down_proj.weight^T -> {target_prefix}.mlp.down_proj.weight",
+            ]
+        )
+        if config.attention_bias:
+            aoa_statements.extend(
+                [
+                    f"{layer_prefix}.self_attn.q_proj.bias -> {target_prefix}.self_attn.q_proj.bias",
+                    f"{layer_prefix}.self_attn.k_proj.bias -> {target_prefix}.self_attn.k_proj.bias",
+                    f"{layer_prefix}.self_attn.v_proj.bias -> {target_prefix}.self_attn.v_proj.bias",
+                ]
+            )
+        return {"aoa_statements": aoa_statements}
 
-    def set_state_dict(self, state_dict, *args, **kwargs):
-        already_converted = kwargs.pop("already_converted", False)
-        if not already_converted:
-            state_dict = self._convert_hf_state_dict(state_dict)
-        return super().set_state_dict(state_dict, *args, **kwargs)
 
-
+@register_base_model
 class Glm4Model(Glm4PretrainedModel):
     def __init__(self, config: Glm4Config):
         config = _normalize_config_dtype(config)
@@ -523,11 +535,14 @@ class Glm4ForCausalLM(Glm4PretrainedModel):
 
         loss = None
         if labels is not None:
+            # Keep the standard causal shift: callers must provide unshifted
+            # labels aligned with input_ids, with ignored positions set to -100.
             shift_logits = logits[:, :-1, :]
             shift_labels = labels[:, 1:]
             loss = F.cross_entropy(
                 shift_logits.reshape([-1, shift_logits.shape[-1]]),
                 shift_labels.reshape([-1]),
+                ignore_index=-100,
                 reduction="mean",
             )
 

--- a/paddleformers/transformers/glm4/modeling.py
+++ b/paddleformers/transformers/glm4/modeling.py
@@ -85,10 +85,6 @@ def apply_rotary_pos_emb(q, k, cos, sin, unsqueeze_dim=1):
     cos = paddle.repeat_interleave(cos, repeats=2, axis=-1)
     sin = paddle.repeat_interleave(sin, repeats=2, axis=-1)
 
-    # 关键修复：将 cos 和 sin 的数据类型转换为与 q/k 相同
-    cos = cos.astype(q.dtype)
-    sin = sin.astype(q.dtype)
-
     rotary_dim = cos.shape[-1]
     q_rot, q_pass = q[..., :rotary_dim], q[..., rotary_dim:]
     k_rot, k_pass = k[..., :rotary_dim], k[..., rotary_dim:]
@@ -99,7 +95,6 @@ def apply_rotary_pos_emb(q, k, cos, sin, unsqueeze_dim=1):
     q_embed = paddle.concat([q_embed, q_pass], axis=-1)
     k_embed = paddle.concat([k_embed, k_pass], axis=-1)
     return q_embed, k_embed
-
 
 class Glm4RotaryEmbedding(nn.Layer):
     def __init__(self, config: Glm4Config):

--- a/paddleformers/transformers/glm4/modeling.py
+++ b/paddleformers/transformers/glm4/modeling.py
@@ -96,6 +96,7 @@ def apply_rotary_pos_emb(q, k, cos, sin, unsqueeze_dim=1):
     k_embed = paddle.concat([k_embed, k_pass], axis=-1)
     return q_embed, k_embed
 
+
 class Glm4RotaryEmbedding(nn.Layer):
     def __init__(self, config: Glm4Config):
         super().__init__()
@@ -108,7 +109,10 @@ class Glm4RotaryEmbedding(nn.Layer):
         if self.rotary_dim % 2 != 0:
             self.rotary_dim -= 1
 
-        inv_freq = 1.0 / (self.base ** (paddle.arange(0, self.rotary_dim, 2, dtype="float32") / self.rotary_dim))
+        inv_freq = 1.0 / (
+            self.base
+            ** (paddle.arange(0, self.rotary_dim, 2, dtype="float32") / self.rotary_dim)
+        )
         self.register_buffer("inv_freq", inv_freq, persistable=False)
 
     def forward(self, position_ids):
@@ -189,11 +193,15 @@ class Glm4Attention(nn.Layer):
         key_states = self.k_proj(hidden_states)
         value_states = self.v_proj(hidden_states)
 
-        query_states = query_states.reshape([bsz, q_len, self.num_heads, self.head_dim]).transpose([0, 2, 1, 3])
-        key_states = key_states.reshape([bsz, q_len, self.num_key_value_heads, self.head_dim]).transpose([0, 2, 1, 3])
-        value_states = value_states.reshape([bsz, q_len, self.num_key_value_heads, self.head_dim]).transpose(
-            [0, 2, 1, 3]
-        )
+        query_states = query_states.reshape(
+            [bsz, q_len, self.num_heads, self.head_dim]
+        ).transpose([0, 2, 1, 3])
+        key_states = key_states.reshape(
+            [bsz, q_len, self.num_key_value_heads, self.head_dim]
+        ).transpose([0, 2, 1, 3])
+        value_states = value_states.reshape(
+            [bsz, q_len, self.num_key_value_heads, self.head_dim]
+        ).transpose([0, 2, 1, 3])
 
         if position_ids is None:
             position_ids = paddle.arange(q_len, dtype="int64").unsqueeze(0).tile([bsz, 1])
@@ -203,7 +211,9 @@ class Glm4Attention(nn.Layer):
         else:
             cos, sin = position_embeddings
 
-        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, unsqueeze_dim=1)
+        query_states, key_states = apply_rotary_pos_emb(
+            query_states, key_states, cos, sin, unsqueeze_dim=1
+        )
 
         if past_key_value is not None and past_key_value[0] is not None:
             past_k, past_v = past_key_value
@@ -219,7 +229,9 @@ class Glm4Attention(nn.Layer):
             key_states = paddle.repeat_interleave(key_states, repeat_factor, axis=1)
             value_states = paddle.repeat_interleave(value_states, repeat_factor, axis=1)
 
-        attn_weights = paddle.matmul(query_states, key_states, transpose_y=True) / (self.head_dim**0.5)
+        attn_weights = paddle.matmul(
+            query_states, key_states, transpose_y=True
+        ) / (self.head_dim ** 0.5)
 
         kv_len = key_states.shape[2]
         cur_q_len = query_states.shape[2]
@@ -245,10 +257,14 @@ class Glm4Attention(nn.Layer):
             else:
                 attn_weights = attn_weights + attention_mask
 
-        attn_weights = F.softmax(attn_weights.astype("float32"), axis=-1).astype(query_states.dtype)
+        attn_weights = F.softmax(attn_weights.astype("float32"), axis=-1).astype(
+            query_states.dtype
+        )
         attn_output = paddle.matmul(attn_weights, value_states)
 
-        attn_output = attn_output.transpose([0, 2, 1, 3]).reshape([bsz, cur_q_len, self.num_heads * self.head_dim])
+        attn_output = attn_output.transpose([0, 2, 1, 3]).reshape(
+            [bsz, cur_q_len, self.num_heads * self.head_dim]
+        )
         attn_output = self.o_proj(attn_output)
 
         return attn_output, present
@@ -360,7 +376,9 @@ class Glm4Model(Glm4PretrainedModel):
             config.hidden_size,
             padding_idx=self.padding_idx,
         )
-        self.layers = nn.LayerList([Glm4DecoderLayer(config) for _ in range(config.num_hidden_layers)])
+        self.layers = nn.LayerList(
+            [Glm4DecoderLayer(config) for _ in range(config.num_hidden_layers)]
+        )
         self.norm = Glm4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.rotary_emb = Glm4RotaryEmbedding(config)
 
@@ -398,7 +416,9 @@ class Glm4Model(Glm4PretrainedModel):
             past_length = past_key_values[0][0].shape[2]
 
         if position_ids is None:
-            position_ids = paddle.arange(past_length, past_length + seq_len, dtype="int64").unsqueeze(0).tile([bsz, 1])
+            position_ids = paddle.arange(
+                past_length, past_length + seq_len, dtype="int64"
+            ).unsqueeze(0).tile([bsz, 1])
 
         position_embeddings = self.rotary_emb(position_ids)
 
@@ -471,7 +491,9 @@ class Glm4ForCausalLM(Glm4PretrainedModel):
                 paddle.zeros_like(position_ids),
             )
         else:
-            position_ids = paddle.arange(input_ids.shape[1], dtype="int64").unsqueeze(0).tile([input_ids.shape[0], 1])
+            position_ids = paddle.arange(
+                input_ids.shape[1], dtype="int64"
+            ).unsqueeze(0).tile([input_ids.shape[0], 1])
 
         if (
             past_key_values is not None

--- a/paddleformers/transformers/glm4/modeling.py
+++ b/paddleformers/transformers/glm4/modeling.py
@@ -1,11 +1,25 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
 
-from ..model_utils import PretrainedModel
 from ..model_outputs import CausalLMOutputWithPast
+from ..model_utils import PretrainedModel
 from .configuration import Glm4Config
 
 __all__ = [
@@ -71,6 +85,10 @@ def apply_rotary_pos_emb(q, k, cos, sin, unsqueeze_dim=1):
     cos = paddle.repeat_interleave(cos, repeats=2, axis=-1)
     sin = paddle.repeat_interleave(sin, repeats=2, axis=-1)
 
+    # 关键修复：将 cos 和 sin 的数据类型转换为与 q/k 相同
+    cos = cos.astype(q.dtype)
+    sin = sin.astype(q.dtype)
+
     rotary_dim = cos.shape[-1]
     q_rot, q_pass = q[..., :rotary_dim], q[..., rotary_dim:]
     k_rot, k_pass = k[..., :rotary_dim], k[..., rotary_dim:]
@@ -95,10 +113,7 @@ class Glm4RotaryEmbedding(nn.Layer):
         if self.rotary_dim % 2 != 0:
             self.rotary_dim -= 1
 
-        inv_freq = 1.0 / (
-            self.base
-            ** (paddle.arange(0, self.rotary_dim, 2, dtype="float32") / self.rotary_dim)
-        )
+        inv_freq = 1.0 / (self.base ** (paddle.arange(0, self.rotary_dim, 2, dtype="float32") / self.rotary_dim))
         self.register_buffer("inv_freq", inv_freq, persistable=False)
 
     def forward(self, position_ids):
@@ -179,15 +194,11 @@ class Glm4Attention(nn.Layer):
         key_states = self.k_proj(hidden_states)
         value_states = self.v_proj(hidden_states)
 
-        query_states = query_states.reshape(
-            [bsz, q_len, self.num_heads, self.head_dim]
-        ).transpose([0, 2, 1, 3])
-        key_states = key_states.reshape(
-            [bsz, q_len, self.num_key_value_heads, self.head_dim]
-        ).transpose([0, 2, 1, 3])
-        value_states = value_states.reshape(
-            [bsz, q_len, self.num_key_value_heads, self.head_dim]
-        ).transpose([0, 2, 1, 3])
+        query_states = query_states.reshape([bsz, q_len, self.num_heads, self.head_dim]).transpose([0, 2, 1, 3])
+        key_states = key_states.reshape([bsz, q_len, self.num_key_value_heads, self.head_dim]).transpose([0, 2, 1, 3])
+        value_states = value_states.reshape([bsz, q_len, self.num_key_value_heads, self.head_dim]).transpose(
+            [0, 2, 1, 3]
+        )
 
         if position_ids is None:
             position_ids = paddle.arange(q_len, dtype="int64").unsqueeze(0).tile([bsz, 1])
@@ -197,9 +208,7 @@ class Glm4Attention(nn.Layer):
         else:
             cos, sin = position_embeddings
 
-        query_states, key_states = apply_rotary_pos_emb(
-            query_states, key_states, cos, sin, unsqueeze_dim=1
-        )
+        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, unsqueeze_dim=1)
 
         if past_key_value is not None and past_key_value[0] is not None:
             past_k, past_v = past_key_value
@@ -215,9 +224,7 @@ class Glm4Attention(nn.Layer):
             key_states = paddle.repeat_interleave(key_states, repeat_factor, axis=1)
             value_states = paddle.repeat_interleave(value_states, repeat_factor, axis=1)
 
-        attn_weights = paddle.matmul(
-            query_states, key_states, transpose_y=True
-        ) / (self.head_dim ** 0.5)
+        attn_weights = paddle.matmul(query_states, key_states, transpose_y=True) / (self.head_dim**0.5)
 
         kv_len = key_states.shape[2]
         cur_q_len = query_states.shape[2]
@@ -243,14 +250,10 @@ class Glm4Attention(nn.Layer):
             else:
                 attn_weights = attn_weights + attention_mask
 
-        attn_weights = F.softmax(attn_weights.astype("float32"), axis=-1).astype(
-            query_states.dtype
-        )
+        attn_weights = F.softmax(attn_weights.astype("float32"), axis=-1).astype(query_states.dtype)
         attn_output = paddle.matmul(attn_weights, value_states)
 
-        attn_output = attn_output.transpose([0, 2, 1, 3]).reshape(
-            [bsz, cur_q_len, self.num_heads * self.head_dim]
-        )
+        attn_output = attn_output.transpose([0, 2, 1, 3]).reshape([bsz, cur_q_len, self.num_heads * self.head_dim])
         attn_output = self.o_proj(attn_output)
 
         return attn_output, present
@@ -362,9 +365,7 @@ class Glm4Model(Glm4PretrainedModel):
             config.hidden_size,
             padding_idx=self.padding_idx,
         )
-        self.layers = nn.LayerList(
-            [Glm4DecoderLayer(config) for _ in range(config.num_hidden_layers)]
-        )
+        self.layers = nn.LayerList([Glm4DecoderLayer(config) for _ in range(config.num_hidden_layers)])
         self.norm = Glm4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.rotary_emb = Glm4RotaryEmbedding(config)
 
@@ -402,9 +403,7 @@ class Glm4Model(Glm4PretrainedModel):
             past_length = past_key_values[0][0].shape[2]
 
         if position_ids is None:
-            position_ids = paddle.arange(
-                past_length, past_length + seq_len, dtype="int64"
-            ).unsqueeze(0).tile([bsz, 1])
+            position_ids = paddle.arange(past_length, past_length + seq_len, dtype="int64").unsqueeze(0).tile([bsz, 1])
 
         position_embeddings = self.rotary_emb(position_ids)
 
@@ -477,9 +476,7 @@ class Glm4ForCausalLM(Glm4PretrainedModel):
                 paddle.zeros_like(position_ids),
             )
         else:
-            position_ids = paddle.arange(
-                input_ids.shape[1], dtype="int64"
-            ).unsqueeze(0).tile([input_ids.shape[0], 1])
+            position_ids = paddle.arange(input_ids.shape[1], dtype="int64").unsqueeze(0).tile([input_ids.shape[0], 1])
 
         if (
             past_key_values is not None

--- a/paddleformers/transformers/glm4/modeling.py
+++ b/paddleformers/transformers/glm4/modeling.py
@@ -87,8 +87,10 @@ def apply_rotary_pos_emb(q, k, cos, sin, unsqueeze_dim=1):
 
     # RoPE frequencies are calculated in fp32.  Cast each copy at its point of
     # use so mixed-precision Q/K projections retain their respective dtypes.
-    q_cos, q_sin = cos.astype(q.dtype), sin.astype(q.dtype)
-    k_cos, k_sin = cos.astype(k.dtype), sin.astype(k.dtype)
+    q_cos = cos.cast(q.dtype)
+    q_sin = sin.cast(q.dtype)
+    k_cos = cos.cast(k.dtype)
+    k_sin = sin.cast(k.dtype)
 
     rotary_dim = cos.shape[-1]
     q_rot, q_pass = q[..., :rotary_dim], q[..., rotary_dim:]
@@ -535,13 +537,9 @@ class Glm4ForCausalLM(Glm4PretrainedModel):
 
         loss = None
         if labels is not None:
-            # Keep the standard causal shift: callers must provide unshifted
-            # labels aligned with input_ids, with ignored positions set to -100.
-            shift_logits = logits[:, :-1, :]
-            shift_labels = labels[:, 1:]
             loss = F.cross_entropy(
-                shift_logits.reshape([-1, shift_logits.shape[-1]]),
-                shift_labels.reshape([-1]),
+                logits.reshape([-1, logits.shape[-1]]),
+                labels.reshape([-1]),
                 ignore_index=-100,
                 reduction="mean",
             )

--- a/tests/transformers/glm4/test_glm4.py
+++ b/tests/transformers/glm4/test_glm4.py
@@ -109,9 +109,7 @@ class Glm4ModelTester:
         # 验证所有需要训练的参数是否都成功计算了梯度
         for name, p in model.named_parameters():
             if not p.stop_gradient:
-                self.parent.assertIsNotNone(
-                    p.grad, msg=f"Parameter {name} has no gradient."
-                )
+                self.parent.assertIsNotNone(p.grad, msg=f"Parameter {name} has no gradient.")
 
 
 class Glm4Test(unittest.TestCase):

--- a/tests/transformers/glm4/test_glm4.py
+++ b/tests/transformers/glm4/test_glm4.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import unittest
+
+import paddle
+
+from paddleformers.transformers.glm4.configuration import Glm4Config
+from paddleformers.transformers.glm4.modeling import (
+    Glm4Model,
+    Glm4ForCausalLM,
+)
+
+
+class Glm4ModelTester:
+    def __init__(self, parent):
+        self.parent = parent
+        self.batch_size = 2
+        self.seq_length = 8
+
+        # 使用较小的网络参数，保证单元测试秒级运行，且不会爆内存
+        self.vocab_size = 1000
+        self.hidden_size = 32
+        self.intermediate_size = 64
+        self.num_hidden_layers = 2
+        self.num_attention_heads = 4
+        self.num_key_value_heads = 2
+        self.head_dim = 8  # 注意：在 GLM4 中，通常 head_dim * num_attention_heads == hidden_size
+
+    def get_config(self):
+        return Glm4Config(
+            vocab_size=self.vocab_size,
+            hidden_size=self.hidden_size,
+            intermediate_size=self.intermediate_size,
+            num_hidden_layers=self.num_hidden_layers,
+            num_attention_heads=self.num_attention_heads,
+            num_key_value_heads=self.num_key_value_heads,
+            head_dim=self.head_dim,
+            max_position_embeddings=128,
+            use_cache=False,  # 测试前向时先关掉cache，避免输出冗余
+            pad_token_id=0,   # <-- 新增：设置一个在 vocab_size (1000) 范围内的 padding_idx
+            bos_token_id=1,   # <-- 为了保险，顺便把其他特俗 token id 也设小一点
+            eos_token_id=[2],
+        )
+
+    def prepare_inputs(self):
+        # 保证 input_ids 在 vocab_size 范围内
+        input_ids = paddle.randint(0, self.vocab_size, (self.batch_size, self.seq_length))
+        return input_ids
+
+    def check_model(self):
+        config = self.get_config()
+        input_ids = self.prepare_inputs()
+        model = Glm4Model(config)
+        model.eval()
+
+        # Glm4Model 默认 return_dict=True，返回字典
+        output = model(input_ids)
+        self.parent.assertIsNotNone(output)
+        self.parent.assertIn("last_hidden_state", output)
+
+        # 校验 hidden state 的形状 [batch_size, seq_len, hidden_size]
+        self.parent.assertEqual(
+            output["last_hidden_state"].shape,
+            [self.batch_size, self.seq_length, self.hidden_size]
+        )
+
+    def check_causal_lm(self):
+        config = self.get_config()
+        input_ids = self.prepare_inputs()
+        model = Glm4ForCausalLM(config)
+        model.eval()
+
+        # Glm4ForCausalLM 默认返回 CausalLMOutputWithPast 对象
+        output = model(input_ids)
+        self.parent.assertIsNotNone(output.logits)
+
+        # 校验 logits 的形状 [batch_size, seq_len, vocab_size]
+        self.parent.assertEqual(
+            output.logits.shape,
+            [self.batch_size, self.seq_length, self.vocab_size]
+        )
+
+    def check_loss(self):
+        config = self.get_config()
+        input_ids = self.prepare_inputs()
+        model = Glm4ForCausalLM(config)
+        model.train()
+
+        # 传入 labels 触发内部的交叉熵 Loss 计算
+        output = model(input_ids, labels=input_ids)
+        self.parent.assertIsNotNone(output.loss)
+        self.parent.assertIsInstance(output.loss.item(), float)
+
+    def check_backward(self):
+        config = self.get_config()
+        input_ids = self.prepare_inputs()
+        model = Glm4ForCausalLM(config)
+        model.train()
+
+        # 反向传播前清理可能残留的梯度
+        model.clear_gradients()
+
+        output = model(input_ids, labels=input_ids)
+        loss = output.loss
+        loss.backward()
+
+        # 验证所有需要训练的参数是否都成功计算了梯度
+        for name, p in model.named_parameters():
+            if not p.stop_gradient:
+                self.parent.assertIsNotNone(
+                    p.grad, msg=f"Parameter {name} has no gradient."
+                )
+
+
+class Glm4Test(unittest.TestCase):
+    def setUp(self):
+        self.tester = Glm4ModelTester(self)
+
+    def test_model_forward(self):
+        self.tester.check_model()
+
+    def test_causal_lm_forward(self):
+        self.tester.check_causal_lm()
+
+    def test_loss_computation(self):
+        self.tester.check_loss()
+
+    def test_backward_pass(self):
+        self.tester.check_backward()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/transformers/glm4/test_glm4.py
+++ b/tests/transformers/glm4/test_glm4.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,10 +19,7 @@ import unittest
 import paddle
 
 from paddleformers.transformers.glm4.configuration import Glm4Config
-from paddleformers.transformers.glm4.modeling import (
-    Glm4Model,
-    Glm4ForCausalLM,
-)
+from paddleformers.transformers.glm4.modeling import Glm4ForCausalLM, Glm4Model
 
 
 class Glm4ModelTester:
@@ -30,7 +27,6 @@ class Glm4ModelTester:
         self.parent = parent
         self.batch_size = 2
         self.seq_length = 8
-
         # 使用较小的网络参数，保证单元测试秒级运行，且不会爆内存
         self.vocab_size = 1000
         self.hidden_size = 32
@@ -38,7 +34,7 @@ class Glm4ModelTester:
         self.num_hidden_layers = 2
         self.num_attention_heads = 4
         self.num_key_value_heads = 2
-        self.head_dim = 8  # 注意：在 GLM4 中，通常 head_dim * num_attention_heads == hidden_size
+        self.head_dim = 8  # GLM4 中 head_dim * num_attention_heads == hidden_size
 
     def get_config(self):
         return Glm4Config(
@@ -50,9 +46,9 @@ class Glm4ModelTester:
             num_key_value_heads=self.num_key_value_heads,
             head_dim=self.head_dim,
             max_position_embeddings=128,
-            use_cache=False,  # 测试前向时先关掉cache，避免输出冗余
-            pad_token_id=0,   # <-- 新增：设置一个在 vocab_size (1000) 范围内的 padding_idx
-            bos_token_id=1,   # <-- 为了保险，顺便把其他特俗 token id 也设小一点
+            use_cache=False,
+            pad_token_id=0,
+            bos_token_id=1,
             eos_token_id=[2],
         )
 
@@ -66,16 +62,14 @@ class Glm4ModelTester:
         input_ids = self.prepare_inputs()
         model = Glm4Model(config)
         model.eval()
-
         # Glm4Model 默认 return_dict=True，返回字典
         output = model(input_ids)
         self.parent.assertIsNotNone(output)
         self.parent.assertIn("last_hidden_state", output)
-
         # 校验 hidden state 的形状 [batch_size, seq_len, hidden_size]
         self.parent.assertEqual(
             output["last_hidden_state"].shape,
-            [self.batch_size, self.seq_length, self.hidden_size]
+            [self.batch_size, self.seq_length, self.hidden_size],
         )
 
     def check_causal_lm(self):
@@ -83,15 +77,13 @@ class Glm4ModelTester:
         input_ids = self.prepare_inputs()
         model = Glm4ForCausalLM(config)
         model.eval()
-
         # Glm4ForCausalLM 默认返回 CausalLMOutputWithPast 对象
         output = model(input_ids)
         self.parent.assertIsNotNone(output.logits)
-
         # 校验 logits 的形状 [batch_size, seq_len, vocab_size]
         self.parent.assertEqual(
             output.logits.shape,
-            [self.batch_size, self.seq_length, self.vocab_size]
+            [self.batch_size, self.seq_length, self.vocab_size],
         )
 
     def check_loss(self):
@@ -99,7 +91,6 @@ class Glm4ModelTester:
         input_ids = self.prepare_inputs()
         model = Glm4ForCausalLM(config)
         model.train()
-
         # 传入 labels 触发内部的交叉熵 Loss 计算
         output = model(input_ids, labels=input_ids)
         self.parent.assertIsNotNone(output.loss)
@@ -110,14 +101,11 @@ class Glm4ModelTester:
         input_ids = self.prepare_inputs()
         model = Glm4ForCausalLM(config)
         model.train()
-
         # 反向传播前清理可能残留的梯度
         model.clear_gradients()
-
         output = model(input_ids, labels=input_ids)
         loss = output.loss
         loss.backward()
-
         # 验证所有需要训练的参数是否都成功计算了梯度
         for name, p in model.named_parameters():
             if not p.stop_gradient:


### PR DESCRIPTION
添加GLM4模型文件到 PaddleFormers/paddleformers/transformers/glm4
测试test_glm4.py到PaddleFormers/tests/transformers/glm4
1. 单卡前向精度对齐验证
日志显示，你的模型在 Paddle 环境下与 Hugging Face 环境下的前向 Logits 差异极小。
最大绝对误差 (max_abs_diff) 均在 1e-5 量级（例如 CASE 1 为 7.34e-05，CASE 4 为 3.33e-05）。
这远远优于你要求的 1e-2 量级，说明模型权重加载和前向计算的计算逻辑（包括 RMSNorm、RotaryEmbedding、Attention 等算子的转换）是完全正确且高精度对齐的。
2. 模型生成验证
通过对比 dump_hf_generate.py 和 dump_paddle_generate.py 的输出，两端的前 10 个生成 Token 完美一致：
CASE 1: [109377, 3837, 122786, 104668, 113255, 3837, 118295, 107410, 98734, 1773] ✅
CASE 2: [99334, 98316, 101881, 106552, 3837, 100039, 111661, 102733, 98327, 102209] ✅
CASE 3: [103974, 105678, 99917, 100000, 3837, 103153, 100370, 106889, 98366, 3837] ✅
CASE 4: [12089, 13, 1084, 374, 825, 315, 279, 1429, 6233, 9716] ✅
CASE 5: [785, 9101, 374, 1602, 1661, 3351, 13, 118291, 98516, 98500] ✅
不仅前 10 个 Token 一致，日志显示的 32 个长度的完整 generated_text 内容也是一模一样的。
