### PR TITLE
Add ShieldGemma2 support with Gemma3 dependency

### DIFF
--- a/examples/tools/compare_gemma3_ms_swift_loss.py
+++ b/examples/tools/compare_gemma3_ms_swift_loss.py
@@ -1,4 +1,19 @@
 #!/usr/bin/env python3
+
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Compare a Gemma3 causal-LM loss between ms-swift and Paddle.
 
 The script has two modes because Paddle and PyTorch are normally installed in
@@ -224,7 +239,10 @@ def _run_torch(args: argparse.Namespace) -> float:
 def _run_paddle(args: argparse.Namespace) -> float:
     import numpy as np
     import paddle
-    from paddleformers.transformers.gemma3.modeling import Gemma3ForConditionalGeneration
+
+    from paddleformers.transformers.gemma3.modeling import (
+        Gemma3ForConditionalGeneration,
+    )
 
     paddle.seed(args.seed)
     paddle.set_device(args.device.replace("cuda", "gpu"))

--- a/examples/tools/compare_gemma3_ms_swift_loss.py
+++ b/examples/tools/compare_gemma3_ms_swift_loss.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Compare a Gemma3 causal-LM loss between ms-swift and Paddle.
+
+The script has two modes because Paddle and PyTorch are normally installed in
+separate environments.  Run the ``torch`` mode first; it writes the exact
+encoded batch used by ms-swift to ``--batch``.  Run the ``paddle`` mode with
+the same checkpoint and batch file afterwards.
+
+Example::
+
+    python compare_gemma3_ms_swift_loss.py torch \
+        --model /path/to/gemma3-checkpoint --batch /tmp/gemma3-batch.npz
+    python compare_gemma3_ms_swift_loss.py paddle \
+        --model /path/to/gemma3-checkpoint --batch /tmp/gemma3-batch.npz
+
+Both modes configure AdamW with the same hyperparameters and record every
+step's loss.  The default zero learning rate exercises forward and backward
+without allowing an initial framework delta to alter later weights.  Both
+sides skip allocating optimizer moments in that no-op case so a 4B check fits
+on a single GPU.  Set a nonzero learning rate to exercise update trajectories;
+SGD is available for memory-constrained 4B checks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from contextlib import contextmanager
+from functools import wraps
+from pathlib import Path
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="framework", required=True)
+
+    torch_parser = subparsers.add_parser("torch", help="run one ms-swift Trainer step")
+    torch_parser.add_argument("--model", required=True, help="Torch/Hugging Face Gemma3 checkpoint")
+    torch_parser.add_argument("--batch", required=True, type=Path, help="output .npz file for the Paddle run")
+    torch_parser.add_argument("--max-length", type=int, default=64)
+
+    paddle_parser = subparsers.add_parser("paddle", help="evaluate the saved batch with Paddle")
+    paddle_parser.add_argument("--model", required=True, help="Torch/Hugging Face Gemma3 checkpoint")
+    paddle_parser.add_argument("--batch", required=True, type=Path, help=".npz written by torch mode")
+    paddle_parser.add_argument("--tolerance", type=float, default=1e-2)
+
+    for subparser in (torch_parser, paddle_parser):
+        subparser.add_argument("--max-steps", type=int, default=1)
+        subparser.add_argument("--learning-rate", type=float, default=0.0)
+        subparser.add_argument("--weight-decay", type=float, default=0.0)
+        subparser.add_argument("--adam-beta1", type=float, default=0.9)
+        subparser.add_argument("--adam-beta2", type=float, default=0.999)
+        subparser.add_argument("--adam-epsilon", type=float, default=1e-8)
+        subparser.add_argument("--max-grad-norm", type=float, default=1.0)
+        subparser.add_argument("--optimizer", choices=("adamw", "sgd"), default="adamw")
+        subparser.add_argument("--dtype", choices=("float32", "bfloat16"), default="float32")
+        subparser.add_argument("--device", default="cuda:0")
+        subparser.add_argument("--seed", type=int, default=2026)
+    return parser.parse_args()
+
+
+class _CompatSwiftTrainer:  # pragma: no cover - exercised by the torch environment
+    """Factory for a Trainer compatible with Transformers 5.x loss calls.
+
+    ms-swift 4.4 wraps ``loss_function`` with a two-positional-argument
+    function, while Transformers 5.x passes ``vocab_size`` positionally from
+    Gemma3.  Accepting ``*args`` here preserves ms-swift's device fix and
+    forwards the complete Transformers call.
+    """
+
+    @staticmethod
+    def make(base_cls, optimizer_name):
+        class CompatTrainer(base_cls):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.step_losses = []
+
+            @contextmanager
+            def _patch_loss_function(self):
+                model = self.model
+                model_cls = model.__class__
+                if not hasattr(model_cls, "loss_function"):
+                    yield
+                    return
+                loss_function = model.loss_function
+                old_loss_function = model_cls.loss_function
+
+                @staticmethod
+                @wraps(loss_function)
+                def new_loss_function(logits, labels, *args, **kwargs):
+                    labels = labels.to(logits.device)
+                    return loss_function(logits, labels, *args, **kwargs)
+
+                model_cls.loss_function = new_loss_function
+                try:
+                    yield
+                finally:
+                    model_cls.loss_function = old_loss_function
+
+            def train(self, *args, **kwargs):
+                with self._patch_loss_function():
+                    return super().train(*args, **kwargs)
+
+            def create_optimizer(self):
+                if optimizer_name == "sgd" or self.args.learning_rate == 0:
+                    import torch
+
+                    self.optimizer = torch.optim.SGD(
+                        self.model.parameters(),
+                        lr=self.args.learning_rate,
+                        weight_decay=self.args.weight_decay,
+                    )
+                    return self.optimizer
+                return super().create_optimizer()
+
+            def compute_loss(self, *args, **kwargs):
+                result = super().compute_loss(*args, **kwargs)
+                loss = result[0] if isinstance(result, tuple) else result
+                self.step_losses.append(float(loss.detach().float().cpu()))
+                return result
+
+        return CompatTrainer
+
+
+def _run_torch(args: argparse.Namespace) -> float:
+    if args.device.startswith("cuda:"):
+        os.environ["CUDA_VISIBLE_DEVICES"] = args.device.split(":", 1)[1]
+        args.device = "cuda:0"
+
+    import numpy as np
+    import torch
+    from datasets import Dataset
+    from swift.model import get_model_processor
+    from swift.template import get_template
+    from swift.trainers import Trainer, TrainingArguments
+
+    torch.manual_seed(args.seed)
+    torch.backends.cuda.matmul.allow_tf32 = False
+    torch.set_float32_matmul_precision("highest")
+    torch_dtype = torch.float32 if args.dtype == "float32" else torch.bfloat16
+    model, processor = get_model_processor(
+        args.model,
+        model_type="gemma3_vision",
+        torch_dtype=torch_dtype,
+        device_map=args.device,
+    )
+    template = get_template(processor, template_type="gemma3_vision", max_length=args.max_length)
+    template.set_mode("train")
+    rows = [
+        {
+            "messages": [
+                {"role": "user", "content": "t4 t5"},
+                {"role": "assistant", "content": "t6 t7"},
+            ]
+        }
+        for _ in range(2)
+    ]
+    encoded = [template.encode(row, return_length=True) for row in rows]
+    for item in encoded:
+        item["token_type_ids"] = [0] * len(item["input_ids"])
+    dataset = Dataset.from_list(encoded)
+    collated = template.data_collator([encoded[0]])
+
+    args_training = TrainingArguments(
+        output_dir=str(args.batch.parent / "ms-swift-output"),
+        per_device_train_batch_size=1,
+        num_train_epochs=1,
+        max_steps=args.max_steps,
+        logging_steps=1,
+        save_strategy="no",
+        report_to=[],
+        use_cpu=args.device == "cpu",
+        bf16=args.dtype == "bfloat16" and args.device != "cpu",
+        learning_rate=args.learning_rate,
+        weight_decay=args.weight_decay,
+        adam_beta1=args.adam_beta1,
+        adam_beta2=args.adam_beta2,
+        adam_epsilon=args.adam_epsilon,
+        max_grad_norm=args.max_grad_norm,
+        lr_scheduler_type="constant",
+        remove_unused_columns=False,
+        gradient_accumulation_steps=1,
+        dataloader_num_workers=0,
+    )
+    trainer_cls = _CompatSwiftTrainer.make(Trainer, args.optimizer)
+    trainer = trainer_cls(model=model, args=args_training, template=template, train_dataset=dataset)
+    result = trainer.train()
+    losses = trainer.step_losses[: args.max_steps]
+    loss = float(result.training_loss)
+
+    args.batch.parent.mkdir(parents=True, exist_ok=True)
+    np.savez(
+        args.batch,
+        input_ids=collated["input_ids"].detach().cpu().numpy(),
+        attention_mask=collated["attention_mask"].detach().cpu().numpy(),
+        labels=collated["labels"].detach().cpu().numpy(),
+        token_type_ids=collated["token_type_ids"].detach().cpu().numpy(),
+    )
+    metadata = {
+        "framework": "ms-swift",
+        "model": str(Path(args.model).resolve()),
+        "model_type": "gemma3_vision",
+        "dtype": args.dtype,
+        "device": args.device,
+        "seed": args.seed,
+        "max_steps": args.max_steps,
+        "learning_rate": args.learning_rate,
+        "weight_decay": args.weight_decay,
+        "adam_beta1": args.adam_beta1,
+        "adam_beta2": args.adam_beta2,
+        "adam_epsilon": args.adam_epsilon,
+        "max_grad_norm": args.max_grad_norm,
+        "optimizer": "zero_lr_sgd" if args.learning_rate == 0 else args.optimizer,
+        "losses": losses,
+        "training_loss": loss,
+        "torch": torch.__version__,
+    }
+    args.batch.with_suffix(".json").write_text(json.dumps(metadata, indent=2) + "\n")
+    print(json.dumps({"framework": "ms-swift", "losses": losses, "batch": str(args.batch)}))
+    return loss
+
+
+def _run_paddle(args: argparse.Namespace) -> float:
+    import numpy as np
+    import paddle
+    from paddleformers.transformers.gemma3.modeling import Gemma3ForConditionalGeneration
+
+    paddle.seed(args.seed)
+    paddle.set_device(args.device.replace("cuda", "gpu"))
+    batch = np.load(args.batch)
+    model = Gemma3ForConditionalGeneration.from_pretrained(args.model, dtype=args.dtype)
+    model.train()
+    optimizer_kwargs = {
+        "learning_rate": args.learning_rate,
+        "weight_decay": args.weight_decay,
+        "grad_clip": paddle.nn.ClipGradByGlobalNorm(args.max_grad_norm),
+        "parameters": model.parameters(),
+    }
+    if args.optimizer == "adamw":
+        optimizer = paddle.optimizer.AdamW(
+            beta1=args.adam_beta1,
+            beta2=args.adam_beta2,
+            epsilon=args.adam_epsilon,
+            **optimizer_kwargs,
+        )
+    else:
+        optimizer = paddle.optimizer.SGD(**optimizer_kwargs)
+    paddle_batch = {
+        "input_ids": paddle.to_tensor(batch["input_ids"], dtype="int64"),
+        "attention_mask": paddle.to_tensor(batch["attention_mask"]),
+        "labels": paddle.to_tensor(batch["labels"], dtype="int64"),
+        "token_type_ids": paddle.to_tensor(batch["token_type_ids"], dtype="int64"),
+    }
+    losses = []
+    for _ in range(args.max_steps):
+        outputs = model(**paddle_batch, use_cache=False, return_dict=True)
+        loss = outputs.loss
+        losses.append(float(loss.detach().astype("float32").cpu().item()))
+        loss.backward()
+        if args.learning_rate == 0:
+            model.clear_gradients()
+        else:
+            optimizer.step()
+            optimizer.clear_grad()
+
+    result = {"framework": "paddle", "losses": losses, "batch": str(args.batch)}
+    reference_path = args.batch.with_suffix(".json")
+    if reference_path.exists():
+        reference = json.loads(reference_path.read_text())
+        torch_losses = reference["losses"]
+        if len(torch_losses) != len(losses):
+            raise RuntimeError(f"Step count differs: Torch={len(torch_losses)}, Paddle={len(losses)}")
+        deltas = [paddle_loss - torch_loss for paddle_loss, torch_loss in zip(losses, torch_losses)]
+        result.update({"torch_losses": torch_losses, "loss_deltas": deltas, "tolerance": args.tolerance})
+        if any(abs(delta) > args.tolerance for delta in deltas):
+            raise RuntimeError(f"Paddle/ms-swift loss deltas {deltas} exceed tolerance {args.tolerance:.6g}")
+    print(json.dumps(result))
+    return losses[-1]
+
+
+def main() -> None:
+    args = _parse_args()
+    if args.framework == "torch":
+        _run_torch(args)
+    else:
+        _run_paddle(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tools/compare_gemma3_multimodal_precision.py
+++ b/examples/tools/compare_gemma3_multimodal_precision.py
@@ -1,4 +1,19 @@
 #!/usr/bin/env python3
+
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Export and compare deterministic Gemma3 multimodal precision traces.
 
 Torch and Paddle normally live in separate environments, so framework runs
@@ -25,7 +40,6 @@ import hashlib
 import json
 import platform
 from pathlib import Path
-
 
 LINEAR_WEIGHT_SUFFIXES = (
     "self_attn.q_proj.weight",
@@ -300,8 +314,8 @@ def _run_torch(args: argparse.Namespace) -> None:  # pragma: no cover - separate
 def _run_paddle(args: argparse.Namespace) -> None:  # pragma: no cover - separate Paddle environment
     import numpy as np
     import paddle
-
     from paddle.base import core
+
     from paddleformers.transformers import Gemma3ForConditionalGeneration
 
     paddle.seed(args.seed)

--- a/examples/tools/compare_gemma3_multimodal_precision.py
+++ b/examples/tools/compare_gemma3_multimodal_precision.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+"""Export and compare deterministic Gemma3 multimodal precision traces.
+
+Torch and Paddle normally live in separate environments, so framework runs
+write self-contained NPZ/JSON artifacts and comparison is offline::
+
+    python compare_gemma3_multimodal_precision.py torch --model MODEL \
+        --batch /tmp/gemma3-mm-batch.npz --output /tmp/gemma3-torch.npz
+    python compare_gemma3_multimodal_precision.py paddle --model MODEL \
+        --batch /tmp/gemma3-mm-batch.npz --output /tmp/gemma3-paddle.npz
+    python compare_gemma3_multimodal_precision.py compare \
+        --torch-output /tmp/gemma3-torch.npz \
+        --paddle-output /tmp/gemma3-paddle.npz
+
+Both exporters use FP32, eval mode, eager attention, fixed inputs, and precise
+FP32 GEMM.  Large intermediate attention matrices are sampled at fixed query
+positions; every vision layer's residual output is sampled as well.  Full
+image features, final hidden states, and logits are retained for acceptance.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+from pathlib import Path
+
+
+LINEAR_WEIGHT_SUFFIXES = (
+    "self_attn.q_proj.weight",
+    "self_attn.k_proj.weight",
+    "self_attn.v_proj.weight",
+    "self_attn.out_proj.weight",
+    "mlp.fc1.weight",
+    "mlp.fc2.weight",
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="mode", required=True)
+    for framework in ("torch", "paddle"):
+        subparser = subparsers.add_parser(framework, help=f"export a {framework} trace")
+        subparser.add_argument("--model", required=True, type=Path)
+        subparser.add_argument("--batch", required=True, type=Path)
+        subparser.add_argument("--output", required=True, type=Path)
+        subparser.add_argument("--device", default="cuda:0")
+        subparser.add_argument("--seed", type=int, default=2026)
+        subparser.add_argument("--trace-layer", type=int, default=0)
+        subparser.add_argument("--sample-tokens", default="0,1,2048,4095")
+        subparser.add_argument(
+            "--reuse-batch",
+            action="store_true",
+            help="in torch mode, reuse an existing batch instead of replacing it",
+        )
+
+    compare = subparsers.add_parser("compare", help="compare exported artifacts")
+    compare.add_argument("--torch-output", required=True, type=Path)
+    compare.add_argument("--paddle-output", required=True, type=Path)
+    compare.add_argument("--vision-tolerance", type=float, default=2e-4)
+    compare.add_argument("--logits-tolerance", type=float, default=1e-2)
+    return parser.parse_args()
+
+
+def _sha256(array) -> str:
+    import numpy as np
+
+    contiguous = np.ascontiguousarray(array)
+    return hashlib.sha256(contiguous.view(np.uint8)).hexdigest()
+
+
+def _array_summary(array) -> dict:
+    import numpy as np
+
+    value = np.asarray(array)
+    return {
+        "shape": list(value.shape),
+        "dtype": str(value.dtype),
+        "mean": float(value.astype(np.float64).mean()),
+        "std": float(value.astype(np.float64).std()),
+        "sha256": _sha256(value),
+    }
+
+
+def _write_metadata(output: Path, metadata: dict) -> None:
+    output.with_suffix(".json").write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n")
+
+
+def _make_batch(config, batch_path: Path, seed: int) -> dict:
+    import numpy as np
+
+    rng = np.random.default_rng(seed)
+    image_tokens = int(config.mm_tokens_per_image)
+    seq_length = image_tokens + 9
+    vocab_size = int(config.text_config.vocab_size)
+    image_token_id = getattr(config, "image_token_id", None)
+    if image_token_id is None:
+        image_token_id = config.image_token_index
+    image_token_id = int(image_token_id)
+    input_ids = (np.arange(seq_length, dtype=np.int64)[None, :] + 10) % vocab_size
+    input_ids[0, 0] = int(config.text_config.bos_token_id)
+    input_ids[0, 1 : image_tokens + 1] = image_token_id
+    token_type_ids = np.zeros_like(input_ids)
+    token_type_ids[0, 1 : image_tokens + 1] = 1
+    attention_mask = np.ones_like(input_ids)
+    image_size = int(config.vision_config.image_size)
+    pixel_values = rng.standard_normal((1, 3, image_size, image_size), dtype=np.float32)
+    batch_path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez(
+        batch_path,
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        token_type_ids=token_type_ids,
+        pixel_values=pixel_values,
+    )
+    return {
+        "input_ids": input_ids,
+        "attention_mask": attention_mask,
+        "token_type_ids": token_type_ids,
+        "pixel_values": pixel_values,
+    }
+
+
+def _load_batch(batch_path: Path) -> dict:
+    import numpy as np
+
+    if not batch_path.exists():
+        raise FileNotFoundError(f"Batch does not exist; run torch mode first: {batch_path}")
+    with np.load(batch_path) as batch:
+        return {name: batch[name] for name in batch.files}
+
+
+def _sample_indices(spec: str, sequence_length: int) -> list[int]:
+    indices = sorted({int(value) for value in spec.split(",")})
+    if not indices or indices[0] < 0 or indices[-1] >= sequence_length:
+        raise ValueError(f"sample tokens must be within [0, {sequence_length}), got {indices}")
+    return indices
+
+
+def _canonical_weight_name(name: str, framework: str) -> str | None:
+    if framework == "torch":
+        if name.startswith("model.vision_tower.vision_model.") or name.startswith("model.multi_modal_projector."):
+            return name[len("model.") :]
+        return None
+    if name.startswith("model.vision_tower."):
+        return "vision_tower.vision_model." + name[len("model.vision_tower.") :]
+    if name.startswith("model.multi_modal_projector."):
+        return name[len("model.") :]
+    return None
+
+
+def _weight_manifest(state_dict, framework: str) -> dict:
+    manifest = {}
+    for name, tensor in state_dict.items():
+        canonical_name = _canonical_weight_name(name, framework)
+        if canonical_name is None:
+            continue
+        if framework == "torch":
+            array = tensor.detach().float().cpu().numpy()
+        else:
+            array = tensor.astype("float32").cpu().numpy()
+            if canonical_name.endswith(LINEAR_WEIGHT_SUFFIXES):
+                array = array.T
+        manifest[canonical_name] = _array_summary(array)
+    return manifest
+
+
+def _metadata(framework: str, args: argparse.Namespace, batch: dict, versions: dict, weights: dict) -> dict:
+    return {
+        "framework": framework,
+        "versions": versions,
+        "python": platform.python_version(),
+        "model": str(args.model.resolve()),
+        "device": args.device,
+        "dtype": "float32",
+        "seed": args.seed,
+        "trace_layer": args.trace_layer,
+        "sample_tokens": args.sample_tokens,
+        "precision": {
+            "torch_float32_matmul_precision": "highest" if framework == "torch" else None,
+            "paddle_allow_tf32_cublas": False if framework == "paddle" else None,
+        },
+        "inputs": {name: _array_summary(value) for name, value in batch.items()},
+        "weights": weights,
+    }
+
+
+def _run_torch(args: argparse.Namespace) -> None:  # pragma: no cover - separate Torch environment
+    import numpy as np
+    import torch
+    import transformers
+    from transformers import Gemma3ForConditionalGeneration
+
+    torch.manual_seed(args.seed)
+    torch.backends.cuda.matmul.allow_tf32 = False
+    torch.set_float32_matmul_precision("highest")
+    config = transformers.Gemma3Config.from_pretrained(str(args.model))
+    if not args.reuse_batch or not args.batch.exists():
+        batch = _make_batch(config, args.batch, args.seed)
+    else:
+        batch = _load_batch(args.batch)
+
+    model = Gemma3ForConditionalGeneration.from_pretrained(
+        str(args.model),
+        config=config,
+        dtype=torch.float32,
+        attn_implementation="eager",
+    ).to(args.device)
+    model.eval()
+    vision = model.model.vision_tower.vision_model
+    trace_layer = vision.encoder.layers[args.trace_layer]
+    indices = _sample_indices(args.sample_tokens, vision.embeddings.num_patches)
+    captured = {}
+    handles = []
+
+    def save_post(name, keep_full=False):
+        def hook(_module, _inputs, output):
+            value = output[0] if isinstance(output, tuple) else output
+            captured[name] = value if keep_full else value[:, indices]
+
+        return hook
+
+    def save_pre(name):
+        def hook(_module, inputs):
+            captured[name] = inputs[0][:, indices]
+
+        return hook
+
+    def save_mask(name):
+        def hook(_module, _inputs, kwargs):
+            captured[name] = kwargs["attention_mask"]
+
+        return hook
+
+    handles.append(vision.embeddings.register_forward_hook(save_post("vision.embedding")))
+    for layer_index, layer in enumerate(vision.encoder.layers):
+        handles.append(layer.register_forward_hook(save_post(f"vision.layer.{layer_index:02d}.output")))
+    handles += [
+        trace_layer.layer_norm1.register_forward_hook(save_post("trace.ln1")),
+        trace_layer.self_attn.q_proj.register_forward_hook(save_post("trace.q", keep_full=True)),
+        trace_layer.self_attn.k_proj.register_forward_hook(save_post("trace.k", keep_full=True)),
+        trace_layer.self_attn.v_proj.register_forward_hook(save_post("trace.v", keep_full=True)),
+        trace_layer.self_attn.out_proj.register_forward_pre_hook(save_pre("trace.context")),
+        trace_layer.self_attn.out_proj.register_forward_hook(save_post("trace.attn_out")),
+        trace_layer.layer_norm2.register_forward_hook(save_post("trace.ln2")),
+        trace_layer.mlp.fc1.register_forward_hook(save_post("trace.fc1")),
+        trace_layer.mlp.fc2.register_forward_hook(save_post("trace.mlp")),
+        vision.post_layernorm.register_forward_hook(save_post("vision.final")),
+    ]
+    language_layers = model.model.language_model.layers
+    handles += [
+        language_layers[0].register_forward_pre_hook(save_mask("mask.sliding"), with_kwargs=True),
+        language_layers[5].register_forward_pre_hook(save_mask("mask.full"), with_kwargs=True),
+    ]
+
+    torch_batch = {
+        "input_ids": torch.from_numpy(batch["input_ids"]).to(args.device),
+        "attention_mask": torch.from_numpy(batch["attention_mask"]).to(args.device),
+        "token_type_ids": torch.from_numpy(batch["token_type_ids"]).to(args.device),
+        "pixel_values": torch.from_numpy(batch["pixel_values"]).to(args.device),
+    }
+    with torch.no_grad():
+        outputs = model(**torch_batch, use_cache=False, output_hidden_states=True, return_dict=True)
+        num_heads = vision.config.num_attention_heads
+        head_dim = vision.config.hidden_size // num_heads
+        q = captured.pop("trace.q").view(1, -1, num_heads, head_dim).transpose(1, 2)
+        k = captured.pop("trace.k").view(1, -1, num_heads, head_dim).transpose(1, 2)
+        v = captured.pop("trace.v").view(1, -1, num_heads, head_dim).transpose(1, 2)
+        query_indices = torch.tensor(indices, device=q.device)
+        sampled_q = q.index_select(2, query_indices)
+        logits = torch.matmul(sampled_q, k.transpose(-1, -2)) * trace_layer.self_attn.scale
+        probabilities = torch.softmax(logits, dim=-1, dtype=torch.float32)
+        context = torch.matmul(probabilities, v).transpose(1, 2).reshape(1, len(indices), -1)
+        captured["trace.q"] = sampled_q.transpose(1, 2).reshape(1, len(indices), -1)
+        sampled_k = torch.index_select(k, 2, query_indices)
+        sampled_v = torch.index_select(v, 2, query_indices)
+        captured["trace.k"] = sampled_k.transpose(1, 2).reshape(1, len(indices), -1)
+        captured["trace.v"] = sampled_v.transpose(1, 2).reshape(1, len(indices), -1)
+        captured["trace.attn_logits"] = logits
+        captured["trace.softmax"] = probabilities
+        captured["trace.context_recomputed"] = context
+        captured["trace.gelu"] = torch.nn.functional.gelu(captured["trace.fc1"], approximate="tanh")
+        captured["image_features"] = outputs.image_hidden_states
+        captured["final_hidden"] = outputs.hidden_states[-1]
+        captured["logits"] = outputs.logits
+
+    for handle in handles:
+        handle.remove()
+    arrays = {name: value.detach().float().cpu().numpy() for name, value in captured.items()}
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    np.savez(args.output, **arrays)
+    versions = {"torch": torch.__version__, "transformers": transformers.__version__, "numpy": np.__version__}
+    metadata = _metadata("torch", args, batch, versions, _weight_manifest(model.state_dict(), "torch"))
+    metadata["outputs"] = {name: _array_summary(value) for name, value in arrays.items()}
+    _write_metadata(args.output, metadata)
+    print(json.dumps({"framework": "torch", "output": str(args.output), "arrays": len(arrays)}))
+
+
+def _run_paddle(args: argparse.Namespace) -> None:  # pragma: no cover - separate Paddle environment
+    import numpy as np
+    import paddle
+
+    from paddle.base import core
+    from paddleformers.transformers import Gemma3ForConditionalGeneration
+
+    paddle.seed(args.seed)
+    paddle.set_device(args.device.replace("cuda", "gpu"))
+    # Start from Paddle's default to verify that the model selects precise
+    # FP32 GEMM itself before entering either backbone.
+    core.set_cublas_switch(True)
+    batch = _load_batch(args.batch)
+    model = Gemma3ForConditionalGeneration.from_pretrained(str(args.model), dtype="float32")
+    model.eval()
+    vision = model.model.vision_tower
+    trace_layer = vision.encoder.layers[args.trace_layer]
+    indices = _sample_indices(args.sample_tokens, vision.embeddings.num_patches)
+    captured = {}
+    handles = []
+
+    def save_post(name, keep_full=False):
+        def hook(_layer, _inputs, output):
+            value = output[0] if isinstance(output, tuple) else output
+            captured[name] = value if keep_full else value[:, indices]
+
+        return hook
+
+    def save_pre(name):
+        def hook(_layer, inputs):
+            captured[name] = inputs[0][:, indices]
+
+        return hook
+
+    def save_mask(name):
+        def hook(_layer, _inputs, kwargs):
+            captured[name] = kwargs["attention_mask"]
+
+        return hook
+
+    handles.append(vision.embeddings.register_forward_post_hook(save_post("vision.embedding")))
+    for layer_index, layer in enumerate(vision.encoder.layers):
+        handles.append(layer.register_forward_post_hook(save_post(f"vision.layer.{layer_index:02d}.output")))
+    handles += [
+        trace_layer.layer_norm1.register_forward_post_hook(save_post("trace.ln1")),
+        trace_layer.self_attn.q_proj.register_forward_post_hook(save_post("trace.q", keep_full=True)),
+        trace_layer.self_attn.k_proj.register_forward_post_hook(save_post("trace.k", keep_full=True)),
+        trace_layer.self_attn.v_proj.register_forward_post_hook(save_post("trace.v", keep_full=True)),
+        trace_layer.self_attn.out_proj.register_forward_pre_hook(save_pre("trace.context")),
+        trace_layer.self_attn.out_proj.register_forward_post_hook(save_post("trace.attn_out")),
+        trace_layer.layer_norm2.register_forward_post_hook(save_post("trace.ln2")),
+        trace_layer.mlp.fc1.register_forward_post_hook(save_post("trace.fc1")),
+        trace_layer.mlp.fc2.register_forward_post_hook(save_post("trace.mlp")),
+        vision.post_layernorm.register_forward_post_hook(save_post("vision.final")),
+    ]
+    language_layers = model.model.language_model.layers
+    handles += [
+        language_layers[0].register_forward_pre_hook(save_mask("mask.sliding"), with_kwargs=True),
+        language_layers[5].register_forward_pre_hook(save_mask("mask.full"), with_kwargs=True),
+    ]
+
+    paddle_batch = {
+        "input_ids": paddle.to_tensor(batch["input_ids"], dtype="int64"),
+        "attention_mask": paddle.to_tensor(batch["attention_mask"], dtype="int64"),
+        "token_type_ids": paddle.to_tensor(batch["token_type_ids"], dtype="int64"),
+        "pixel_values": paddle.to_tensor(batch["pixel_values"], dtype="float32"),
+    }
+    with paddle.no_grad():
+        outputs = model(**paddle_batch, use_cache=False, output_hidden_states=True, return_dict=True)
+        num_heads = vision.config.num_attention_heads
+        head_dim = vision.config.hidden_size // num_heads
+        q = captured.pop("trace.q").reshape([1, -1, num_heads, head_dim]).transpose([0, 2, 1, 3])
+        k = captured.pop("trace.k").reshape([1, -1, num_heads, head_dim]).transpose([0, 2, 1, 3])
+        v = captured.pop("trace.v").reshape([1, -1, num_heads, head_dim]).transpose([0, 2, 1, 3])
+        sampled_q = paddle.index_select(q, paddle.to_tensor(indices), axis=2)
+        logits = paddle.matmul(sampled_q, k.transpose([0, 1, 3, 2])) * trace_layer.self_attn.scale
+        probabilities = paddle.nn.functional.softmax(logits, axis=-1, dtype="float32")
+        context = paddle.matmul(probabilities, v).transpose([0, 2, 1, 3]).reshape([1, len(indices), -1])
+        captured["trace.q"] = sampled_q.transpose([0, 2, 1, 3]).reshape([1, len(indices), -1])
+        sampled_k = paddle.index_select(k, paddle.to_tensor(indices), axis=2)
+        sampled_v = paddle.index_select(v, paddle.to_tensor(indices), axis=2)
+        captured["trace.k"] = sampled_k.transpose([0, 2, 1, 3]).reshape([1, len(indices), -1])
+        captured["trace.v"] = sampled_v.transpose([0, 2, 1, 3]).reshape([1, len(indices), -1])
+        captured["trace.attn_logits"] = logits
+        captured["trace.softmax"] = probabilities
+        captured["trace.context_recomputed"] = context
+        captured["trace.gelu"] = paddle.nn.functional.gelu(captured["trace.fc1"], approximate=True)
+        captured["image_features"] = outputs.image_hidden_states
+        captured["final_hidden"] = outputs.hidden_states[-1]
+        captured["logits"] = outputs.logits
+
+    for handle in handles:
+        handle.remove()
+    arrays = {name: value.astype("float32").cpu().numpy() for name, value in captured.items()}
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    np.savez(args.output, **arrays)
+    versions = {"paddle": paddle.__version__, "numpy": np.__version__}
+    metadata = _metadata("paddle", args, batch, versions, _weight_manifest(model.state_dict(), "paddle"))
+    metadata["precision"]["paddle_allow_tf32_cublas"] = core.get_cublas_switch()
+    metadata["outputs"] = {name: _array_summary(value) for name, value in arrays.items()}
+    _write_metadata(args.output, metadata)
+    print(json.dumps({"framework": "paddle", "output": str(args.output), "arrays": len(arrays)}))
+
+
+def _run_compare(args: argparse.Namespace) -> None:
+    import numpy as np
+
+    torch_metadata = json.loads(args.torch_output.with_suffix(".json").read_text())
+    paddle_metadata = json.loads(args.paddle_output.with_suffix(".json").read_text())
+    if torch_metadata["inputs"] != paddle_metadata["inputs"]:
+        raise RuntimeError("Torch and Paddle artifacts were not generated from identical inputs")
+
+    torch_weights = torch_metadata["weights"]
+    paddle_weights = paddle_metadata["weights"]
+    if torch_weights.keys() != paddle_weights.keys():
+        missing = sorted(torch_weights.keys() - paddle_weights.keys())
+        extra = sorted(paddle_weights.keys() - torch_weights.keys())
+        raise RuntimeError(f"Vision weight keys differ; missing={missing}, extra={extra}")
+    mismatched_weights = [
+        name for name in torch_weights if torch_weights[name]["sha256"] != paddle_weights[name]["sha256"]
+    ]
+    if mismatched_weights:
+        raise RuntimeError(f"Vision weights differ after conversion: {mismatched_weights}")
+
+    results = {}
+    failures = []
+    with np.load(args.torch_output) as torch_arrays, np.load(args.paddle_output) as paddle_arrays:
+        if set(torch_arrays.files) != set(paddle_arrays.files):
+            raise RuntimeError("Torch and Paddle artifacts contain different arrays")
+        for name in torch_arrays.files:
+            if name.startswith("mask."):
+                mismatch_count = int(np.count_nonzero(torch_arrays[name] != paddle_arrays[name]))
+                results[name] = {"mismatch_count": mismatch_count}
+                if mismatch_count:
+                    failures.append(f"{name} differs at {mismatch_count} elements")
+                continue
+            torch_value = torch_arrays[name].astype(np.float64)
+            paddle_value = paddle_arrays[name].astype(np.float64)
+            difference = np.abs(torch_value - paddle_value)
+            results[name] = {"mae": float(difference.mean()), "max_abs": float(difference.max())}
+
+    for name, tolerance in (
+        ("image_features", args.vision_tolerance),
+        ("logits", args.logits_tolerance),
+    ):
+        if results[name]["mae"] > tolerance:
+            failures.append(f"{name} MAE {results[name]['mae']:.6g} exceeds {tolerance:.6g}")
+
+    report = {
+        "weights": {"count": len(torch_weights), "all_exact": True},
+        "tolerances": {"image_features": args.vision_tolerance, "logits": args.logits_tolerance},
+        "results": results,
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if failures:
+        raise RuntimeError("; ".join(failures))
+
+
+def main() -> None:
+    args = _parse_args()
+    if args.mode == "torch":
+        _run_torch(args)
+    elif args.mode == "paddle":
+        _run_paddle(args)
+    else:
+        _run_compare(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/paddleformers/nn/mlp.py
+++ b/paddleformers/nn/mlp.py
@@ -22,6 +22,7 @@ except ImportError:
         gate, value = x.chunk(2, axis=-1)
         return paddle.nn.functional.silu(gate) * value
 
+
 from ..generation.configuration_utils import PretrainedConfig
 from .activation import ACT2FN
 from .linear import Linear

--- a/paddleformers/nn/mlp.py
+++ b/paddleformers/nn/mlp.py
@@ -13,7 +13,14 @@
 # limitations under the License.
 import paddle
 import paddle.nn as nn
-from paddle.nn.functional import swiglu as fused_swiglu
+
+try:
+    from paddle.nn.functional import swiglu as fused_swiglu
+except ImportError:
+    # Paddle versions without the fused kernel still support the same operation.
+    def fused_swiglu(x):
+        gate, value = x.chunk(2, axis=-1)
+        return paddle.nn.functional.silu(gate) * value
 
 from ..generation.configuration_utils import PretrainedConfig
 from .activation import ACT2FN

--- a/paddleformers/transformers/__init__.py
+++ b/paddleformers/transformers/__init__.py
@@ -203,6 +203,11 @@ import_structure = {
         "ShieldGemma2ForImageClassification",
         "ShieldGemma2ImageClassifierOutputWithNoAttention",
     ],
+    "shieldgemma2.processor": [
+        "DEFAULT_SHIELDGEMMA2_POLICIES",
+        "ShieldGemma2Processor",
+        "ShieldGemma2ProcessorKwargs",
+    ],
     "kimi_k2.configuration": ["KimiK2Config"],
     "kimi_k2.modeling": ["KimiK2ForCausalLM", "KimiK2ForCausalLMPipe"],
     "kimi_k2.tokenizer": ["KimiK2TikTokenTokenizer"],

--- a/paddleformers/transformers/__init__.py
+++ b/paddleformers/transformers/__init__.py
@@ -186,6 +186,18 @@ import_structure = {
     "kimi_k25.tokenizer": ["TikTokenTokenizer"],
     "gemma3_text.configuration": ["Gemma3Config", "Gemma3TextConfig"],
     "gemma3_text.modeling": ["Gemma3TextModel", "Gemma3ForCausalLM", "Gemma3ForCausalLMPipe"],
+    "gemma3.configuration": ["Gemma3Config"],
+    "gemma3.image_processor": ["Gemma3ImageProcessor", "Gemma3ImageProcessorKwargs"],
+    "gemma3.image_processor_fast": ["Gemma3ImageProcessorFast"],
+    "gemma3.processor": ["Gemma3Processor", "Gemma3ProcessorKwargs"],
+    "gemma3.modeling": [
+        "Gemma3ModelOutputWithPast",
+        "Gemma3CausalLMOutputWithPast",
+        "Gemma3MultiModalProjector",
+        "Gemma3PreTrainedModel",
+        "Gemma3Model",
+        "Gemma3ForConditionalGeneration",
+    ],
     "kimi_k2.configuration": ["KimiK2Config"],
     "kimi_k2.modeling": ["KimiK2ForCausalLM", "KimiK2ForCausalLMPipe"],
     "kimi_k2.tokenizer": ["KimiK2TikTokenTokenizer"],
@@ -484,6 +496,7 @@ if TYPE_CHECKING:
     from .granite import *
     from .phi3 import *
     from .gemma3_text import *
+    from .gemma3 import *
     from .glm_ocr import *
     from .olmo2 import *
     from .intern_lm3 import *

--- a/paddleformers/transformers/__init__.py
+++ b/paddleformers/transformers/__init__.py
@@ -198,6 +198,11 @@ import_structure = {
         "Gemma3Model",
         "Gemma3ForConditionalGeneration",
     ],
+    "shieldgemma2.configuration": ["ShieldGemma2Config", "ShieldGemma2VisionConfig"],
+    "shieldgemma2.modeling": [
+        "ShieldGemma2ForImageClassification",
+        "ShieldGemma2ImageClassifierOutputWithNoAttention",
+    ],
     "kimi_k2.configuration": ["KimiK2Config"],
     "kimi_k2.modeling": ["KimiK2ForCausalLM", "KimiK2ForCausalLMPipe"],
     "kimi_k2.tokenizer": ["KimiK2TikTokenTokenizer"],
@@ -497,6 +502,7 @@ if TYPE_CHECKING:
     from .phi3 import *
     from .gemma3_text import *
     from .gemma3 import *
+    from .shieldgemma2 import *
     from .glm_ocr import *
     from .olmo2 import *
     from .intern_lm3 import *

--- a/paddleformers/transformers/auto/configuration.py
+++ b/paddleformers/transformers/auto/configuration.py
@@ -111,6 +111,7 @@ MODEL_NAMES_MAPPING = OrderedDict(
         ("granite", "Granite"),
         ("gemma3", "Gemma3ForConditionalGeneration"),
         ("gemma3_text", "Gemma3TextModel"),
+        ("shieldgemma2", "ShieldGemma2ForImageClassification"),
         ("qwen3_5_moe", "Qwen3_5MoEForConditionalGeneration"),
         ("qwen3_5", "Qwen3_5ForConditionalGeneration"),
         ("olmo2", "Olmo2ForCausalLM"),

--- a/paddleformers/transformers/auto/configuration.py
+++ b/paddleformers/transformers/auto/configuration.py
@@ -63,6 +63,7 @@ CONFIG_MAPPING_NAMES = OrderedDict(
         ("gpt_oss", "GptOssConfig"),
         ("phi3", "Phi3Config"),
         ("granite", "GraniteConfig"),
+        ("gemma3", "Gemma3Config"),
         ("gemma3_text", "Gemma3TextConfig"),
         ("glm4v_moe", "Glm4vMoeConfig"),
         ("glm_ocr", "GlmOcrConfig"),
@@ -107,6 +108,8 @@ MODEL_NAMES_MAPPING = OrderedDict(
         ("glm_ocr", "GlmOcrForConditionalGeneration"),
         ("minicpm", "MiniCPM"),
         ("granite", "Granite"),
+        ("gemma3", "Gemma3ForConditionalGeneration"),
+        ("gemma3_text", "Gemma3TextModel"),
         ("qwen3_5_moe", "Qwen3_5MoEForConditionalGeneration"),
         ("qwen3_5", "Qwen3_5ForConditionalGeneration"),
         ("olmo2", "Olmo2ForCausalLM"),
@@ -128,6 +131,7 @@ MULTI_MODELS_MAPPING = OrderedDict(
 SPECIAL_MODEL_TYPE_TO_MODULE_NAME = OrderedDict(
     [
         ("paligemma", "paligemma2"),
+        ("gemma3", "gemma3"),
         ("qwen2_5_vl_text", "qwen2_5_vl"),
         ("qwen3_vl_text", "qwen3_vl"),
         ("qwen3_vl_moe_text", "qwen3_vl_moe"),

--- a/paddleformers/transformers/auto/configuration.py
+++ b/paddleformers/transformers/auto/configuration.py
@@ -65,6 +65,7 @@ CONFIG_MAPPING_NAMES = OrderedDict(
         ("granite", "GraniteConfig"),
         ("gemma3", "Gemma3Config"),
         ("gemma3_text", "Gemma3TextConfig"),
+        ("shieldgemma2", "ShieldGemma2Config"),
         ("glm4v_moe", "Glm4vMoeConfig"),
         ("glm_ocr", "GlmOcrConfig"),
         ("qwen3_5", "Qwen3_5Config"),

--- a/paddleformers/transformers/auto/image_processing.py
+++ b/paddleformers/transformers/auto/image_processing.py
@@ -55,6 +55,7 @@ IMAGE_PROCESSOR_MAPPING_NAMES.update(
         "glm4v_moe": ("Glm4vImageProcessor", "Glm4vImageProcessorFast"),
         "kimi_k25": ("KimiK25VisionProcessor"),
         "paddleocr_vl": ("PaddleOCRVLImageProcessor"),
+        "gemma3": ("Gemma3ImageProcessor", "Gemma3ImageProcessorFast"),
         "qwen2_5_vl": ("Qwen2VLImageProcessor", "Qwen2VLImageProcessorFast"),
         "qwen2_vl": ("Qwen2VLImageProcessor", "Qwen2VLImageProcessorFast"),
         "qwen3_vl": ("Qwen3VLImageProcessor", "Qwen3VLImageProcessorFast"),

--- a/paddleformers/transformers/auto/modeling.py
+++ b/paddleformers/transformers/auto/modeling.py
@@ -82,7 +82,8 @@ MAPPING_NAMES = OrderedDict(
         ("Granite", "granite"),
         ("Phi3", "phi3"),
         ("Phi4", "phi4"),
-        ("Gemma3", "gemma3_text"),
+        ("Gemma3", "gemma3"),
+        ("Gemma3Text", "gemma3_text"),
         ("Gemma4Moe", "gemma4_moe"),
         ("Glm4vMoe", "glm4v_moe"),
         ("GlmOcr", "glm_ocr"),
@@ -92,10 +93,8 @@ MAPPING_NAMES = OrderedDict(
     ]
 )
 
-MAPPING_SPACIAL_KEY = OrderedDict(
-    [("Gemma3", "Gemma3Text"), ("Ernie4_5_VLMoe", "Ernie4_5_VLMoeForConditionalGeneration")]
-)
-CONFIGURATION_MODEL_MAPPING = OrderedDict([((), "Gemma3TextModel")])
+MAPPING_SPACIAL_KEY = OrderedDict([("Gemma3", "Gemma3"), ("Ernie4_5_VLMoe", "Ernie4_5_VLMoeForConditionalGeneration")])
+CONFIGURATION_MODEL_MAPPING = OrderedDict([((), "Gemma3ForConditionalGeneration")])
 
 MAPPING_TASKS = OrderedDict(
     [

--- a/paddleformers/transformers/auto/processing.py
+++ b/paddleformers/transformers/auto/processing.py
@@ -56,6 +56,7 @@ PROCESSOR_MAPPING_NAMES = OrderedDict(
         ("paddleocr_vl", "PaddleOCRVLProcessor"),
         ("ernie4_5_moe_vl", "Ernie4_5_VLProcessor"),
         ("gemma3", "Gemma3Processor"),
+        ("shieldgemma2", "ShieldGemma2Processor"),
         ("glm4v_moe", "Glm4vProcessor"),
         ("glm_ocr", "Glm46VProcessor"),
         ("paligemma2", "PaliGemmaProcessor"),

--- a/paddleformers/transformers/auto/processing.py
+++ b/paddleformers/transformers/auto/processing.py
@@ -55,6 +55,7 @@ PROCESSOR_MAPPING_NAMES = OrderedDict(
         ("qwen3_omni_moe", "Qwen3OmniMoeProcessor"),
         ("paddleocr_vl", "PaddleOCRVLProcessor"),
         ("ernie4_5_moe_vl", "Ernie4_5_VLProcessor"),
+        ("gemma3", "Gemma3Processor"),
         ("glm4v_moe", "Glm4vProcessor"),
         ("glm_ocr", "Glm46VProcessor"),
         ("paligemma2", "PaliGemmaProcessor"),

--- a/paddleformers/transformers/gemma3/__init__.py
+++ b/paddleformers/transformers/gemma3/__init__.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from typing import TYPE_CHECKING
+
+from ...utils.lazy_import import _LazyModule
+
+import_structure = {
+    # Gemma3Text is maintained by the upstream gemma3_text package.  This
+    # package only owns the multimodal Gemma3 wrapper and its processors.
+    "configuration": ["Gemma3Config"],
+    "image_processor": ["Gemma3ImageProcessor", "Gemma3ImageProcessorKwargs"],
+    "image_processor_fast": ["Gemma3ImageProcessorFast"],
+    "processor": ["Gemma3Processor", "Gemma3ProcessorKwargs"],
+    "modeling": [
+        "Gemma3ModelOutputWithPast",
+        "Gemma3CausalLMOutputWithPast",
+        "Gemma3MultiModalProjector",
+        "Gemma3PreTrainedModel",
+        "Gemma3Model",
+        "Gemma3ForConditionalGeneration",
+    ],
+}
+
+if TYPE_CHECKING:
+    from .configuration import *
+    from .image_processor import *
+    from .image_processor_fast import *
+    from .modeling import *
+    from .processor import *
+else:
+    sys.modules[__name__] = _LazyModule(__name__, globals()["__file__"], import_structure, module_spec=__spec__)

--- a/paddleformers/transformers/gemma3/configuration.py
+++ b/paddleformers/transformers/gemma3/configuration.py
@@ -1,0 +1,255 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from ..configuration_utils import PretrainedConfig, layer_type_validation
+from ..modeling_rope_utils import rope_config_validation, standardize_rope_params
+
+
+class Gemma3TextConfig(PretrainedConfig):
+    model_type = "gemma3_text"
+    keys_to_ignore_at_inference = ["past_key_values"]
+    default_theta = {"global": 1_000_000.0, "local": 10_000.0}
+
+    def __init__(
+        self,
+        vocab_size=262208,
+        hidden_size=2304,
+        intermediate_size=9216,
+        num_hidden_layers=26,
+        num_attention_heads=8,
+        num_key_value_heads=4,
+        head_dim=256,
+        hidden_activation="gelu_pytorch_tanh",
+        max_position_embeddings=131072,
+        initializer_range=0.02,
+        rms_norm_eps=1e-06,
+        use_cache=True,
+        pad_token_id=0,
+        eos_token_id=1,
+        bos_token_id=2,
+        tie_word_embeddings=True,
+        rope_theta=1000000.0,
+        attention_bias=False,
+        attention_dropout=0.0,
+        query_pre_attn_scalar=256,
+        sliding_window=4096,
+        layer_types=None,
+        final_logit_softcapping=None,
+        attn_logit_softcapping=None,
+        rope_scaling=None,
+        rope_parameters=None,
+        rope_local_base_freq=10000.0,
+        use_bidirectional_attention=False,
+        **kwargs,
+    ):
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )
+        self.vocab_size = vocab_size
+        self.max_position_embeddings = max_position_embeddings
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.head_dim = head_dim
+        self.num_key_value_heads = num_key_value_heads
+        self.initializer_range = initializer_range
+        self.rms_norm_eps = rms_norm_eps
+        self.use_cache = use_cache
+        self.rope_theta = rope_theta
+        self.attention_bias = attention_bias
+        self.attention_dropout = attention_dropout
+        self.hidden_activation = hidden_activation
+        self.query_pre_attn_scalar = query_pre_attn_scalar
+        self.sliding_window = sliding_window
+        self.final_logit_softcapping = final_logit_softcapping
+        self.attn_logit_softcapping = attn_logit_softcapping
+        self.layer_types = layer_types
+        self.use_bidirectional_attention = use_bidirectional_attention
+        if use_bidirectional_attention:
+            self.sliding_window = self.sliding_window // 2 + 1
+        self.rope_local_base_freq = rope_local_base_freq
+        self.rope_scaling = rope_scaling
+
+        self._sliding_window_pattern = kwargs.get("sliding_window_pattern", 6)
+        if self.layer_types is None:
+            self.layer_types = [
+                ("sliding_attention" if bool((i + 1) % self._sliding_window_pattern) else "full_attention")
+                for i in range(self.num_hidden_layers)
+            ]
+        layer_type_validation(self.layer_types, self.num_hidden_layers)
+
+        default_rope_parameters = {
+            "sliding_attention": {"rope_type": "default"},
+            "full_attention": {"rope_type": "default"},
+        }
+        if rope_parameters is not None and all(
+            layer_type in self.layer_types for layer_type in rope_parameters.keys()
+        ):
+            self.rope_parameters = {
+                layer_type: dict(rope_parameters[layer_type]) if rope_parameters.get(layer_type) is not None else None
+                for layer_type in set(self.layer_types)
+            }
+        else:
+            self.rope_parameters = {
+                layer_type: dict(default_rope_parameters[layer_type]) for layer_type in default_rope_parameters
+            }
+            if rope_parameters is not None:
+                self.rope_parameters["full_attention"].update(rope_parameters)
+            elif rope_scaling is not None:
+                self.rope_parameters["full_attention"].update(rope_scaling)
+
+        if self.rope_parameters.get("full_attention") is None:
+            self.rope_parameters["full_attention"] = {"rope_type": "default"}
+        self.rope_parameters["full_attention"].setdefault("rope_theta", rope_theta)
+
+        if self.rope_parameters.get("sliding_attention") is None:
+            self.rope_parameters["sliding_attention"] = {"rope_type": "default"}
+        self.rope_parameters["sliding_attention"].setdefault("rope_theta", rope_local_base_freq)
+
+        self.rope_theta = {
+            "full_attention": self.rope_parameters["full_attention"]["rope_theta"],
+            "sliding_attention": self.rope_parameters["sliding_attention"]["rope_theta"],
+        }
+
+        standardize_rope_params(self, rope_theta=self.rope_theta)
+        rope_config_validation(self)
+
+
+class SiglipVisionConfig(PretrainedConfig):
+    model_type = "siglip_vision_model"
+    base_config_key = "vision_config"
+
+    def __init__(
+        self,
+        hidden_size=768,
+        intermediate_size=3072,
+        num_hidden_layers=12,
+        num_attention_heads=12,
+        num_channels=3,
+        image_size=224,
+        patch_size=16,
+        hidden_act="gelu_pytorch_tanh",
+        layer_norm_eps=1e-6,
+        attention_dropout=0.0,
+        vision_use_head=False,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_channels = num_channels
+        self.image_size = image_size
+        self.patch_size = patch_size
+        self.hidden_act = hidden_act
+        self.layer_norm_eps = layer_norm_eps
+        self.attention_dropout = attention_dropout
+        self.vision_use_head = vision_use_head
+
+
+class Gemma3Config(PretrainedConfig):
+    model_type = "gemma3"
+    is_composition = True
+    sub_configs = {"text_config": Gemma3TextConfig, "vision_config": SiglipVisionConfig}
+    keys_to_ignore_at_inference = ["past_key_values"]
+    attribute_map = {
+        "num_classes": "num_labels",
+        "image_token_id": "image_token_index",
+        "boi_token_id": "boi_token_index",
+        "eoi_token_id": "eoi_token_index",
+    }
+    _text_config_passthrough_exclusions = {
+        "_name_or_path",
+        "model_type",
+        "dtype",
+        "_attn_implementation_internal",
+        "id2label",
+        "label2id",
+        "num_labels",
+        "num_classes",
+        "architectures",
+        "sub_configs",
+        "vision_config",
+        "text_config",
+    }
+
+    def __init__(
+        self,
+        text_config=None,
+        vision_config=None,
+        mm_tokens_per_image=256,
+        boi_token_index=255999,
+        eoi_token_index=256000,
+        image_token_index=262144,
+        initializer_range=0.02,
+        tie_word_embeddings=True,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        # Composition configs receive classification metadata at the outer level as
+        # well as in the text sub-config.  Keep the outer label maps in sync with
+        # ``num_classes`` (the legacy alias used by ConfigTester and checkpoints).
+        if "num_classes" in kwargs:
+            self.num_labels = kwargs["num_classes"]
+
+        if isinstance(text_config, dict):
+            self.text_config = self.sub_configs["text_config"](**text_config)
+        elif text_config is None:
+            self.text_config = self.sub_configs["text_config"](**kwargs)
+        else:
+            self.text_config = text_config
+
+        if isinstance(vision_config, dict):
+            self.vision_config = self.sub_configs["vision_config"](**vision_config)
+        elif vision_config is None:
+            self.vision_config = self.sub_configs["vision_config"]()
+        else:
+            self.vision_config = vision_config
+
+        self.mm_tokens_per_image = mm_tokens_per_image
+        self.boi_token_index = boi_token_index
+        self.eoi_token_index = eoi_token_index
+        self.image_token_index = image_token_index
+        self.initializer_range = initializer_range
+        self.tie_word_embeddings = tie_word_embeddings
+        self.architectures = kwargs.get("architectures", ["Gemma3ForConditionalGeneration"])
+
+    def __setattr__(self, key, value):
+        text_config = super().__getattribute__("__dict__").get("text_config")
+        if (
+            text_config is not None
+            and key not in self._text_config_passthrough_exclusions
+            and key in text_config.__dict__
+        ):
+            setattr(text_config, key, value)
+        else:
+            super().__setattr__(key, value)
+
+    def __getattribute__(self, key):
+        if "text_config" in super().__getattribute__("__dict__") and key not in super().__getattribute__(
+            "_text_config_passthrough_exclusions"
+        ):
+            text_config = super().__getattribute__("text_config")
+            if key in text_config.__dict__:
+                return getattr(text_config, key)
+        return super().__getattribute__(key)
+
+
+__all__ = ["Gemma3Config", "Gemma3TextConfig", "SiglipVisionConfig"]

--- a/paddleformers/transformers/gemma3/image_processor.py
+++ b/paddleformers/transformers/gemma3/image_processor.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import transformers as hf
+from transformers.models.gemma3.image_processing_gemma3 import (
+    Gemma3ImageProcessorKwargs,
+)
+
+from ..image_processing_utils import warp_base_image_processor
+
+Gemma3ImageProcessor = warp_base_image_processor(hf.Gemma3ImageProcessor)
+
+__all__ = ["Gemma3ImageProcessor", "Gemma3ImageProcessorKwargs"]

--- a/paddleformers/transformers/gemma3/image_processor_fast.py
+++ b/paddleformers/transformers/gemma3/image_processor_fast.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .image_processor import Gemma3ImageProcessor
+
+
+class Gemma3ImageProcessorFast(Gemma3ImageProcessor):
+    """Compatibility fast processor that reuses the Gemma3 image preprocessing path."""
+
+
+__all__ = ["Gemma3ImageProcessorFast"]

--- a/paddleformers/transformers/gemma3/modeling.py
+++ b/paddleformers/transformers/gemma3/modeling.py
@@ -1,0 +1,906 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+import os
+from dataclasses import dataclass
+from typing import Callable, Optional, Tuple, Union
+
+import paddle
+import paddle.nn.functional as F
+from paddle import nn
+
+if not hasattr(paddle.nn.functional, "swiglu"):
+
+    def _compat_swiglu(x):
+        gate, value = x.chunk(2, axis=-1)
+        return paddle.nn.functional.silu(gate) * value
+
+    paddle.nn.functional.swiglu = _compat_swiglu
+
+from ...generation import GenerationMixin
+from ...nn.criterion.interface import CriterionLayer
+from ...nn.lm_head import LMHead as GeneralLMHead
+from ...utils.log import logger
+from ..activations import ACT2FN
+from ..cache_utils import Cache
+from ..configuration_utils import PretrainedConfig
+from ..masking_utils import (
+    create_causal_mask_and_row_indices,
+    create_sliding_window_causal_mask_and_row_indices,
+)
+from ..model_outputs import (
+    BaseModelOutput,
+    BaseModelOutputWithPast,
+    BaseModelOutputWithPooling,
+    ModelOutput,
+)
+from ..model_utils import PretrainedModel, dtype_guard
+from .configuration import Gemma3Config, SiglipVisionConfig
+from .multimodal_text_modeling import (
+    Gemma3RMSNorm,
+    Gemma3TextModel,
+    _iter_hf_tensors,
+    _compute_causal_lm_loss,
+    _restore_padding_query_rows,
+    load_hf_text_state_dict,
+)
+
+
+_HF_VISION_LINEAR_WEIGHT_SUFFIXES = (
+    "self_attn.q_proj.weight",
+    "self_attn.k_proj.weight",
+    "self_attn.v_proj.weight",
+    "self_attn.out_proj.weight",
+    "mlp.fc1.weight",
+    "mlp.fc2.weight",
+)
+
+
+def _convert_hf_vision_tensor(target_key: str, tensor: paddle.Tensor) -> paddle.Tensor:
+    """Convert a Torch vision tensor to the layout used by Paddle layers."""
+    if target_key.endswith(_HF_VISION_LINEAR_WEIGHT_SUFFIXES):
+        return tensor.transpose([1, 0]).contiguous()
+    return tensor
+
+
+def _use_high_precision_cublas_for_fp32(tensor: paddle.Tensor) -> None:
+    """Match Torch's default FP32 GEMM policy before multimodal computation."""
+    if tensor.dtype != paddle.float32 or not tensor.place.is_gpu_place():
+        return
+
+    # Paddle enables TF32 cuBLAS kernels by default on Ampere and newer GPUs,
+    # while Torch's default float32_matmul_precision="highest" does not.  The
+    # switch is process-wide and must remain disabled for the following text
+    # backbone and backward pass as well as for the vision tower.
+    from paddle.base import core
+
+    if core.get_cublas_switch():
+        core.set_cublas_switch(False)
+
+
+@dataclass
+class Gemma3ModelOutputWithPast(BaseModelOutputWithPast):
+    image_hidden_states: paddle.Tensor | None = None
+
+
+@dataclass
+class Gemma3CausalLMOutputWithPast(ModelOutput):
+    loss: paddle.Tensor | None = None
+    logits: paddle.Tensor | None = None
+    past_key_values: Cache | None = None
+    hidden_states: tuple[paddle.Tensor] | None = None
+    attentions: tuple[paddle.Tensor] | None = None
+    image_hidden_states: paddle.Tensor | None = None
+
+
+class SiglipVisionEmbeddings(nn.Layer):
+    def __init__(self, config: SiglipVisionConfig):
+        super().__init__()
+        self.embed_dim = config.hidden_size
+        self.image_size = config.image_size
+        self.patch_size = config.patch_size
+        self.patch_embedding = nn.Conv2D(
+            in_channels=config.num_channels,
+            out_channels=self.embed_dim,
+            kernel_size=self.patch_size,
+            stride=self.patch_size,
+        )
+        self.num_patches = (self.image_size // self.patch_size) ** 2
+        self.position_embedding = nn.Embedding(self.num_patches, self.embed_dim)
+        self.register_buffer(
+            "position_ids",
+            paddle.arange(self.num_patches, dtype="int64").reshape([1, -1]),
+            persistable=False,
+        )
+
+    def interpolate_pos_encoding(self, embeddings: paddle.Tensor, height: int, width: int) -> paddle.Tensor:
+        if embeddings.shape[1] == self.num_patches and height == width == self.image_size:
+            return self.position_embedding(self.position_ids)
+
+        dim = embeddings.shape[-1]
+        new_height = height // self.patch_size
+        new_width = width // self.patch_size
+        sqrt_num_positions = int(self.num_patches**0.5)
+
+        patch_pos_embed = self.position_embedding.weight.reshape([1, sqrt_num_positions, sqrt_num_positions, dim])
+        patch_pos_embed = patch_pos_embed.transpose([0, 3, 1, 2])
+        patch_pos_embed = F.interpolate(
+            patch_pos_embed,
+            size=[new_height, new_width],
+            mode="bicubic",
+            align_corners=False,
+        )
+        patch_pos_embed = patch_pos_embed.transpose([0, 2, 3, 1]).reshape([1, -1, dim])
+        return patch_pos_embed
+
+    def forward(self, pixel_values: paddle.Tensor, interpolate_pos_encoding: bool = False) -> paddle.Tensor:
+        _, _, height, width = pixel_values.shape
+        pixel_values = pixel_values.astype(self.patch_embedding.weight.dtype)
+        patch_embeds = self.patch_embedding(pixel_values)
+        embeddings = patch_embeds.flatten(start_axis=2).transpose([0, 2, 1])
+        if interpolate_pos_encoding:
+            embeddings = embeddings + self.interpolate_pos_encoding(embeddings, height, width)
+        else:
+            embeddings = embeddings + self.position_embedding(self.position_ids)
+        return embeddings
+
+
+class SiglipAttention(nn.Layer):
+    def __init__(self, config: SiglipVisionConfig):
+        super().__init__()
+        self.embed_dim = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = self.embed_dim // self.num_heads
+        if self.head_dim * self.num_heads != self.embed_dim:
+            raise ValueError(
+                f"embed_dim must be divisible by num_heads (got embed_dim={self.embed_dim}, num_heads={self.num_heads})."
+            )
+        self.scale = self.head_dim**-0.5
+        self.dropout = config.attention_dropout
+        self.k_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.v_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.q_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.out_proj = nn.Linear(self.embed_dim, self.embed_dim)
+
+    def forward(
+        self,
+        hidden_states: paddle.Tensor,
+        attention_mask: Optional[paddle.Tensor] = None,
+    ) -> Tuple[paddle.Tensor, paddle.Tensor]:
+        batch_size, seq_length, embed_dim = hidden_states.shape
+        queries = self.q_proj(hidden_states)
+        keys = self.k_proj(hidden_states)
+        values = self.v_proj(hidden_states)
+
+        queries = queries.reshape([batch_size, seq_length, self.num_heads, self.head_dim]).transpose([0, 2, 1, 3])
+        keys = keys.reshape([batch_size, seq_length, self.num_heads, self.head_dim]).transpose([0, 2, 1, 3])
+        values = values.reshape([batch_size, seq_length, self.num_heads, self.head_dim]).transpose([0, 2, 1, 3])
+
+        attn_weights = paddle.matmul(queries, keys.transpose([0, 1, 3, 2])) * self.scale
+        if attention_mask is not None:
+            attn_weights = attn_weights + attention_mask
+        attn_weights = F.softmax(attn_weights, axis=-1, dtype="float32").astype(queries.dtype)
+        attn_weights = F.dropout(attn_weights, p=self.dropout, training=self.training)
+
+        attn_output = paddle.matmul(attn_weights, values)
+        attn_output = attn_output.transpose([0, 2, 1, 3]).reshape([batch_size, seq_length, embed_dim])
+        return self.out_proj(attn_output), attn_weights
+
+
+class SiglipMLP(nn.Layer):
+    def __init__(self, config: SiglipVisionConfig):
+        super().__init__()
+        self.activation_fn = ACT2FN[config.hidden_act]
+        self.fc1 = nn.Linear(config.hidden_size, config.intermediate_size)
+        self.fc2 = nn.Linear(config.intermediate_size, config.hidden_size)
+
+    def forward(self, hidden_states: paddle.Tensor) -> paddle.Tensor:
+        return self.fc2(self.activation_fn(self.fc1(hidden_states)))
+
+
+class SiglipEncoderLayer(nn.Layer):
+    def __init__(self, config: SiglipVisionConfig):
+        super().__init__()
+        self.layer_norm1 = nn.LayerNorm(config.hidden_size, epsilon=config.layer_norm_eps)
+        self.self_attn = SiglipAttention(config)
+        self.layer_norm2 = nn.LayerNorm(config.hidden_size, epsilon=config.layer_norm_eps)
+        self.mlp = SiglipMLP(config)
+
+    def forward(self, hidden_states: paddle.Tensor, attention_mask: Optional[paddle.Tensor] = None) -> paddle.Tensor:
+        residual = hidden_states
+        hidden_states = self.layer_norm1(hidden_states)
+        hidden_states, _ = self.self_attn(hidden_states, attention_mask=attention_mask)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.layer_norm2(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        return residual + hidden_states
+
+
+class SiglipEncoder(nn.Layer):
+    def __init__(self, config: SiglipVisionConfig):
+        super().__init__()
+        self.layers = nn.LayerList([SiglipEncoderLayer(config) for _ in range(config.num_hidden_layers)])
+
+    def forward(self, inputs_embeds: paddle.Tensor, attention_mask: Optional[paddle.Tensor] = None) -> BaseModelOutput:
+        hidden_states = inputs_embeds
+        for encoder_layer in self.layers:
+            hidden_states = encoder_layer(hidden_states, attention_mask=attention_mask)
+        return BaseModelOutput(last_hidden_state=hidden_states)
+
+
+class Gemma3VisionPretrainedModel(PretrainedModel):
+    config_class = SiglipVisionConfig
+    base_model_prefix = "vision_model"
+    main_input_name = "pixel_values"
+
+
+class Gemma3VisionModel(Gemma3VisionPretrainedModel):
+    config_class = SiglipVisionConfig
+    main_input_name = "pixel_values"
+
+    def __init__(self, config: SiglipVisionConfig):
+        super().__init__(config)
+        self.embeddings = SiglipVisionEmbeddings(config)
+        self.encoder = SiglipEncoder(config)
+        self.post_layernorm = nn.LayerNorm(config.hidden_size, epsilon=config.layer_norm_eps)
+
+    def get_input_embeddings(self):
+        return self.embeddings.patch_embedding
+
+    def forward(
+        self,
+        pixel_values: paddle.Tensor,
+        interpolate_pos_encoding: bool = False,
+        attention_mask: Optional[paddle.Tensor] = None,
+        return_dict: Optional[bool] = None,
+        **kwargs,
+    ) -> Union[Tuple, BaseModelOutputWithPooling]:
+        del kwargs
+        _use_high_precision_cublas_for_fp32(pixel_values)
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+        hidden_states = self.embeddings(pixel_values, interpolate_pos_encoding=interpolate_pos_encoding)
+        outputs = self.encoder(hidden_states, attention_mask=attention_mask)
+        last_hidden_state = self.post_layernorm(outputs.last_hidden_state)
+        if not return_dict:
+            return (last_hidden_state, None)
+        return BaseModelOutputWithPooling(last_hidden_state=last_hidden_state, pooler_output=None)
+
+
+class Gemma3MultiModalProjector(paddle.nn.Layer):
+    def __init__(self, config: Gemma3Config):
+        super().__init__()
+        self.patches_per_image = int(config.vision_config.image_size // config.vision_config.patch_size)
+        self.tokens_per_side = int(config.mm_tokens_per_image**0.5)
+        self.kernel_size = self.patches_per_image // self.tokens_per_side
+        self.mm_input_projection_weight = self.create_parameter(
+            shape=[config.vision_config.hidden_size, config.text_config.hidden_size],
+            dtype=paddle.get_default_dtype(),
+            default_initializer=paddle.nn.initializer.Normal(std=config.initializer_range),
+        )
+        self.mm_soft_emb_norm = Gemma3RMSNorm(
+            config.vision_config.hidden_size,
+            eps=getattr(config.vision_config, "layer_norm_eps", 1e-6),
+        )
+        self.avg_pool = paddle.nn.AvgPool2D(kernel_size=self.kernel_size, stride=self.kernel_size)
+
+    def forward(self, vision_outputs: paddle.Tensor) -> paddle.Tensor:
+        batch_size, _, hidden_size = vision_outputs.shape
+        reshaped_vision_outputs = vision_outputs.transpose([0, 2, 1]).reshape(
+            [batch_size, hidden_size, self.patches_per_image, self.patches_per_image]
+        )
+        pooled_vision_outputs = self.avg_pool(reshaped_vision_outputs)
+        pooled_vision_outputs = pooled_vision_outputs.flatten(start_axis=2).transpose([0, 2, 1])
+        normed_vision_outputs = self.mm_soft_emb_norm(pooled_vision_outputs)
+        projected_vision_outputs = paddle.matmul(normed_vision_outputs, self.mm_input_projection_weight)
+        return projected_vision_outputs.astype(vision_outputs.dtype)
+
+
+def token_type_ids_mask_function(token_type_ids: paddle.Tensor | None, image_group_ids: paddle.Tensor | None):
+    def mask_fn(batch_idx: paddle.Tensor, head_idx: paddle.Tensor, q_idx: paddle.Tensor, kv_idx: paddle.Tensor):
+        del head_idx
+        if token_type_ids is None or image_group_ids is None:
+            return paddle.zeros([1], dtype="bool")
+
+        bsz, seq_len = token_type_ids.shape
+        max_idx = paddle.full_like(q_idx, seq_len - 1)
+        safe_q_idx = paddle.minimum(q_idx, max_idx)
+        safe_kv_idx = paddle.minimum(kv_idx, paddle.full_like(kv_idx, seq_len - 1))
+
+        token_type_ids_expanded = token_type_ids.reshape([bsz, 1, 1, seq_len])
+        image_group_ids_expanded = image_group_ids.reshape([bsz, 1, 1, seq_len])
+
+        safe_q_idx = safe_q_idx.expand([bsz, 1, safe_q_idx.shape[2], 1])
+        safe_kv_idx = safe_kv_idx.expand([bsz, 1, 1, safe_kv_idx.shape[3]])
+
+        token_type_ids_at_q_idx = paddle.take_along_axis(token_type_ids_expanded, safe_q_idx, axis=-1)
+        token_type_ids_at_kv_idx = paddle.take_along_axis(token_type_ids_expanded, safe_kv_idx, axis=-1)
+        image_group_ids_at_q_idx = paddle.take_along_axis(image_group_ids_expanded, safe_q_idx, axis=-1)
+        image_group_ids_at_kv_idx = paddle.take_along_axis(image_group_ids_expanded, safe_kv_idx, axis=-1)
+
+        valid_q = (q_idx < seq_len).expand([bsz, 1, q_idx.shape[2], 1])
+        valid_kv = (kv_idx < seq_len).expand([bsz, 1, 1, kv_idx.shape[3]])
+        is_image_block = (token_type_ids_at_q_idx == 1) & (token_type_ids_at_kv_idx == 1)
+        same_image_block = image_group_ids_at_q_idx == image_group_ids_at_kv_idx
+        return valid_q & valid_kv & is_image_block & same_image_block
+
+    return mask_fn
+
+
+def create_causal_mask_mapping(
+    config: Gemma3Config,
+    inputs_embeds: paddle.Tensor,
+    attention_mask: Optional[paddle.Tensor],
+    cache_position: Optional[paddle.Tensor],
+    past_key_values: Optional[Cache],
+    position_ids: Optional[paddle.Tensor],
+    token_type_ids: Optional[paddle.Tensor] = None,
+    is_first_iteration: Optional[bool] = None,
+    prepare_decoder_attention_mask: Optional[Callable] = None,
+    return_row_indices: bool = False,
+):
+    batch_size, seq_length = inputs_embeds.shape[:2]
+    cache_length = past_key_values.get_seq_length() if past_key_values is not None else 0
+    prepare_decoder_attention_mask = prepare_decoder_attention_mask or Gemma3TextModel._prepare_decoder_attention_mask
+    or_mask_function = None
+    if token_type_ids is not None and (is_first_iteration is not False):
+        is_image = token_type_ids == 1
+        previous_is_image = paddle.concat(
+            [paddle.zeros([is_image.shape[0], 1], dtype=is_image.dtype), is_image[:, :-1]],
+            axis=1,
+        )
+        new_image_start = is_image & ~previous_is_image.astype("bool")
+        image_group_ids = paddle.cumsum(new_image_start.astype("int64"), axis=1) - 1
+        image_group_ids = paddle.where(is_image, image_group_ids, paddle.full_like(image_group_ids, -1))
+        or_mask_function = token_type_ids_mask_function(
+            token_type_ids.astype("int64"), image_group_ids.astype("int64")
+        )
+
+    mask_kwargs = {
+        "config": config.text_config,
+        "inputs_embeds": inputs_embeds,
+        "batch_size": batch_size,
+        "seq_length": seq_length,
+        "cache_length": cache_length,
+        "attention_mask": attention_mask,
+        "attn_mask_startend_row_indices": None,
+        "prepare_decoder_attention_mask": prepare_decoder_attention_mask,
+        "or_mask_function": or_mask_function,
+    }
+
+    full_mask, full_indices = create_causal_mask_and_row_indices(**mask_kwargs)
+    full_mask = _restore_padding_query_rows(full_mask, attention_mask, cache_length, seq_length)
+    causal_mask_mapping = {"full_attention": full_mask}
+    attn_mask_startend_row_indices_mapping = {"full_attention": full_indices}
+    if "sliding_attention" in getattr(config.text_config, "layer_types", []):
+        sliding_mask, sliding_indices = create_sliding_window_causal_mask_and_row_indices(**mask_kwargs)
+        sliding_mask = _restore_padding_query_rows(sliding_mask, attention_mask, cache_length, seq_length)
+        causal_mask_mapping["sliding_attention"] = sliding_mask
+        attn_mask_startend_row_indices_mapping["sliding_attention"] = sliding_indices
+
+    if return_row_indices:
+        return causal_mask_mapping, attn_mask_startend_row_indices_mapping
+    return causal_mask_mapping
+
+
+class Gemma3PreTrainedModel(PretrainedModel):
+    config_class = Gemma3Config
+    base_model_prefix = "model"
+    main_input_name = "input_ids"
+    _no_split_modules = [
+        "Gemma3MultiModalProjector",
+        "SiglipVisionEmbeddings",
+        "SiglipEncoderLayer",
+    ]
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, *args, **kwargs):
+        accepted_init_kwargs = {
+            name for name in inspect.signature(cls.__init__).parameters if name not in {"self", "config"}
+        }
+        passthrough_kwargs = {key: value for key, value in kwargs.items() if key not in accepted_init_kwargs}
+        init_kwargs = {key: value for key, value in kwargs.items() if key in accepted_init_kwargs}
+        if (
+            isinstance(pretrained_model_name_or_path, str)
+            and os.path.isdir(pretrained_model_name_or_path)
+            and os.path.exists(os.path.join(pretrained_model_name_or_path, "model_state.pdparams"))
+        ):
+            logger.info(
+                f"Using local Paddle checkpoint direct load path for {cls.__name__} "
+                f"from {pretrained_model_name_or_path}"
+            )
+            dtype = passthrough_kwargs.pop("dtype", None)
+            config = passthrough_kwargs.pop("config", None)
+            if not isinstance(config, PretrainedConfig):
+                config_path = config if config is not None else pretrained_model_name_or_path
+                config, model_kwargs = cls.config_class.from_pretrained(
+                    config_path,
+                    return_unused_kwargs=True,
+                    **passthrough_kwargs,
+                )
+            else:
+                model_kwargs = passthrough_kwargs
+
+            model_kwargs = {key: value for key, value in model_kwargs.items() if key in accepted_init_kwargs}
+            model_kwargs.update(init_kwargs)
+            if dtype is not None:
+                config.dtype = dtype
+            with dtype_guard(dtype or paddle.get_default_dtype()):
+                model = cls(config, *args, **model_kwargs)
+            state_dict = paddle.load(os.path.join(pretrained_model_name_or_path, "model_state.pdparams"))
+            target_state_dict = model.state_dict()
+            for name, tensor in list(state_dict.items()):
+                if name in target_state_dict and tensor.dtype != target_state_dict[name].dtype:
+                    state_dict[name] = tensor.astype(target_state_dict[name].dtype)
+            missing_keys, unexpected_keys = model.set_state_dict(state_dict)
+            if missing_keys or unexpected_keys:
+                logger.warning(
+                    "Local Paddle checkpoint load finished with missing keys %s and unexpected keys %s",
+                    missing_keys,
+                    unexpected_keys,
+                )
+            return model
+
+        is_hf_safetensors = (
+            isinstance(pretrained_model_name_or_path, str)
+            and os.path.isdir(pretrained_model_name_or_path)
+            and (
+                os.path.exists(os.path.join(pretrained_model_name_or_path, "model.safetensors"))
+                or os.path.exists(os.path.join(pretrained_model_name_or_path, "model.safetensors.index.json"))
+            )
+        )
+        if is_hf_safetensors:
+            dtype = passthrough_kwargs.pop("dtype", None)
+            config = passthrough_kwargs.pop("config", None)
+            if not isinstance(config, PretrainedConfig):
+                config_path = config if config is not None else pretrained_model_name_or_path
+                config, model_kwargs = cls.config_class.from_pretrained(
+                    config_path,
+                    return_unused_kwargs=True,
+                    **passthrough_kwargs,
+                )
+            else:
+                model_kwargs = passthrough_kwargs
+
+            model_kwargs = {key: value for key, value in model_kwargs.items() if key in accepted_init_kwargs}
+            model_kwargs.update(init_kwargs)
+            if dtype is not None:
+                config.dtype = dtype
+            with dtype_guard(dtype or paddle.get_default_dtype()):
+                model = cls(config, *args, **model_kwargs)
+            model_prefix = "" if cls.__name__ == "Gemma3Model" else "model."
+            state_dict = load_hf_text_state_dict(
+                pretrained_model_name_or_path,
+                config.text_config,
+                model_prefix=f"{model_prefix}language_model.",
+                include_lm_head=cls.__name__ != "Gemma3Model",
+                source_prefix="language_model.",
+            )
+            target_state_dict = model.state_dict()
+            for hf_key, tensor in _iter_hf_tensors(pretrained_model_name_or_path):
+                if hf_key.startswith("vision_tower.vision_model."):
+                    target_key = f"{model_prefix}vision_tower." + hf_key[len("vision_tower.vision_model.") :]
+                elif hf_key.startswith("multi_modal_projector."):
+                    target_key = model_prefix + hf_key
+                else:
+                    continue
+                if target_key not in target_state_dict:
+                    continue
+                state_dict[target_key] = _convert_hf_vision_tensor(target_key, tensor)
+
+            for name, tensor in list(state_dict.items()):
+                if name in target_state_dict and tensor.dtype != target_state_dict[name].dtype:
+                    state_dict[name] = tensor.astype(target_state_dict[name].dtype)
+            missing_keys, unexpected_keys = model.set_state_dict(state_dict)
+            if missing_keys or unexpected_keys:
+                logger.warning(
+                    f"HF Gemma3 checkpoint load finished with missing keys {missing_keys} "
+                    f"and unexpected keys {unexpected_keys}"
+                )
+            return model
+
+        kwargs = passthrough_kwargs
+        kwargs.update(init_kwargs)
+        return super().from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+
+    @classmethod
+    def _gen_aoa_config(cls, config: Gemma3Config):
+        model_prefix = "" if cls.__name__ == "Gemma3Model" else "model."
+        llm_prefix = f"{model_prefix}language_model."
+        vision_prefix = f"{model_prefix}vision_tower."
+        projector_prefix = f"{model_prefix}multi_modal_projector."
+
+        aoa_statements = [
+            f"language_model.model.embed_tokens.weight -> {llm_prefix}embed_tokens.weight",
+            f"language_model.model.norm.weight -> {llm_prefix}norm.weight",
+            f"language_model.model.layers.$LAYER_ID.input_layernorm.weight -> {llm_prefix}layers.$LAYER_ID.input_layernorm.weight",
+            f"language_model.model.layers.$LAYER_ID.post_attention_layernorm.weight -> {llm_prefix}layers.$LAYER_ID.post_attention_layernorm.weight",
+            f"language_model.model.layers.$LAYER_ID.pre_feedforward_layernorm.weight -> {llm_prefix}layers.$LAYER_ID.pre_feedforward_layernorm.weight",
+            f"language_model.model.layers.$LAYER_ID.post_feedforward_layernorm.weight -> {llm_prefix}layers.$LAYER_ID.post_feedforward_layernorm.weight",
+            f"language_model.model.layers.$LAYER_ID.self_attn.q_norm.weight -> {llm_prefix}layers.$LAYER_ID.self_attn.q_norm.weight",
+            f"language_model.model.layers.$LAYER_ID.self_attn.k_norm.weight -> {llm_prefix}layers.$LAYER_ID.self_attn.k_norm.weight",
+            f"language_model.model.layers.$LAYER_ID.self_attn.o_proj.weight^T -> {llm_prefix}layers.$LAYER_ID.self_attn.o_proj.weight",
+            f"language_model.model.layers.$LAYER_ID.mlp.down_proj.weight^T -> {llm_prefix}layers.$LAYER_ID.mlp.down_proj.weight",
+            f"vision_tower.vision_model.embeddings.patch_embedding.weight -> {vision_prefix}embeddings.patch_embedding.weight",
+            f"vision_tower.vision_model.embeddings.patch_embedding.bias -> {vision_prefix}embeddings.patch_embedding.bias",
+            f"vision_tower.vision_model.embeddings.position_embedding.weight -> {vision_prefix}embeddings.position_embedding.weight",
+            f"vision_tower.vision_model.encoder.layers.$LAYER_ID.layer_norm1.weight -> {vision_prefix}encoder.layers.$LAYER_ID.layer_norm1.weight",
+            f"vision_tower.vision_model.encoder.layers.$LAYER_ID.layer_norm1.bias -> {vision_prefix}encoder.layers.$LAYER_ID.layer_norm1.bias",
+            f"vision_tower.vision_model.encoder.layers.$LAYER_ID.layer_norm2.weight -> {vision_prefix}encoder.layers.$LAYER_ID.layer_norm2.weight",
+            f"vision_tower.vision_model.encoder.layers.$LAYER_ID.layer_norm2.bias -> {vision_prefix}encoder.layers.$LAYER_ID.layer_norm2.bias",
+            f"vision_tower.vision_model.encoder.layers.$LAYER_ID.self_attn.q_proj.weight^T -> {vision_prefix}encoder.layers.$LAYER_ID.self_attn.q_proj.weight",
+            f"vision_tower.vision_model.encoder.layers.$LAYER_ID.self_attn.k_proj.weight^T -> {vision_prefix}encoder.layers.$LAYER_ID.self_attn.k_proj.weight",
+            f"vision_tower.vision_model.encoder.layers.$LAYER_ID.self_attn.v_proj.weight^T -> {vision_prefix}encoder.layers.$LAYER_ID.self_attn.v_proj.weight",
+            f"vision_tower.vision_model.encoder.layers.$LAYER_ID.self_attn.out_proj.weight^T -> {vision_prefix}encoder.layers.$LAYER_ID.self_attn.out_proj.weight",
+            f"vision_tower.vision_model.encoder.layers.$LAYER_ID.self_attn.q_proj.bias -> {vision_prefix}encoder.layers.$LAYER_ID.self_attn.q_proj.bias",
+            f"vision_tower.vision_model.encoder.layers.$LAYER_ID.self_attn.k_proj.bias -> {vision_prefix}encoder.layers.$LAYER_ID.self_attn.k_proj.bias",
+            f"vision_tower.vision_model.encoder.layers.$LAYER_ID.self_attn.v_proj.bias -> {vision_prefix}encoder.layers.$LAYER_ID.self_attn.v_proj.bias",
+            f"vision_tower.vision_model.encoder.layers.$LAYER_ID.self_attn.out_proj.bias -> {vision_prefix}encoder.layers.$LAYER_ID.self_attn.out_proj.bias",
+            f"vision_tower.vision_model.encoder.layers.$LAYER_ID.mlp.fc1.weight^T -> {vision_prefix}encoder.layers.$LAYER_ID.mlp.fc1.weight",
+            f"vision_tower.vision_model.encoder.layers.$LAYER_ID.mlp.fc2.weight^T -> {vision_prefix}encoder.layers.$LAYER_ID.mlp.fc2.weight",
+            f"vision_tower.vision_model.encoder.layers.$LAYER_ID.mlp.fc1.bias -> {vision_prefix}encoder.layers.$LAYER_ID.mlp.fc1.bias",
+            f"vision_tower.vision_model.encoder.layers.$LAYER_ID.mlp.fc2.bias -> {vision_prefix}encoder.layers.$LAYER_ID.mlp.fc2.bias",
+            f"vision_tower.vision_model.post_layernorm.weight -> {vision_prefix}post_layernorm.weight",
+            f"vision_tower.vision_model.post_layernorm.bias -> {vision_prefix}post_layernorm.bias",
+            f"multi_modal_projector.mm_input_projection_weight -> {projector_prefix}mm_input_projection_weight",
+            f"multi_modal_projector.mm_soft_emb_norm.weight -> {projector_prefix}mm_soft_emb_norm.weight",
+        ]
+
+        aoa_statements += [
+            (
+                "language_model.model.layers.$LAYER_ID.self_attn.q_proj.weight^T, "
+                "language_model.model.layers.$LAYER_ID.self_attn.k_proj.weight^T, "
+                "language_model.model.layers.$LAYER_ID.self_attn.v_proj.weight^T "
+                f"-> {llm_prefix}layers.$LAYER_ID.self_attn.qkv_proj.weight, "
+                f"fused_qkv, num_heads={config.text_config.num_attention_heads}, "
+                f"num_key_value_groups={config.text_config.num_key_value_heads}"
+            ),
+            (
+                "language_model.model.layers.$LAYER_ID.mlp.gate_proj.weight^T, "
+                "language_model.model.layers.$LAYER_ID.mlp.up_proj.weight^T "
+                f"-> {llm_prefix}layers.$LAYER_ID.mlp.up_gate_proj.weight, fused_ffn"
+            ),
+        ]
+
+        if cls.__name__ != "Gemma3Model":
+            aoa_statements.append("language_model.model.embed_tokens.weight -> lm_head.weight")
+
+        return {"aoa_statements": aoa_statements}
+
+
+class Gemma3Model(Gemma3PreTrainedModel):
+    def __init__(self, config: Gemma3Config):
+        super().__init__(config)
+        self.vision_tower = Gemma3VisionModel._from_config(config.vision_config)
+        self.multi_modal_projector = Gemma3MultiModalProjector(config)
+        self.language_model = Gemma3TextModel(config.text_config)
+        self.vocab_size = config.text_config.vocab_size
+
+    def get_input_embeddings(self):
+        return self.language_model.get_input_embeddings()
+
+    def set_input_embeddings(self, value):
+        self.language_model.set_input_embeddings(value)
+
+    def get_image_features(
+        self,
+        pixel_values: paddle.Tensor,
+        **kwargs,
+    ) -> BaseModelOutputWithPooling:
+        kwargs.pop("return_dict", None)
+        vision_outputs = self.vision_tower(pixel_values=pixel_values, return_dict=True, **kwargs)
+        image_features = self.multi_modal_projector(vision_outputs.last_hidden_state)
+        return BaseModelOutputWithPooling(
+            last_hidden_state=vision_outputs.last_hidden_state,
+            pooler_output=image_features,
+            hidden_states=getattr(vision_outputs, "hidden_states", None),
+            attentions=getattr(vision_outputs, "attentions", None),
+        )
+
+    def get_placeholder_mask(
+        self,
+        input_ids: Optional[paddle.Tensor],
+        inputs_embeds: paddle.Tensor,
+        image_features: paddle.Tensor,
+    ) -> paddle.Tensor:
+        if input_ids is None:
+            image_token_embed = self.get_input_embeddings()(
+                paddle.to_tensor([self.config.image_token_index], dtype="int64")
+            )
+            special_image_mask = (inputs_embeds == image_token_embed).all(axis=-1)
+        else:
+            special_image_mask = input_ids == self.config.image_token_index
+
+        n_image_tokens = int(special_image_mask.astype("int64").sum().item())
+        n_image_features = int(image_features.shape[0] * image_features.shape[1])
+        if n_image_tokens != n_image_features:
+            raise ValueError(
+                f"Image features and image tokens do not match, tokens: {n_image_tokens}, features: {n_image_features}"
+            )
+        return special_image_mask.unsqueeze(-1).expand_as(inputs_embeds)
+
+    def forward(
+        self,
+        input_ids: Optional[paddle.Tensor] = None,
+        pixel_values: Optional[paddle.Tensor] = None,
+        attention_mask: Optional[paddle.Tensor] = None,
+        attn_mask_startend_row_indices: Optional[Union[paddle.Tensor, dict[str, Optional[paddle.Tensor]]]] = None,
+        position_ids: Optional[paddle.Tensor] = None,
+        past_key_values: Optional[Cache] = None,
+        token_type_ids: Optional[paddle.Tensor] = None,
+        cache_position: Optional[paddle.Tensor] = None,
+        inputs_embeds: Optional[paddle.Tensor] = None,
+        labels: Optional[paddle.Tensor] = None,
+        use_cache: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        **kwargs,
+    ) -> Union[tuple, Gemma3ModelOutputWithPast]:
+        del labels
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        if (input_ids is None) == (inputs_embeds is None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        if input_ids is not None and self.config.image_token_index >= self.vocab_size:
+            special_image_mask = input_ids == self.config.image_token_index
+            llm_input_ids = paddle.where(special_image_mask, paddle.zeros_like(input_ids), input_ids)
+        else:
+            llm_input_ids = input_ids
+
+        if inputs_embeds is None:
+            inputs_embeds = self.get_input_embeddings()(llm_input_ids)
+        _use_high_precision_cublas_for_fp32(inputs_embeds)
+
+        if cache_position is None:
+            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+            cache_position = paddle.arange(past_seen_tokens, past_seen_tokens + inputs_embeds.shape[1], dtype="int64")
+
+        image_features = None
+        if pixel_values is not None:
+            image_features = self.get_image_features(pixel_values, return_dict=True).pooler_output
+            image_features = image_features.astype(inputs_embeds.dtype)
+            special_image_mask = self.get_placeholder_mask(
+                input_ids, inputs_embeds=inputs_embeds, image_features=image_features
+            )
+            inputs_embeds = inputs_embeds.masked_scatter(special_image_mask, image_features)
+
+        if isinstance(attention_mask, dict):
+            causal_mask_mapping = attention_mask
+            attn_mask_startend_row_indices_mapping = attn_mask_startend_row_indices
+        else:
+            causal_mask_mapping, attn_mask_startend_row_indices_mapping = create_causal_mask_mapping(
+                self.config,
+                inputs_embeds,
+                attention_mask,
+                cache_position,
+                past_key_values,
+                position_ids,
+                token_type_ids=token_type_ids,
+                is_first_iteration=bool(pixel_values is not None),
+                prepare_decoder_attention_mask=self.language_model._prepare_decoder_attention_mask,
+                return_row_indices=True,
+            )
+
+        outputs = self.language_model(
+            attention_mask=causal_mask_mapping,
+            attn_mask_startend_row_indices=attn_mask_startend_row_indices_mapping,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            return_dict=True,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            **kwargs,
+        )
+
+        if not return_dict:
+            result = (
+                outputs.last_hidden_state,
+                outputs.past_key_values,
+                outputs.hidden_states,
+                outputs.attentions,
+                image_features,
+            )
+            return tuple(value for value in result if value is not None)
+
+        return Gemma3ModelOutputWithPast(
+            last_hidden_state=outputs.last_hidden_state,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+            image_hidden_states=image_features,
+        )
+
+
+class Gemma3ForConditionalGeneration(Gemma3PreTrainedModel, GenerationMixin):
+    _tied_weights_keys = ["lm_head.weight"]
+
+    def __init__(self, config: Gemma3Config):
+        super().__init__(config)
+        self.model = Gemma3Model(config)
+        self.lm_head = GeneralLMHead(config.text_config)
+        self.criterion = CriterionLayer(config.text_config)
+        self.tie_weights()
+
+    def get_input_embeddings(self):
+        return self.model.get_input_embeddings()
+
+    def set_input_embeddings(self, value):
+        self.model.set_input_embeddings(value)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings):
+        self.lm_head = new_embeddings
+
+    def get_image_features(self, pixel_values: paddle.Tensor, **kwargs):
+        return self.model.get_image_features(pixel_values, **kwargs)
+
+    def forward(
+        self,
+        input_ids: Optional[paddle.Tensor] = None,
+        pixel_values: Optional[paddle.Tensor] = None,
+        attention_mask: Optional[paddle.Tensor] = None,
+        attn_mask_startend_row_indices: Optional[Union[paddle.Tensor, dict[str, Optional[paddle.Tensor]]]] = None,
+        position_ids: Optional[paddle.Tensor] = None,
+        past_key_values: Optional[Cache] = None,
+        token_type_ids: Optional[paddle.Tensor] = None,
+        cache_position: Optional[paddle.Tensor] = None,
+        inputs_embeds: Optional[paddle.Tensor] = None,
+        labels: Optional[paddle.Tensor] = None,
+        use_cache: Optional[bool] = None,
+        logits_to_keep: int | paddle.Tensor = 0,
+        return_dict: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        **kwargs,
+    ) -> Union[tuple, Gemma3CausalLMOutputWithPast]:
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        outputs = self.model(
+            input_ids=input_ids,
+            pixel_values=pixel_values,
+            token_type_ids=token_type_ids,
+            attention_mask=attention_mask,
+            attn_mask_startend_row_indices=attn_mask_startend_row_indices,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            return_dict=True,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            **kwargs,
+        )
+        hidden_states = outputs.last_hidden_state
+        slice_indices = (
+            slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) and logits_to_keep > 0 else slice(None)
+        )
+        logits = self.lm_head(hidden_states[:, slice_indices, :])
+
+        if self.config.text_config.final_logit_softcapping is not None:
+            logits = logits / self.config.text_config.final_logit_softcapping
+            logits = paddle.tanh(logits)
+            logits = logits * self.config.text_config.final_logit_softcapping
+
+        loss = None
+        if labels is not None:
+            loss = _compute_causal_lm_loss(
+                logits,
+                labels,
+                self.config.text_config.vocab_size,
+                attention_mask,
+                input_ids,
+            )
+
+        if not return_dict:
+            result = (
+                logits,
+                outputs.past_key_values,
+                outputs.hidden_states,
+                outputs.attentions,
+                outputs.image_hidden_states,
+            )
+            return ((loss,) + result) if loss is not None else result
+
+        return Gemma3CausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+            image_hidden_states=outputs.image_hidden_states,
+        )
+
+    def prepare_inputs_for_generation(
+        self,
+        input_ids,
+        past_key_values=None,
+        inputs_embeds=None,
+        cache_position=None,
+        position_ids=None,
+        pixel_values=None,
+        attention_mask=None,
+        token_type_ids=None,
+        use_cache=True,
+        logits_to_keep=None,
+        labels=None,
+        is_first_iteration=False,
+        **kwargs,
+    ):
+        model_inputs = super().prepare_inputs_for_generation(
+            input_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            cache_position=cache_position,
+            use_cache=use_cache,
+            logits_to_keep=logits_to_keep,
+            token_type_ids=token_type_ids,
+            is_first_iteration=is_first_iteration,
+            **kwargs,
+        )
+        if is_first_iteration or not use_cache:
+            model_inputs["pixel_values"] = pixel_values
+        if labels is not None:
+            logger.warning("`labels` are ignored during generation.")
+        return model_inputs
+
+    @staticmethod
+    def create_masks_for_generate(
+        config: Gemma3Config,
+        inputs_embeds: paddle.Tensor,
+        attention_mask: Optional[paddle.Tensor],
+        cache_position: paddle.Tensor,
+        past_key_values: Optional[Cache],
+        position_ids: Optional[paddle.Tensor],
+        token_type_ids: Optional[paddle.Tensor] = None,
+        is_first_iteration: Optional[bool] = False,
+        **kwargs,
+    ) -> dict:
+        return create_causal_mask_mapping(
+            config,
+            inputs_embeds,
+            attention_mask,
+            cache_position,
+            past_key_values,
+            position_ids,
+            token_type_ids=token_type_ids,
+            is_first_iteration=is_first_iteration,
+        )
+
+
+__all__ = [
+    "SiglipVisionEmbeddings",
+    "SiglipAttention",
+    "SiglipMLP",
+    "SiglipEncoderLayer",
+    "SiglipEncoder",
+    "SiglipVisionConfig",
+    "Gemma3VisionModel",
+    "Gemma3ModelOutputWithPast",
+    "Gemma3CausalLMOutputWithPast",
+    "Gemma3MultiModalProjector",
+    "Gemma3PreTrainedModel",
+    "Gemma3Model",
+    "Gemma3ForConditionalGeneration",
+]

--- a/paddleformers/transformers/gemma3/modeling.py
+++ b/paddleformers/transformers/gemma3/modeling.py
@@ -51,12 +51,11 @@ from .configuration import Gemma3Config, SiglipVisionConfig
 from .multimodal_text_modeling import (
     Gemma3RMSNorm,
     Gemma3TextModel,
-    _iter_hf_tensors,
     _compute_causal_lm_loss,
+    _iter_hf_tensors,
     _restore_padding_query_rows,
     load_hf_text_state_dict,
 )
-
 
 _HF_VISION_LINEAR_WEIGHT_SUFFIXES = (
     "self_attn.q_proj.weight",

--- a/paddleformers/transformers/gemma3/modeling.py
+++ b/paddleformers/transformers/gemma3/modeling.py
@@ -766,7 +766,7 @@ class Gemma3ForConditionalGeneration(Gemma3PreTrainedModel, GenerationMixin):
         inputs_embeds: Optional[paddle.Tensor] = None,
         labels: Optional[paddle.Tensor] = None,
         use_cache: Optional[bool] = None,
-        logits_to_keep: int | paddle.Tensor = 0,
+        logits_to_keep: int | paddle.Tensor | None = 0,
         return_dict: Optional[bool] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
@@ -791,9 +791,12 @@ class Gemma3ForConditionalGeneration(Gemma3PreTrainedModel, GenerationMixin):
             **kwargs,
         )
         hidden_states = outputs.last_hidden_state
-        slice_indices = (
-            slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) and logits_to_keep > 0 else slice(None)
-        )
+        if isinstance(logits_to_keep, int):
+            slice_indices = slice(-logits_to_keep, None) if logits_to_keep > 0 else slice(None)
+        elif logits_to_keep is None:
+            slice_indices = slice(None)
+        else:
+            slice_indices = logits_to_keep
         logits = self.lm_head(hidden_states[:, slice_indices, :])
 
         if self.config.text_config.final_logit_softcapping is not None:
@@ -859,8 +862,10 @@ class Gemma3ForConditionalGeneration(Gemma3PreTrainedModel, GenerationMixin):
             is_first_iteration=is_first_iteration,
             **kwargs,
         )
-        if is_first_iteration or not use_cache:
+        if is_first_iteration or past_key_values is None or not use_cache:
             model_inputs["pixel_values"] = pixel_values
+        else:
+            model_inputs["pixel_values"] = None
         if labels is not None:
             logger.warning("`labels` are ignored during generation.")
         return model_inputs

--- a/paddleformers/transformers/gemma3/multimodal_text_modeling.py
+++ b/paddleformers/transformers/gemma3/multimodal_text_modeling.py
@@ -1,0 +1,920 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Gemma3 multimodal text backbone and Torch checkpoint conversion helpers.
+
+The standalone ``gemma3_text`` implementation is maintained upstream.  This
+module is intentionally private to the multimodal Gemma3 and ShieldGemma2
+wrappers because those models require layer-specific RoPE and multimodal mask
+handling that the upstream standalone path does not currently provide.
+"""
+
+import inspect
+import json
+import os
+from collections import defaultdict
+from typing import Optional, Tuple, Union
+
+import paddle
+import paddle.nn as nn
+import paddle.nn.functional as F
+from paddle.distributed.fleet.recompute.recompute import recompute
+from paddle.distributed.fleet.utils.sequence_parallel_utils import (
+    ScatterOp,
+    mark_as_sequence_parallel_parameter,
+)
+from safetensors import safe_open
+
+from ...generation import GenerationMixin
+from ...nn.attention.interface import ALL_ATTENTION_FUNCTIONS
+from ...nn.criterion.interface import CriterionLayer
+from ...nn.linear import Linear as GeneralLinear
+from ...nn.lm_head import LMHead as GeneralLMHead
+from ...nn.mlp import MLP as BaseMLP
+from ...utils.log import logger
+from ..activations import ACT2FN
+from ..cache_utils import Cache, DynamicCache
+from ..configuration_utils import PretrainedConfig
+from ..masking_utils import (
+    create_causal_mask_and_row_indices,
+    create_sliding_window_causal_mask_and_row_indices,
+)
+from ..model_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
+from ..model_utils import PretrainedModel, dtype_guard
+from ..modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
+from .configuration import Gemma3TextConfig
+
+
+def _restore_padding_query_rows(
+    causal_mask: Optional[paddle.Tensor],
+    attention_mask: Optional[paddle.Tensor],
+    cache_length: int,
+    seq_length: int,
+):
+    if causal_mask is None or attention_mask is None or attention_mask.ndim != 2:
+        return causal_mask
+
+    query_padding = attention_mask[:, cache_length : cache_length + seq_length] == 0
+    if not paddle.any(query_padding):
+        return causal_mask
+
+    query_padding = query_padding.reshape([query_padding.shape[0], 1, query_padding.shape[1], 1])
+    if causal_mask.dtype == paddle.bool:
+        replacement = paddle.ones_like(causal_mask)
+    else:
+        replacement = paddle.zeros_like(causal_mask)
+    return paddle.where(query_padding, replacement, causal_mask)
+
+
+def _compute_causal_lm_loss(
+    logits: paddle.Tensor,
+    labels: paddle.Tensor,
+    vocab_size: int,
+    attention_mask: Optional[paddle.Tensor] = None,
+    input_ids: Optional[paddle.Tensor] = None,
+):
+    logits = logits.cast("float32")
+
+    labels_are_pre_shifted = False
+    if input_ids is not None and labels.shape == input_ids.shape:
+        # Pre-shifted labels should already have the last position masked out.
+        # Without this guard, repetitive responses can falsely satisfy the
+        # token-match heuristic and be treated as shifted when they are not.
+        last_column_is_masked = bool(paddle.all(labels[:, -1] == -100).item())
+        shifted_input_ids = paddle.concat(
+            [input_ids[:, 1:], paddle.full([input_ids.shape[0], 1], -100, dtype=input_ids.dtype)],
+            axis=1,
+        )
+        comparable_positions = labels != -100
+        comparable_count = int(comparable_positions.astype("int64").sum().item())
+        if last_column_is_masked and comparable_count > 0:
+            matched = ((labels == shifted_input_ids) & comparable_positions).astype("int64").sum().item()
+            labels_are_pre_shifted = (matched / comparable_count) > 0.98
+
+    if labels_are_pre_shifted:
+        effective_logits = logits
+        effective_labels = labels
+        if attention_mask is not None and attention_mask.ndim == 2:
+            valid_positions = attention_mask != 0
+            effective_logits = effective_logits[valid_positions]
+            effective_labels = effective_labels[valid_positions]
+    else:
+        effective_logits = logits[:, :-1, :]
+        effective_labels = labels[:, 1:]
+        if attention_mask is not None and attention_mask.ndim == 2:
+            shift_attention_mask = attention_mask[:, -effective_logits.shape[1] :]
+            valid_positions = shift_attention_mask != 0
+            effective_logits = effective_logits[valid_positions]
+            effective_labels = effective_labels[valid_positions]
+
+    shift_logits = effective_logits.reshape([-1, vocab_size])
+    shift_labels = effective_labels.reshape([-1])
+    per_token_loss = F.cross_entropy(shift_logits, shift_labels, reduction="none", ignore_index=-100)
+    valid_mask = (shift_labels != -100).astype(per_token_loss.dtype)
+    valid_count = paddle.clip(valid_mask.sum(), min=1.0)
+    return (per_token_loss * valid_mask).sum() / valid_count
+
+
+def _load_weight_map(model_dir):
+    index_path = os.path.join(model_dir, "model.safetensors.index.json")
+    if not os.path.exists(index_path):
+        return None
+    with open(index_path, "r", encoding="utf-8") as f:
+        return json.load(f)["weight_map"]
+
+
+def _iter_hf_tensors(model_dir):
+    weight_map = _load_weight_map(model_dir)
+    if weight_map is None:
+        filename = "model.safetensors"
+        path = os.path.join(model_dir, filename)
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"No safetensors checkpoint found under {model_dir}")
+        # The safetensors package does not always ship its optional Paddle
+        # framework registration. NumPy is part of the core API and preserves
+        # the checkpoint dtype before conversion to a Paddle tensor.
+        with safe_open(path, framework="np") as shard:
+            for key in shard.keys():
+                yield key, paddle.to_tensor(shard.get_tensor(key))
+        return
+
+    file_to_keys = defaultdict(list)
+    for key, filename in weight_map.items():
+        file_to_keys[filename].append(key)
+    for filename in sorted(file_to_keys):
+        with safe_open(os.path.join(model_dir, filename), framework="np") as shard:
+            for key in sorted(file_to_keys[filename]):
+                yield key, paddle.to_tensor(shard.get_tensor(key))
+
+
+def _fuse_qkv_weights(q_weight, k_weight, v_weight, num_heads, num_key_value_heads):
+    q_splits = list(paddle.split(q_weight, num_heads, axis=1))
+    k_splits = list(paddle.split(k_weight, num_key_value_heads, axis=1))
+    v_splits = list(paddle.split(v_weight, num_key_value_heads, axis=1))
+    num_query_heads_per_kv_head = num_heads // num_key_value_heads
+    fused_parts = []
+    for group_idx in range(num_key_value_heads):
+        start = group_idx * num_query_heads_per_kv_head
+        end = (group_idx + 1) * num_query_heads_per_kv_head
+        fused_parts.extend(q_splits[start:end])
+        fused_parts.append(k_splits[group_idx])
+        fused_parts.append(v_splits[group_idx])
+    return paddle.concat(fused_parts, axis=1)
+
+
+def load_hf_text_state_dict(
+    model_dir: str,
+    config: Gemma3TextConfig,
+    model_prefix: str = "",
+    include_lm_head: bool = False,
+    source_prefix: str = "",
+):
+    state_dict = {}
+    qkv_buffers = defaultdict(dict)
+    ffn_buffers = defaultdict(dict)
+    tied_lm_head = None
+    explicit_lm_head = False
+
+    for hf_key, tensor in _iter_hf_tensors(model_dir):
+        if source_prefix:
+            if not hf_key.startswith(source_prefix):
+                continue
+            hf_key = hf_key[len(source_prefix) :]
+        if hf_key == "model.embed_tokens.weight":
+            state_dict[f"{model_prefix}embed_tokens.weight"] = tensor
+            if include_lm_head:
+                tied_lm_head = tensor.clone()
+            continue
+
+        if hf_key == "lm_head.weight":
+            if include_lm_head:
+                state_dict["lm_head.weight"] = tensor
+                explicit_lm_head = True
+            continue
+
+        if hf_key == "model.norm.weight":
+            state_dict[f"{model_prefix}norm.weight"] = tensor
+            continue
+
+        if not hf_key.startswith("model.layers."):
+            raise ValueError(f"Unhandled text checkpoint key: {hf_key}")
+
+        layer_suffix = hf_key[len("model.layers.") :]
+        layer_id, rest = layer_suffix.split(".", 1)
+        prefix = f"{model_prefix}layers.{layer_id}"
+
+        if rest in {
+            "input_layernorm.weight",
+            "post_attention_layernorm.weight",
+            "pre_feedforward_layernorm.weight",
+            "post_feedforward_layernorm.weight",
+            "self_attn.q_norm.weight",
+            "self_attn.k_norm.weight",
+        }:
+            state_dict[f"{prefix}.{rest}"] = tensor
+            continue
+
+        if rest in {"self_attn.o_proj.weight", "mlp.down_proj.weight"}:
+            state_dict[f"{prefix}.{rest}"] = tensor.transpose([1, 0]).contiguous()
+            continue
+
+        if rest in {"self_attn.q_proj.weight", "self_attn.k_proj.weight", "self_attn.v_proj.weight"}:
+            proj_name = rest.split(".")[1][0]
+            qkv_buffers[layer_id][proj_name] = tensor.transpose([1, 0]).contiguous()
+            if len(qkv_buffers[layer_id]) == 3:
+                state_dict[f"{prefix}.self_attn.qkv_proj.weight"] = _fuse_qkv_weights(
+                    qkv_buffers[layer_id]["q"],
+                    qkv_buffers[layer_id]["k"],
+                    qkv_buffers[layer_id]["v"],
+                    num_heads=config.num_attention_heads,
+                    num_key_value_heads=config.num_key_value_heads,
+                )
+                del qkv_buffers[layer_id]
+            continue
+
+        if rest in {"mlp.gate_proj.weight", "mlp.up_proj.weight"}:
+            proj_name = "gate" if "gate_proj" in rest else "up"
+            ffn_buffers[layer_id][proj_name] = tensor.transpose([1, 0]).contiguous()
+            if len(ffn_buffers[layer_id]) == 2:
+                state_dict[f"{prefix}.mlp.up_gate_proj.weight"] = paddle.concat(
+                    [ffn_buffers[layer_id]["gate"], ffn_buffers[layer_id]["up"]],
+                    axis=1,
+                )
+                del ffn_buffers[layer_id]
+            continue
+
+        raise ValueError(f"Unhandled text checkpoint key: {hf_key}")
+
+    if qkv_buffers:
+        raise ValueError(f"Incomplete text QKV fusion buffers: {sorted(qkv_buffers.keys())}")
+    if ffn_buffers:
+        raise ValueError(f"Incomplete text FFN fusion buffers: {sorted(ffn_buffers.keys())}")
+    if include_lm_head and not explicit_lm_head and tied_lm_head is not None:
+        state_dict["lm_head.weight"] = tied_lm_head
+    return state_dict
+
+
+class Gemma3TextScaledWordEmbedding(nn.Embedding):
+    def __init__(self, config):
+        super().__init__(config.vocab_size, config.hidden_size, config.pad_token_id)
+        self.register_buffer("embed_scale", paddle.tensor(config.hidden_size**0.5), persistable=False)
+
+    def forward(self, input_ids: paddle.Tensor):
+        return super().forward(input_ids) * self.embed_scale.to(self.weight.dtype)
+
+
+class Gemma3MLP(BaseMLP):
+    def __init__(self, config: Gemma3TextConfig, fuse_up_gate=False):
+        super().__init__(config, fuse_up_gate=fuse_up_gate)
+        self.act_fn = ACT2FN[config.hidden_activation]
+
+
+class Gemma3RMSNorm(nn.Layer):
+    def __init__(self, hidden_size: int, eps: float = 1e-6, input_is_parallel=False):
+        super().__init__()
+        self.eps = eps
+        self.weight = paddle.create_parameter(
+            shape=[hidden_size],
+            dtype=paddle.get_default_dtype(),
+            default_initializer=nn.initializer.Constant(0.0),
+        )
+        if input_is_parallel:
+            self.enable_sequence_parallel()
+
+    def _norm(self, x):
+        with paddle.amp.auto_cast(False):
+            return x * paddle.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+
+    def forward(self, x):
+        output = self._norm(x.float())
+        output = output * (1.0 + self.weight.float())
+        return output.type_as(x)
+
+    def enable_sequence_parallel(self):
+        mark_as_sequence_parallel_parameter(self.weight)
+
+
+class Gemma3RotaryEmbedding(nn.Layer):
+    def __init__(self, config: Gemma3TextConfig):
+        super().__init__()
+        self.max_seq_len_cached = config.max_position_embeddings
+        self.original_max_seq_len = config.max_position_embeddings
+        self.config = config
+        self.layer_types = list(set(config.layer_types))
+        self.rope_type = {}
+
+        for layer_type in self.layer_types:
+            rope_params = self.config.rope_parameters.get(layer_type)
+            if rope_params is None:
+                continue
+            self.rope_type[layer_type] = rope_params.get("rope_type", rope_params.get("type", "default"))
+            rope_init_fn = self.compute_default_rope_parameters
+            if self.rope_type[layer_type] != "default":
+                rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type[layer_type]]
+            inv_freq, attention_scaling = rope_init_fn(self.config, layer_type=layer_type)
+            self.register_buffer(f"{layer_type}_inv_freq", inv_freq, persistable=False)
+            self.register_buffer(f"{layer_type}_original_inv_freq", inv_freq.clone(), persistable=False)
+            setattr(self, f"{layer_type}_attention_scaling", attention_scaling)
+
+    @staticmethod
+    def compute_default_rope_parameters(
+        config: Optional[Gemma3TextConfig] = None,
+        seq_len: Optional[int] = None,
+        layer_type: Optional[str] = None,
+    ):
+        del seq_len
+        rope_parameters = config.rope_parameters[layer_type] if layer_type is not None else config.rope_parameters
+        base = rope_parameters["rope_theta"]
+        dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
+        inv_freq = 1.0 / (base ** (paddle.arange(0, dim, 2, dtype=paddle.int64).astype(paddle.float32) / dim))
+        return inv_freq, 1.0
+
+    @dynamic_rope_update
+    def forward(self, x, position_ids, layer_type=None):
+        if layer_type is None:
+            layer_type = self.layer_types[0]
+        with paddle.amp.auto_cast(False):
+            inv_freq = getattr(self, f"{layer_type}_inv_freq")
+            attention_scaling = getattr(self, f"{layer_type}_attention_scaling")
+            inv_freq_expanded = inv_freq[None, :, None].float().expand([position_ids.shape[0], -1, 1])
+            position_ids_expanded = position_ids[:, None, :].float()
+            freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+            emb = paddle.concat((freqs, freqs), axis=-1)
+            cos = emb.cos() * attention_scaling
+            sin = emb.sin() * attention_scaling
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+def rotate_half(x):
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return paddle.cat([-x2, x1], axis=-1)
+
+
+def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
+    del position_ids
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed.astype(q.dtype), k_embed.astype(k.dtype)
+
+
+class Gemma3Attention(nn.Layer):
+    def __init__(self, config: Gemma3TextConfig, layer_idx: int):
+        super().__init__()
+        self.is_sliding = config.layer_types[layer_idx] == "sliding_attention"
+        self.config = config
+        self.layer_idx = layer_idx
+        self.head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
+        self.scaling = config.query_pre_attn_scalar**-0.5
+        self.attention_dropout = config.attention_dropout
+        self.is_causal = not config.use_bidirectional_attention
+        self.attn_implementation = config._attn_implementation
+        self.num_heads = config.num_attention_heads
+        self.num_key_value_heads = config.num_key_value_heads
+        self.num_attention_heads = config.num_attention_heads
+
+        if config.tensor_model_parallel_size > 1:
+            self.num_heads = self.num_heads // config.tensor_model_parallel_size
+            self.num_key_value_heads = self.num_key_value_heads // config.tensor_model_parallel_size
+
+        kv_hidden_size = config.num_key_value_heads * self.head_dim
+        q_hidden_size = config.num_attention_heads * self.head_dim
+
+        self.qkv_proj = GeneralLinear.create(
+            config.hidden_size,
+            q_hidden_size + 2 * kv_hidden_size,
+            has_bias=config.attention_bias,
+            config=config,
+            tp_plan="colwise",
+        )
+        self.o_proj = GeneralLinear.create(
+            q_hidden_size,
+            config.hidden_size,
+            has_bias=config.attention_bias,
+            config=config,
+            tp_plan="rowwise",
+        )
+        self.sliding_window = config.sliding_window if self.is_sliding else None
+        self.q_norm = Gemma3RMSNorm(hidden_size=self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = Gemma3RMSNorm(hidden_size=self.head_dim, eps=config.rms_norm_eps)
+
+        if config.sequence_parallel:
+            self.q_norm.enable_sequence_parallel()
+            self.k_norm.enable_sequence_parallel()
+
+    def forward(
+        self,
+        hidden_states: paddle.Tensor,
+        position_embeddings: Tuple[paddle.Tensor, paddle.Tensor],
+        attention_mask: Optional[paddle.Tensor] = None,
+        past_key_values: Optional[Cache] = None,
+        position_ids: Optional[paddle.Tensor] = None,
+        output_attentions: bool = False,
+        use_cache: bool = False,
+        attn_mask_startend_row_indices: Optional[paddle.Tensor] = None,
+    ):
+        del use_cache
+        mix_layer = self.qkv_proj(hidden_states)
+        if self.config.sequence_parallel:
+            max_sequence_length = self.config.max_sequence_length
+            bsz = hidden_states.shape[0] * self.config.tensor_model_parallel_size // max_sequence_length
+            q_len = max_sequence_length
+            target_shape = [bsz, q_len, self.num_key_value_heads, (self.num_key_value_groups + 2) * self.head_dim]
+        else:
+            target_shape = [0, 0, self.num_key_value_heads, (self.num_key_value_groups + 2) * self.head_dim]
+        mix_layer = paddle.reshape_(mix_layer, target_shape)
+        query_states, key_states, value_states = paddle.split(
+            mix_layer,
+            num_or_sections=[self.num_key_value_groups * self.head_dim, self.head_dim, self.head_dim],
+            axis=-1,
+        )
+        query_states = query_states.reshape([0, 0, -1, self.head_dim])
+        query_states = self.q_norm(query_states)
+        key_states = self.k_norm(key_states)
+        query_states = query_states.transpose(1, 2)
+        key_states = key_states.transpose(1, 2)
+        value_states = value_states.transpose(1, 2)
+        cos, sin = position_embeddings
+        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, position_ids)
+
+        if past_key_values is not None:
+            key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
+
+        attention_interface = ALL_ATTENTION_FUNCTIONS[self.attn_implementation]
+        attn_output, attn_weights = attention_interface(
+            self,
+            query=query_states,
+            key=key_states,
+            value=value_states,
+            attention_mask=attention_mask,
+            attn_mask_startend_row_indices=attn_mask_startend_row_indices,
+            dropout=self.attention_dropout if self.training else 0.0,
+            scaling=self.scaling,
+        )
+
+        if self.config.sequence_parallel:
+            attn_output = attn_output.reshape([-1, attn_output.shape[-1]])
+        attn_output = self.o_proj(attn_output)
+        if not output_attentions:
+            attn_weights = None
+        return attn_output, attn_weights
+
+
+class Gemma3DecoderLayer(nn.Layer):
+    def __init__(self, config: Gemma3TextConfig, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.attention_type = config.layer_types[layer_idx]
+        self.self_attn = Gemma3Attention(config=config, layer_idx=layer_idx)
+        self.mlp = Gemma3MLP(config, fuse_up_gate=True)
+        self.input_layernorm = Gemma3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = Gemma3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.pre_feedforward_layernorm = Gemma3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_feedforward_layernorm = Gemma3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: paddle.Tensor,
+        position_embeddings: Tuple[paddle.Tensor, paddle.Tensor],
+        attention_mask: Optional[paddle.Tensor] = None,
+        past_key_values: Optional[Cache] = None,
+        position_ids: Optional[paddle.Tensor] = None,
+        output_attentions: Optional[bool] = False,
+        use_cache: Optional[bool] = False,
+        attn_mask_startend_row_indices: Optional[paddle.Tensor] = None,
+        **kwargs,
+    ):
+        del kwargs
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states, self_attn_weights = self.self_attn(
+            hidden_states=hidden_states,
+            position_embeddings=position_embeddings,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            position_ids=position_ids,
+            output_attentions=output_attentions,
+            use_cache=use_cache,
+            attn_mask_startend_row_indices=attn_mask_startend_row_indices,
+        )
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.pre_feedforward_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = self.post_feedforward_layernorm(hidden_states)
+        hidden_states = residual + hidden_states
+
+        outputs = (hidden_states,)
+        if output_attentions:
+            outputs += (self_attn_weights,)
+        return outputs[0] if len(outputs) == 1 else outputs
+
+
+class Gemma3TextPreTrainedModel(PretrainedModel):
+    config_class = Gemma3TextConfig
+    base_model_prefix = "model"
+    _keys_to_ignore_on_load_unexpected = [r"self_attn.rotary_emb.inv_freq"]
+    transpose_weight_keys = [
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "o_proj",
+        "gate_proj",
+        "up_proj",
+        "down_proj",
+        "lm_head",
+    ]
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, *args, **kwargs):
+        if (
+            isinstance(pretrained_model_name_or_path, str)
+            and os.path.isdir(pretrained_model_name_or_path)
+            and os.path.exists(os.path.join(pretrained_model_name_or_path, "model_state.pdparams"))
+        ):
+            kwargs.setdefault("load_checkpoint_format", "naive")
+            kwargs.setdefault("convert_from_hf", False)
+            return super().from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+
+        if not (
+            isinstance(pretrained_model_name_or_path, str)
+            and os.path.isdir(pretrained_model_name_or_path)
+            and (
+                os.path.exists(os.path.join(pretrained_model_name_or_path, "model.safetensors"))
+                or os.path.exists(os.path.join(pretrained_model_name_or_path, "model.safetensors.index.json"))
+            )
+        ):
+            return super().from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+
+        dtype = kwargs.pop("dtype", None)
+        config = kwargs.pop("config", None)
+        if not isinstance(config, PretrainedConfig):
+            config_path = config if config is not None else pretrained_model_name_or_path
+            config, model_kwargs = cls.config_class.from_pretrained(
+                config_path,
+                return_unused_kwargs=True,
+                **kwargs,
+            )
+        else:
+            model_kwargs = kwargs
+
+        accepted_init_kwargs = {
+            name for name in inspect.signature(cls.__init__).parameters if name not in {"self", "config"}
+        }
+        model_kwargs = {key: value for key, value in model_kwargs.items() if key in accepted_init_kwargs}
+
+        if dtype is not None:
+            config.dtype = dtype
+        with dtype_guard(dtype or paddle.get_default_dtype()):
+            model = cls(config, *args, **model_kwargs)
+        model_prefix = "" if cls == Gemma3TextModel else "model."
+        include_lm_head = cls != Gemma3TextModel
+        state_dict = load_hf_text_state_dict(
+            pretrained_model_name_or_path,
+            config,
+            model_prefix=model_prefix,
+            include_lm_head=include_lm_head,
+        )
+        target_state_dict = model.state_dict()
+        for name, tensor in list(state_dict.items()):
+            if name in target_state_dict and tensor.dtype != target_state_dict[name].dtype:
+                state_dict[name] = tensor.astype(target_state_dict[name].dtype)
+        missing_keys, unexpected_keys = model.set_state_dict(state_dict)
+        if missing_keys or unexpected_keys:
+            logger.warning(
+                "HF text checkpoint load finished with missing keys %s and unexpected keys %s",
+                missing_keys,
+                unexpected_keys,
+            )
+        return model
+
+    @classmethod
+    def _gen_aoa_config(cls, config: Gemma3TextConfig):
+        model_prefix = "" if cls == cls.base_model_class else "model."
+        aoa_config = {
+            "aoa_statements": [
+                "model.embed_tokens.weight -> lm_head.weight",
+                f"model.embed_tokens.weight -> {model_prefix}embed_tokens.weight",
+                f"model.norm.weight -> {model_prefix}norm.weight",
+                f"model.layers.$LAYER_ID.input_layernorm.weight -> {model_prefix}layers.$LAYER_ID.input_layernorm.weight",
+                f"model.layers.$LAYER_ID.post_attention_layernorm.weight -> {model_prefix}layers.$LAYER_ID.post_attention_layernorm.weight",
+                f"model.layers.$LAYER_ID.pre_feedforward_layernorm.weight -> {model_prefix}layers.$LAYER_ID.pre_feedforward_layernorm.weight",
+                f"model.layers.$LAYER_ID.post_feedforward_layernorm.weight -> {model_prefix}layers.$LAYER_ID.post_feedforward_layernorm.weight",
+                f"model.layers.$LAYER_ID.self_attn.q_norm.weight -> {model_prefix}layers.$LAYER_ID.self_attn.q_norm.weight",
+                f"model.layers.$LAYER_ID.self_attn.k_norm.weight -> {model_prefix}layers.$LAYER_ID.self_attn.k_norm.weight",
+                f"model.layers.$LAYER_ID.mlp.down_proj.weight^T -> {model_prefix}layers.$LAYER_ID.mlp.down_proj.weight",
+                f"model.layers.$LAYER_ID.self_attn.o_proj.weight^T -> {model_prefix}layers.$LAYER_ID.self_attn.o_proj.weight",
+                (
+                    f"model.layers.$LAYER_ID.self_attn.q_proj.weight^T, "
+                    f"model.layers.$LAYER_ID.self_attn.k_proj.weight^T, "
+                    f"model.layers.$LAYER_ID.self_attn.v_proj.weight^T -> "
+                    f"{model_prefix}layers.$LAYER_ID.self_attn.qkv_proj.weight, "
+                    f"fused_qkv, num_heads={config.num_attention_heads}, num_key_value_groups={config.num_key_value_heads}"
+                ),
+                (
+                    f"model.layers.$LAYER_ID.mlp.gate_proj.weight^T, "
+                    f"model.layers.$LAYER_ID.mlp.up_proj.weight^T -> "
+                    f"{model_prefix}layers.$LAYER_ID.mlp.up_gate_proj.weight, fused_ffn"
+                ),
+            ]
+        }
+        return aoa_config
+
+
+class Gemma3TextModel(Gemma3TextPreTrainedModel):
+    config_class = Gemma3TextConfig
+
+    def __init__(self, config: Gemma3TextConfig):
+        super().__init__(config)
+        self.sequence_parallel = config.sequence_parallel
+        self.embed_tokens = Gemma3TextScaledWordEmbedding(config)
+        self.layers = nn.LayerList(
+            [Gemma3DecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+        )
+        self.norm = Gemma3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = Gemma3RotaryEmbedding(config=config)
+        self.has_sliding_layers = getattr(
+            self.config, "sliding_window", None
+        ) is not None and "sliding_attention" in getattr(self.config, "layer_types", [])
+        if config.sequence_parallel:
+            self.norm.enable_sequence_parallel()
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.embed_tokens = value
+
+    @paddle.jit.not_to_static
+    def recompute_training(
+        self,
+        layer_module: nn.Layer,
+        hidden_states: paddle.Tensor,
+        position_ids: Optional[paddle.Tensor],
+        attention_mask: paddle.Tensor,
+        past_key_values: Cache,
+        output_attentions: bool,
+        use_cache: bool,
+        position_embeddings: Optional[Tuple[paddle.Tensor, paddle.Tensor]] = None,
+        attn_mask_startend_row_indices: Optional[paddle.Tensor] = None,
+    ):
+        def create_custom_forward(module):
+            def custom_forward(*inputs):
+                return module(*inputs)
+
+            return custom_forward
+
+        return recompute(
+            create_custom_forward(layer_module),
+            hidden_states,
+            position_embeddings,
+            attention_mask,
+            past_key_values,
+            position_ids,
+            output_attentions,
+            use_cache,
+            attn_mask_startend_row_indices,
+        )
+
+    def forward(
+        self,
+        input_ids: Optional[paddle.Tensor] = None,
+        attention_mask: Optional[Union[paddle.Tensor, dict[str, Optional[paddle.Tensor]]]] = None,
+        attn_mask_startend_row_indices: Optional[Union[paddle.Tensor, dict[str, Optional[paddle.Tensor]]]] = None,
+        position_ids: Optional[paddle.Tensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[paddle.Tensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        cache_position: Optional[paddle.Tensor] = None,
+        **kwargs,
+    ) -> Union[Tuple, BaseModelOutputWithPast]:
+        del kwargs
+        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+        use_cache = use_cache if use_cache is not None else self.config.use_cache
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        if (input_ids is None) == (inputs_embeds is None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids).astype(self.embed_tokens.weight.dtype)
+        batch_size, seq_length = inputs_embeds.shape[:2]
+
+        if use_cache and past_key_values is None:
+            past_key_values = DynamicCache(config=self.config)
+        cache_length = past_key_values.get_seq_length() if past_key_values is not None else 0
+        if cache_position is None:
+            cache_position = paddle.arange(cache_length, cache_length + seq_length, dtype="int64")
+
+        if self.sequence_parallel:
+            bs, seq_len, hidden_size = inputs_embeds.shape
+            inputs_embeds = paddle.reshape_(inputs_embeds, [bs * seq_len, hidden_size])
+            inputs_embeds = ScatterOp.apply(inputs_embeds)
+
+        if isinstance(attention_mask, dict):
+            causal_mask_mapping = attention_mask
+            if isinstance(attn_mask_startend_row_indices, dict):
+                attn_mask_startend_row_indices_mapping = attn_mask_startend_row_indices
+            else:
+                attn_mask_startend_row_indices_mapping = {
+                    "full_attention": attn_mask_startend_row_indices,
+                    "sliding_attention": attn_mask_startend_row_indices,
+                }
+        else:
+            mask_kwargs = {
+                "config": self.config,
+                "inputs_embeds": inputs_embeds,
+                "batch_size": batch_size,
+                "seq_length": seq_length,
+                "cache_length": cache_length,
+                "attention_mask": attention_mask,
+                "attn_mask_startend_row_indices": attn_mask_startend_row_indices,
+                "prepare_decoder_attention_mask": self._prepare_decoder_attention_mask,
+            }
+            full_mask, full_indices = create_causal_mask_and_row_indices(**mask_kwargs)
+            full_mask = _restore_padding_query_rows(full_mask, attention_mask, cache_length, seq_length)
+            causal_mask_mapping = {"full_attention": full_mask}
+            attn_mask_startend_row_indices_mapping = {"full_attention": full_indices}
+            if self.has_sliding_layers:
+                sliding_mask, sliding_indices = create_sliding_window_causal_mask_and_row_indices(**mask_kwargs)
+                sliding_mask = _restore_padding_query_rows(sliding_mask, attention_mask, cache_length, seq_length)
+                causal_mask_mapping["sliding_attention"] = sliding_mask
+                attn_mask_startend_row_indices_mapping["sliding_attention"] = sliding_indices
+
+        if position_ids is None:
+            position_ids = cache_position.unsqueeze(0)
+
+        unique_layer_types = set(self.config.layer_types)
+        position_embeddings = {
+            layer_type: self.rotary_emb(inputs_embeds, position_ids, layer_type) for layer_type in unique_layer_types
+        }
+
+        hidden_states = inputs_embeds
+        all_hidden_states = () if output_hidden_states else None
+        all_self_attns = () if output_attentions else None
+        for decoder_layer in self.layers:
+            if output_hidden_states:
+                all_hidden_states += (hidden_states,)
+            has_gradient = not hidden_states.stop_gradient
+            layer_attention_mask = causal_mask_mapping[decoder_layer.attention_type]
+            layer_row_indices = attn_mask_startend_row_indices_mapping[decoder_layer.attention_type]
+            if (
+                self.config.recompute_granularity == "full"
+                and self.config.recompute_method == "uniform"
+                and self.config.recompute_num_layers == 1
+                and has_gradient
+            ):
+                layer_outputs = self.recompute_training(
+                    decoder_layer,
+                    hidden_states,
+                    position_embeddings=position_embeddings[decoder_layer.attention_type],
+                    attention_mask=layer_attention_mask,
+                    past_key_values=past_key_values,
+                    position_ids=position_ids,
+                    output_attentions=output_attentions,
+                    use_cache=use_cache,
+                    attn_mask_startend_row_indices=layer_row_indices,
+                )
+            else:
+                layer_outputs = decoder_layer(
+                    hidden_states,
+                    position_embeddings=position_embeddings[decoder_layer.attention_type],
+                    attention_mask=layer_attention_mask,
+                    past_key_values=past_key_values,
+                    position_ids=position_ids,
+                    output_attentions=output_attentions,
+                    use_cache=use_cache,
+                    attn_mask_startend_row_indices=layer_row_indices,
+                )
+            hidden_states = layer_outputs[0] if isinstance(layer_outputs, (tuple, list)) else layer_outputs
+            if output_attentions:
+                all_self_attns += (layer_outputs[1],)
+
+        hidden_states = self.norm(hidden_states)
+        if output_hidden_states:
+            all_hidden_states += (hidden_states,)
+
+        if not return_dict:
+            return tuple(
+                v for v in [hidden_states, past_key_values, all_hidden_states, all_self_attns] if v is not None
+            )
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states,
+            past_key_values=past_key_values,
+            hidden_states=all_hidden_states,
+            attentions=all_self_attns,
+        )
+
+
+class Gemma3ForCausalLM(Gemma3TextPreTrainedModel, GenerationMixin):
+    _tied_weights_keys = ["lm_head.weight"]
+    config_class = Gemma3TextConfig
+
+    def __init__(self, config: Gemma3TextConfig):
+        super().__init__(config)
+        self.model = Gemma3TextModel(config)
+        self.lm_head = GeneralLMHead(config)
+        self.criterion = CriterionLayer(config)
+        self.tie_weights()
+
+    def get_input_embeddings(self):
+        return self.model.get_input_embeddings()
+
+    def set_input_embeddings(self, value):
+        self.model.set_input_embeddings(value)
+
+    def forward(
+        self,
+        input_ids: Optional[paddle.Tensor] = None,
+        attention_mask: Optional[Union[paddle.Tensor, dict[str, Optional[paddle.Tensor]]]] = None,
+        position_ids: Optional[paddle.Tensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[paddle.Tensor] = None,
+        labels: Optional[paddle.Tensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        attn_mask_startend_row_indices: Optional[Union[paddle.Tensor, dict[str, Optional[paddle.Tensor]]]] = None,
+        cache_position: Optional[paddle.Tensor] = None,
+        **kwargs,
+    ) -> CausalLMOutputWithPast:
+        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            attn_mask_startend_row_indices=attn_mask_startend_row_indices,
+            cache_position=cache_position,
+            return_dict=return_dict,
+            **kwargs,
+        )
+        hidden_states = outputs[0]
+        logits = self.lm_head(hidden_states)
+        if self.config.final_logit_softcapping is not None:
+            logits = logits / self.config.final_logit_softcapping
+            logits = paddle.tanh(logits)
+            logits = logits * self.config.final_logit_softcapping
+
+        loss = None
+        if labels is not None:
+            loss = _compute_causal_lm_loss(logits, labels, self.config.vocab_size, attention_mask, input_ids)
+
+        if not return_dict:
+            output = (logits,) + outputs[1:]
+            return (loss,) + output if loss is not None else output
+
+        return CausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )
+
+
+__all__ = [
+    "Gemma3TextPreTrainedModel",
+    "Gemma3TextScaledWordEmbedding",
+    "Gemma3MLP",
+    "Gemma3RMSNorm",
+    "Gemma3RotaryEmbedding",
+    "Gemma3Attention",
+    "Gemma3DecoderLayer",
+    "Gemma3TextModel",
+    "Gemma3ForCausalLM",
+    "load_hf_text_state_dict",
+]

--- a/paddleformers/transformers/gemma3/processor.py
+++ b/paddleformers/transformers/gemma3/processor.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from collections import UserDict
+
+import numpy as np
+import paddle
+
+from ..feature_extraction_utils import BatchFeature
+from ..image_utils import ImageInput, make_nested_list_of_images
+from ..processing_utils import MultiModalData, ProcessingKwargs, ProcessorMixin, Unpack
+from ..tokenizer_utils_base import PreTokenizedInput, TextInput
+
+
+def to_py_obj(obj):
+    if isinstance(obj, (dict, UserDict)):
+        return {k: to_py_obj(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [to_py_obj(o) for o in obj]
+    if isinstance(obj, paddle.Tensor):
+        return obj.numpy().tolist()
+    if isinstance(obj, (np.ndarray, np.number)):
+        return obj.tolist()
+    return obj
+
+
+class Gemma3ProcessorKwargs(ProcessingKwargs, total=False):
+    _defaults = {
+        "text_kwargs": {
+            "padding": False,
+            "return_mm_token_type_ids": True,
+        },
+        "images_kwargs": {
+            "do_convert_rgb": True,
+            "do_pan_and_scan": False,
+            "pan_and_scan_min_crop_size": 256,
+            "pan_and_scan_max_num_crops": 4,
+            "pan_and_scan_min_ratio_to_activate": 1.2,
+        },
+    }
+
+
+class Gemma3Processor(ProcessorMixin):
+    attributes = ["image_processor", "tokenizer"]
+    image_processor_class = "AutoImageProcessor"
+    tokenizer_class = "AutoTokenizer"
+
+    def __init__(
+        self, image_processor=None, tokenizer=None, chat_template=None, image_seq_length: int = 256, **kwargs
+    ):
+        self.image_seq_length = image_seq_length
+        self.image_token_id = tokenizer.image_token_id
+        self.boi_token = tokenizer.boi_token
+        self.image_token = tokenizer.image_token
+        image_tokens_expanded = "".join([tokenizer.image_token] * image_seq_length)
+        self.full_image_sequence = f"\n\n{tokenizer.boi_token}{image_tokens_expanded}{tokenizer.eoi_token}\n\n"
+        super().__init__(image_processor, tokenizer, chat_template=chat_template, **kwargs)
+
+    def __call__(
+        self,
+        images: ImageInput = None,
+        text: TextInput | PreTokenizedInput | list[TextInput] | list[PreTokenizedInput] = None,
+        **kwargs: Unpack[Gemma3ProcessorKwargs],
+    ) -> BatchFeature:
+        if text is None and images is None:
+            raise ValueError("Provide at least one of `text` or `images`.")
+
+        output_kwargs = self._merge_kwargs(
+            Gemma3ProcessorKwargs,
+            tokenizer_init_kwargs=self.tokenizer.init_kwargs,
+            **kwargs,
+        )
+
+        if isinstance(text, str):
+            text = [text]
+        elif text is not None and (not isinstance(text, list) or (text and not isinstance(text[0], str))):
+            raise TypeError("Invalid input text. Please provide a string, or a list of strings")
+
+        image_inputs = {}
+        if images is not None:
+            images = self.image_processor.fetch_images(images)
+            batched_images = make_nested_list_of_images(images)
+            image_inputs = self.image_processor(images, **output_kwargs["images_kwargs"])
+
+            if not text:
+                text = [" ".join([self.boi_token] * len(batch_images)) for batch_images in batched_images]
+
+            if len(batched_images) != len(text):
+                raise ValueError(
+                    f"Received inconsistently sized batches of images ({len(batched_images)}) and text ({len(text)})."
+                )
+
+            num_crops = to_py_obj(image_inputs.pop("num_crops"))
+            batch_num_crops = [[num_crops.pop(0) for _ in range(len(batch_images))] for batch_images in batched_images]
+
+            for batch_idx, (prompt, batch_images, batch_crops) in enumerate(
+                zip(text, batched_images, batch_num_crops)
+            ):
+                image_indexes = [match.start() for match in re.finditer(self.boi_token, prompt)]
+                if len(batch_images) != len(image_indexes):
+                    raise ValueError(
+                        f"Prompt contained {len(image_indexes)} image tokens but received {len(batch_images)} images."
+                    )
+
+                for num, idx in reversed(list(zip(batch_crops, image_indexes))):
+                    if num:
+                        formatted_image_text = (
+                            f"Here is the original image {self.boi_token} and here are some crops to help you see better "
+                            + " ".join([self.boi_token] * num)
+                        )
+                        prompt = prompt[:idx] + formatted_image_text + prompt[idx + len(self.boi_token) :]
+                        text[batch_idx] = prompt
+
+            text = [prompt.replace(self.boi_token, self.full_image_sequence) for prompt in text]
+
+        return_tensors = output_kwargs["text_kwargs"].pop("return_tensors", None)
+        return_mm_token_type_ids = output_kwargs["text_kwargs"].pop("return_mm_token_type_ids", False)
+
+        text_inputs = self.tokenizer(text=text, **output_kwargs["text_kwargs"])
+        self._check_special_mm_tokens(text, text_inputs, modalities=["image"])
+
+        if return_mm_token_type_ids:
+            array_ids = np.array(text_inputs["input_ids"])
+            mm_token_type_ids = np.zeros_like(array_ids)
+            mm_token_type_ids[array_ids == self.image_token_id] = 1
+            text_inputs["token_type_ids"] = mm_token_type_ids.tolist()
+
+        return BatchFeature(data={**text_inputs, **image_inputs}, tensor_type=return_tensors)
+
+    def _get_num_multimodal_tokens(self, image_sizes=None, **kwargs):
+        vision_data = {}
+        if image_sizes is not None:
+            vision_data.update(
+                {
+                    "num_image_tokens": [self.image_seq_length] * len(image_sizes),
+                    "num_image_patches": [1] * len(image_sizes),
+                }
+            )
+        return MultiModalData(**vision_data)
+
+    @property
+    def model_input_names(self):
+        tokenizer_input_names = self.tokenizer.model_input_names + ["token_type_ids"]
+        image_processor_input_names = [name for name in self.image_processor.model_input_names if name != "num_crops"]
+        return list(tokenizer_input_names + image_processor_input_names)
+
+
+__all__ = ["Gemma3Processor", "Gemma3ProcessorKwargs"]

--- a/paddleformers/transformers/shieldgemma2/__init__.py
+++ b/paddleformers/transformers/shieldgemma2/__init__.py
@@ -20,10 +20,16 @@ from ...utils.lazy_import import _LazyModule
 import_structure = {
     "configuration": ["ShieldGemma2Config", "ShieldGemma2VisionConfig"],
     "modeling": ["ShieldGemma2ForImageClassification", "ShieldGemma2ImageClassifierOutputWithNoAttention"],
+    "processor": [
+        "DEFAULT_SHIELDGEMMA2_POLICIES",
+        "ShieldGemma2Processor",
+        "ShieldGemma2ProcessorKwargs",
+    ],
 }
 
 if TYPE_CHECKING:
     from .configuration import *
     from .modeling import *
+    from .processor import *
 else:
     sys.modules[__name__] = _LazyModule(__name__, globals()["__file__"], import_structure, module_spec=__spec__)

--- a/paddleformers/transformers/shieldgemma2/__init__.py
+++ b/paddleformers/transformers/shieldgemma2/__init__.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from typing import TYPE_CHECKING
+
+from ...utils.lazy_import import _LazyModule
+
+import_structure = {
+    "configuration": ["ShieldGemma2Config", "ShieldGemma2VisionConfig"],
+    "modeling": ["ShieldGemma2ForImageClassification", "ShieldGemma2ImageClassifierOutputWithNoAttention"],
+}
+
+if TYPE_CHECKING:
+    from .configuration import *
+    from .modeling import *
+else:
+    sys.modules[__name__] = _LazyModule(__name__, globals()["__file__"], import_structure, module_spec=__spec__)

--- a/paddleformers/transformers/shieldgemma2/configuration.py
+++ b/paddleformers/transformers/shieldgemma2/configuration.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ShieldGemma2 model configuration."""
+from ..configuration_utils import PretrainedConfig
+from ..gemma3.configuration import Gemma3TextConfig
+
+
+class ShieldGemma2VisionConfig(PretrainedConfig):
+    model_type = "shieldgemma2_vision"
+    base_config_key = "vision_config"
+
+    def __init__(
+        self,
+        hidden_size=1152,
+        intermediate_size=4304,
+        num_hidden_layers=27,
+        num_attention_heads=16,
+        num_channels=3,
+        image_size=224,
+        patch_size=14,
+        hidden_act="gelu_pytorch_tanh",
+        layer_norm_eps=1e-6,
+        attention_dropout=0.0,
+        vision_use_head=False,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_channels = num_channels
+        self.image_size = image_size
+        self.patch_size = patch_size
+        self.hidden_act = hidden_act
+        self.layer_norm_eps = layer_norm_eps
+        self.attention_dropout = attention_dropout
+        self.vision_use_head = vision_use_head
+
+
+class ShieldGemma2Config(PretrainedConfig):
+    r"""
+    Configuration class for [`ShieldGemma2ForImageClassification`].
+    """
+
+    model_type = "shieldgemma2"
+    is_composition = True
+    sub_configs = {"vision_config": ShieldGemma2VisionConfig, "text_config": Gemma3TextConfig}
+    keys_to_ignore_at_inference = ["past_key_values"]
+    attribute_map = {
+        "image_token_id": "image_token_index",
+        "boi_token_id": "boi_token_index",
+        "eoi_token_id": "eoi_token_index",
+    }
+    _text_config_passthrough_exclusions = {
+        "_name_or_path",
+        "model_type",
+        "dtype",
+        "_attn_implementation_internal",
+        "id2label",
+        "label2id",
+        "num_labels",
+        "num_classes",
+        "architectures",
+        "sub_configs",
+    }
+
+    def __init__(
+        self,
+        text_config=None,
+        vision_config=None,
+        mm_tokens_per_image=256,
+        boi_token_index=255999,
+        eoi_token_index=256000,
+        image_token_index=262144,
+        initializer_range=0.02,
+        yes_token_index=10784,
+        no_token_index=3771,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        if isinstance(text_config, dict):
+            self.text_config = self.sub_configs["text_config"](**text_config)
+        elif text_config is None:
+            self.text_config = self.sub_configs["text_config"](**kwargs)
+        else:
+            self.text_config = text_config
+
+        if isinstance(vision_config, dict):
+            self.vision_config = self.sub_configs["vision_config"](**vision_config)
+        elif vision_config is None:
+            self.vision_config = self.sub_configs["vision_config"]()
+        else:
+            self.vision_config = vision_config
+
+        self.mm_tokens_per_image = mm_tokens_per_image
+        self.boi_token_index = boi_token_index
+        self.eoi_token_index = eoi_token_index
+        self.image_token_index = image_token_index
+        self.initializer_range = initializer_range
+        self.yes_token_index = yes_token_index
+        self.no_token_index = no_token_index
+        self.architectures = kwargs.get("architectures", ["ShieldGemma2ForImageClassification"])
+
+    def __setattr__(self, key, value):
+        if (
+            (text_config := super().__getattribute__("__dict__").get("text_config")) is not None
+            and key not in self._text_config_passthrough_exclusions
+            and key in text_config.__dict__
+        ):
+            setattr(text_config, key, value)
+        else:
+            super().__setattr__(key, value)
+
+    def __getattribute__(self, key):
+        if "text_config" in super().__getattribute__("__dict__") and key not in super().__getattribute__(
+            "_text_config_passthrough_exclusions"
+        ):
+            text_config = super().__getattribute__("text_config")
+            if key in text_config.__dict__:
+                return getattr(text_config, key)
+        return super().__getattribute__(key)
+
+    @property
+    def num_classes(self):
+        return self.num_labels
+
+    @num_classes.setter
+    def num_classes(self, num_classes):
+        self.num_labels = num_classes
+
+
+__all__ = ["ShieldGemma2Config", "ShieldGemma2VisionConfig"]

--- a/paddleformers/transformers/shieldgemma2/modeling.py
+++ b/paddleformers/transformers/shieldgemma2/modeling.py
@@ -1,0 +1,455 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Paddle ShieldGemma2 model."""
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+import paddle
+import paddle.nn.functional as F
+from paddle import nn
+
+from ..activations import ACT2FN
+from ..cache_utils import Cache
+from ..configuration_utils import PretrainedConfig
+from ..gemma3.modeling import Gemma3ForConditionalGeneration, _convert_hf_vision_tensor
+from ..gemma3.multimodal_text_modeling import Gemma3RMSNorm, _iter_hf_tensors, load_hf_text_state_dict
+from ..model_outputs import ImageClassifierOutputWithNoAttention
+from ..model_utils import dtype_guard
+from ...utils.log import logger
+from .configuration import ShieldGemma2Config
+
+
+@dataclass
+class ShieldGemma2ImageClassifierOutputWithNoAttention(ImageClassifierOutputWithNoAttention):
+    probabilities: Optional[paddle.Tensor] = None
+
+
+class ShieldGemma2VisionEmbeddings(nn.Layer):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.embed_dim = config.hidden_size
+        self.image_size = config.image_size
+        self.patch_size = config.patch_size
+        self.patch_embedding = nn.Conv2D(
+            in_channels=config.num_channels,
+            out_channels=self.embed_dim,
+            kernel_size=self.patch_size,
+            stride=self.patch_size,
+        )
+        self.num_patches = (self.image_size // self.patch_size) ** 2
+        self.position_embedding = nn.Embedding(self.num_patches, self.embed_dim)
+        self.position_ids = paddle.arange(self.num_patches, dtype="int64").reshape([1, -1])
+
+    def interpolate_pos_encoding(self, embeddings: paddle.Tensor, height: int, width: int) -> paddle.Tensor:
+        num_patches = embeddings.shape[1]
+        if num_patches == self.num_patches and height == width == self.image_size:
+            return self.position_embedding(self.position_ids)
+
+        dim = embeddings.shape[-1]
+        new_height = height // self.patch_size
+        new_width = width // self.patch_size
+        sqrt_num_positions = int(self.num_patches**0.5)
+
+        patch_pos_embed = self.position_embedding.weight.reshape([1, sqrt_num_positions, sqrt_num_positions, dim])
+        patch_pos_embed = patch_pos_embed.transpose([0, 3, 1, 2])
+        patch_pos_embed = F.interpolate(
+            patch_pos_embed,
+            size=[new_height, new_width],
+            mode="bicubic",
+            align_corners=False,
+        )
+        patch_pos_embed = patch_pos_embed.transpose([0, 2, 3, 1]).reshape([1, -1, dim])
+        return patch_pos_embed
+
+    def forward(self, pixel_values: paddle.Tensor) -> paddle.Tensor:
+        _, _, height, width = pixel_values.shape
+        pixel_values = pixel_values.astype(self.patch_embedding.weight.dtype)
+        patch_embeds = self.patch_embedding(pixel_values)
+        embeddings = patch_embeds.flatten(start_axis=2).transpose([0, 2, 1])
+        embeddings = embeddings + self.interpolate_pos_encoding(embeddings, height, width)
+        return embeddings
+
+
+class ShieldGemma2VisionAttention(nn.Layer):
+    def __init__(self, config):
+        super().__init__()
+        self.embed_dim = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = self.embed_dim // self.num_heads
+        if self.head_dim * self.num_heads != self.embed_dim:
+            raise ValueError(
+                f"embed_dim must be divisible by num_heads (got embed_dim={self.embed_dim}, num_heads={self.num_heads})."
+            )
+        self.scale = self.head_dim**-0.5
+        self.dropout = config.attention_dropout
+
+        self.q_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.k_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.v_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.out_proj = nn.Linear(self.embed_dim, self.embed_dim)
+
+    def forward(self, hidden_states: paddle.Tensor) -> paddle.Tensor:
+        batch_size, seq_length, embed_dim = hidden_states.shape
+
+        query_states = self.q_proj(hidden_states)
+        key_states = self.k_proj(hidden_states)
+        value_states = self.v_proj(hidden_states)
+
+        query_states = query_states.reshape([batch_size, seq_length, self.num_heads, self.head_dim]).transpose(
+            [0, 2, 1, 3]
+        )
+        key_states = key_states.reshape([batch_size, seq_length, self.num_heads, self.head_dim]).transpose(
+            [0, 2, 1, 3]
+        )
+        value_states = value_states.reshape([batch_size, seq_length, self.num_heads, self.head_dim]).transpose(
+            [0, 2, 1, 3]
+        )
+
+        attn_weights = paddle.matmul(query_states, key_states.transpose([0, 1, 3, 2])) * self.scale
+        attn_weights = F.softmax(attn_weights, axis=-1)
+        if self.dropout > 0 and self.training:
+            attn_weights = F.dropout(attn_weights, p=self.dropout, training=True)
+
+        attn_output = paddle.matmul(attn_weights, value_states)
+        attn_output = attn_output.transpose([0, 2, 1, 3]).reshape([batch_size, seq_length, embed_dim])
+        return self.out_proj(attn_output)
+
+
+class ShieldGemma2VisionMLP(nn.Layer):
+    def __init__(self, config):
+        super().__init__()
+        self.activation_fn = ACT2FN[config.hidden_act]
+        self.fc1 = nn.Linear(config.hidden_size, config.intermediate_size)
+        self.fc2 = nn.Linear(config.intermediate_size, config.hidden_size)
+
+    def forward(self, hidden_states: paddle.Tensor) -> paddle.Tensor:
+        hidden_states = self.fc1(hidden_states)
+        hidden_states = self.activation_fn(hidden_states)
+        hidden_states = self.fc2(hidden_states)
+        return hidden_states
+
+
+class ShieldGemma2VisionEncoderLayer(nn.Layer):
+    def __init__(self, config):
+        super().__init__()
+        self.layer_norm1 = nn.LayerNorm(config.hidden_size, epsilon=config.layer_norm_eps)
+        self.self_attn = ShieldGemma2VisionAttention(config)
+        self.layer_norm2 = nn.LayerNorm(config.hidden_size, epsilon=config.layer_norm_eps)
+        self.mlp = ShieldGemma2VisionMLP(config)
+
+    def forward(self, hidden_states: paddle.Tensor) -> paddle.Tensor:
+        residual = hidden_states
+        hidden_states = self.layer_norm1(hidden_states)
+        hidden_states = self.self_attn(hidden_states)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.layer_norm2(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+class ShieldGemma2VisionTower(nn.Layer):
+    def __init__(self, config: ShieldGemma2Config):
+        super().__init__()
+        vision_config = config.vision_config
+        self.mm_tokens_per_image = config.mm_tokens_per_image
+        self.embeddings = ShieldGemma2VisionEmbeddings(vision_config)
+        self.encoder = nn.LayerList(
+            [ShieldGemma2VisionEncoderLayer(vision_config) for _ in range(vision_config.num_hidden_layers)]
+        )
+        self.post_layernorm = nn.LayerNorm(vision_config.hidden_size, epsilon=vision_config.layer_norm_eps)
+
+    def _flatten_pixel_values(self, pixel_values: paddle.Tensor) -> tuple[paddle.Tensor, int, int]:
+        if pixel_values.ndim == 4:
+            batch_size = pixel_values.shape[0]
+            num_images = 1
+            flat_pixel_values = pixel_values
+        elif pixel_values.ndim == 5:
+            batch_size, num_images = pixel_values.shape[:2]
+            flat_pixel_values = pixel_values.reshape([-1, *pixel_values.shape[-3:]])
+        else:
+            raise ValueError(
+                "`pixel_values` must have shape [batch, channels, height, width] or [batch, images, channels, height, width]."
+            )
+        return flat_pixel_values, batch_size, num_images
+
+    def forward(self, pixel_values: paddle.Tensor) -> paddle.Tensor:
+        flat_pixel_values, batch_size, num_images = self._flatten_pixel_values(pixel_values)
+        hidden_states = self.embeddings(flat_pixel_values)
+        for encoder_layer in self.encoder:
+            hidden_states = encoder_layer(hidden_states)
+        hidden_states = self.post_layernorm(hidden_states)
+        return hidden_states.reshape([batch_size, num_images, hidden_states.shape[1], hidden_states.shape[2]])
+
+
+class ShieldGemma2MultiModalProjector(nn.Layer):
+    def __init__(self, config: ShieldGemma2Config):
+        super().__init__()
+        self.vision_hidden_size = config.vision_config.hidden_size
+        self.text_hidden_size = config.text_config.hidden_size
+        self.patches_per_image = int(config.vision_config.image_size // config.vision_config.patch_size)
+        self.tokens_per_side = int(config.mm_tokens_per_image**0.5)
+        self.kernel_size = self.patches_per_image // self.tokens_per_side
+        self.mm_input_projection_weight = self.create_parameter(
+            shape=[self.vision_hidden_size, self.text_hidden_size],
+            dtype=paddle.get_default_dtype(),
+            default_initializer=nn.initializer.Normal(std=config.initializer_range),
+        )
+        self.mm_soft_emb_norm = Gemma3RMSNorm(
+            self.vision_hidden_size, eps=getattr(config.vision_config, "layer_norm_eps", 1e-6)
+        )
+        self.avg_pool = nn.AvgPool2D(kernel_size=self.kernel_size, stride=self.kernel_size)
+
+    def forward(self, vision_outputs: paddle.Tensor) -> paddle.Tensor:
+        batch_size, num_images, _, hidden_size = vision_outputs.shape
+        reshaped_vision_outputs = vision_outputs.reshape(
+            [batch_size * num_images, self.patches_per_image * self.patches_per_image, hidden_size]
+        )
+        reshaped_vision_outputs = reshaped_vision_outputs.transpose([0, 2, 1])
+        reshaped_vision_outputs = reshaped_vision_outputs.reshape(
+            [batch_size * num_images, hidden_size, self.patches_per_image, self.patches_per_image]
+        )
+
+        pooled_vision_outputs = self.avg_pool(reshaped_vision_outputs)
+        pooled_vision_outputs = pooled_vision_outputs.flatten(start_axis=2).transpose([0, 2, 1])
+        normed_vision_outputs = self.mm_soft_emb_norm(pooled_vision_outputs)
+        projected_vision_outputs = paddle.matmul(normed_vision_outputs, self.mm_input_projection_weight)
+        projected_vision_outputs = projected_vision_outputs.astype(vision_outputs.dtype)
+        return projected_vision_outputs.reshape([batch_size, num_images * projected_vision_outputs.shape[1], -1])
+
+
+class ShieldGemma2MultiModalModel(nn.Layer):
+    def __init__(self, config: ShieldGemma2Config):
+        super().__init__()
+        self.config = config
+        self.language_model = Gemma3ForConditionalGeneration(config)
+        self.vision_tower = ShieldGemma2VisionTower(config)
+        self.multi_modal_projector = ShieldGemma2MultiModalProjector(config)
+
+    def get_input_embeddings(self):
+        return self.language_model.get_input_embeddings()
+
+    def set_input_embeddings(self, value):
+        self.language_model.set_input_embeddings(value)
+
+    def get_output_embeddings(self):
+        return self.language_model.get_output_embeddings()
+
+    def set_output_embeddings(self, new_embeddings):
+        self.language_model.set_output_embeddings(new_embeddings)
+
+    def get_image_features(self, pixel_values: paddle.Tensor) -> paddle.Tensor:
+        image_features = self.vision_tower(pixel_values)
+        return self.multi_modal_projector(image_features)
+
+    def _merge_image_features(
+        self,
+        input_ids: paddle.Tensor,
+        inputs_embeds: paddle.Tensor,
+        image_features: paddle.Tensor,
+    ) -> paddle.Tensor:
+        image_mask = input_ids == self.config.image_token_index
+        tokens_per_sample = image_features.shape[1]
+        merged_embeds = paddle.clone(inputs_embeds)
+
+        for batch_idx in range(input_ids.shape[0]):
+            image_positions = paddle.nonzero(image_mask[batch_idx]).flatten()
+            if image_positions.shape[0] != tokens_per_sample:
+                raise ValueError(
+                    "Image features and image placeholders do not match for sample "
+                    f"{batch_idx}: found {image_positions.shape[0]} placeholders but expected {tokens_per_sample}."
+                )
+            if image_positions.shape[0] > 0:
+                merged_embeds[batch_idx, image_positions, :] = image_features[batch_idx].astype(merged_embeds.dtype)
+
+        return merged_embeds
+
+    def forward(
+        self,
+        input_ids: Optional[paddle.Tensor] = None,
+        pixel_values: Optional[paddle.Tensor] = None,
+        attention_mask: Optional[paddle.Tensor] = None,
+        position_ids: Optional[paddle.Tensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[paddle.Tensor] = None,
+        labels: Optional[paddle.Tensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        **kwargs,
+    ):
+        if input_ids is None and inputs_embeds is None:
+            raise ValueError("You must specify either `input_ids` or `inputs_embeds`.")
+
+        if inputs_embeds is None:
+            if input_ids is None:
+                raise ValueError("`input_ids` is required when `inputs_embeds` is not provided.")
+            inputs_embeds = self.get_input_embeddings()(input_ids)
+
+        if pixel_values is not None:
+            if input_ids is None:
+                raise ValueError("`input_ids` is required when `pixel_values` are provided.")
+            image_features = self.get_image_features(pixel_values).astype(inputs_embeds.dtype)
+            inputs_embeds = self._merge_image_features(input_ids, inputs_embeds, image_features)
+
+        return self.language_model(
+            input_ids=input_ids,
+            pixel_values=pixel_values,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            token_type_ids=kwargs.pop("token_type_ids", None),
+            inputs_embeds=inputs_embeds,
+            labels=labels,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=True,
+            **kwargs,
+        )
+
+
+class ShieldGemma2ForImageClassification(Gemma3ForConditionalGeneration):
+    config_class = ShieldGemma2Config
+    base_model_prefix = "backbone"
+    input_modalities = ("image", "text")
+
+    def __init__(self, config: ShieldGemma2Config):
+        config.tie_word_embeddings = False
+        config.text_config.tie_word_embeddings = False
+        super().__init__(config)
+        self.yes_token_index = getattr(config, "yes_token_index", 10784)
+        self.no_token_index = getattr(config, "no_token_index", 3771)
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, *args, **kwargs):
+        is_hf_safetensors = (
+            isinstance(pretrained_model_name_or_path, str)
+            and os.path.isdir(pretrained_model_name_or_path)
+            and (
+                os.path.exists(os.path.join(pretrained_model_name_or_path, "model.safetensors"))
+                or os.path.exists(os.path.join(pretrained_model_name_or_path, "model.safetensors.index.json"))
+            )
+        )
+        if not is_hf_safetensors:
+            return super().from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+
+        config = kwargs.pop("config", None)
+        dtype = kwargs.pop("dtype", None)
+        if not isinstance(config, PretrainedConfig):
+            config = cls.config_class.from_pretrained(pretrained_model_name_or_path)
+        if dtype is not None:
+            config.dtype = dtype
+        with dtype_guard(dtype or paddle.get_default_dtype()):
+            model = cls(config, *args)
+        target_state_dict = model.state_dict()
+        state_dict = load_hf_text_state_dict(
+            pretrained_model_name_or_path,
+            config.text_config,
+            model_prefix="model.language_model.",
+            # ShieldGemma2's HF checkpoint intentionally omits lm_head.  The
+            # Torch implementation initializes this task head in post_init;
+            # copying the tied embedding here would change its semantics.
+            include_lm_head=False,
+            source_prefix="model.language_model.",
+        )
+
+        for hf_key, tensor in _iter_hf_tensors(pretrained_model_name_or_path):
+            if hf_key.startswith("model.vision_tower.vision_model."):
+                target_key = "model.vision_tower." + hf_key[len("model.vision_tower.vision_model.") :]
+            elif hf_key.startswith("model.multi_modal_projector."):
+                target_key = "model." + hf_key[len("model.") :]
+            else:
+                continue
+            if target_key not in target_state_dict:
+                continue
+            state_dict[target_key] = _convert_hf_vision_tensor(target_key, tensor)
+
+        for name, tensor in list(state_dict.items()):
+            if name in target_state_dict and tensor.dtype != target_state_dict[name].dtype:
+                state_dict[name] = tensor.astype(target_state_dict[name].dtype)
+        missing_keys, unexpected_keys = model.set_state_dict(state_dict)
+        if missing_keys or unexpected_keys:
+            logger.warning(
+                f"HF ShieldGemma2 checkpoint load finished with missing keys {missing_keys} "
+                f"and unexpected keys {unexpected_keys}"
+            )
+        return model
+
+    @classmethod
+    def _gen_aoa_config(cls, config: ShieldGemma2Config):
+        aoa_config = super()._gen_aoa_config(config)
+        statements = []
+        for statement in aoa_config["aoa_statements"]:
+            sources, target = statement.split(" -> ", 1)
+            prefixed_sources = ", ".join(f"model.{source}" for source in sources.split(", "))
+            statements.append(f"{prefixed_sources} -> {target}")
+        return {"aoa_statements": statements}
+
+    def forward(
+        self,
+        input_ids: Optional[paddle.Tensor] = None,
+        pixel_values: Optional[paddle.Tensor] = None,
+        attention_mask: Optional[paddle.Tensor] = None,
+        position_ids: Optional[paddle.Tensor] = None,
+        past_key_values: Optional[Cache] = None,
+        token_type_ids: Optional[paddle.Tensor] = None,
+        cache_position: Optional[paddle.Tensor] = None,
+        inputs_embeds: Optional[paddle.Tensor] = None,
+        labels: Optional[paddle.Tensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        logits_to_keep=0,
+        **kwargs,
+    ) -> ShieldGemma2ImageClassifierOutputWithNoAttention:
+        outputs = super().forward(
+            input_ids=input_ids,
+            pixel_values=pixel_values,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            token_type_ids=token_type_ids,
+            cache_position=cache_position,
+            inputs_embeds=inputs_embeds,
+            labels=labels,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=True,
+            logits_to_keep=logits_to_keep,
+            **kwargs,
+        )
+
+        last_token_logits = outputs.logits[:, -1, :]
+        index_tensor = paddle.to_tensor([self.yes_token_index, self.no_token_index], dtype="int64")
+        selected_logits = paddle.index_select(last_token_logits, index=index_tensor, axis=-1)
+        probabilities = F.softmax(selected_logits, axis=-1)
+
+        return ShieldGemma2ImageClassifierOutputWithNoAttention(
+            loss=outputs.loss,
+            logits=selected_logits,
+            hidden_states=outputs.hidden_states,
+            probabilities=probabilities,
+        )
+
+
+__all__ = ["ShieldGemma2ForImageClassification", "ShieldGemma2ImageClassifierOutputWithNoAttention"]

--- a/paddleformers/transformers/shieldgemma2/modeling.py
+++ b/paddleformers/transformers/shieldgemma2/modeling.py
@@ -21,14 +21,18 @@ import paddle
 import paddle.nn.functional as F
 from paddle import nn
 
+from ...utils.log import logger
 from ..activations import ACT2FN
 from ..cache_utils import Cache
 from ..configuration_utils import PretrainedConfig
 from ..gemma3.modeling import Gemma3ForConditionalGeneration, _convert_hf_vision_tensor
-from ..gemma3.multimodal_text_modeling import Gemma3RMSNorm, _iter_hf_tensors, load_hf_text_state_dict
+from ..gemma3.multimodal_text_modeling import (
+    Gemma3RMSNorm,
+    _iter_hf_tensors,
+    load_hf_text_state_dict,
+)
 from ..model_outputs import ImageClassifierOutputWithNoAttention
 from ..model_utils import dtype_guard
-from ...utils.log import logger
 from .configuration import ShieldGemma2Config
 
 

--- a/paddleformers/transformers/shieldgemma2/processor.py
+++ b/paddleformers/transformers/shieldgemma2/processor.py
@@ -19,7 +19,6 @@ from ..gemma3.processor import Gemma3Processor, Gemma3ProcessorKwargs
 from ..image_utils import ImageInput
 from ..processing_utils import Unpack
 
-
 DEFAULT_SHIELDGEMMA2_POLICIES: Mapping[str, str] = {
     "dangerous": (
         "No Dangerous Content: The image shall not contain content that"
@@ -61,9 +60,7 @@ class ShieldGemma2Processor(Gemma3Processor):
         **kwargs,
     ):
         super().__init__(image_processor, tokenizer, chat_template, image_seq_length, **kwargs)
-        self.policy_definitions = (
-            DEFAULT_SHIELDGEMMA2_POLICIES if policy_definitions is None else policy_definitions
-        )
+        self.policy_definitions = DEFAULT_SHIELDGEMMA2_POLICIES if policy_definitions is None else policy_definitions
 
     def __call__(
         self,
@@ -106,9 +103,7 @@ class ShieldGemma2Processor(Gemma3Processor):
             if not isinstance(image, list):
                 image = [image]
             elif len(image) > 1:
-                raise ValueError(
-                    f"ShieldGemma2 can process at most one image per sample, but got {len(image)} images"
-                )
+                raise ValueError(f"ShieldGemma2 can process at most one image per sample, but got {len(image)} images")
 
             for policy in policies:
                 if policy not in policy_definitions:

--- a/paddleformers/transformers/shieldgemma2/processor.py
+++ b/paddleformers/transformers/shieldgemma2/processor.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Mapping, Sequence
+
+from ..feature_extraction_utils import BatchFeature
+from ..gemma3.processor import Gemma3Processor, Gemma3ProcessorKwargs
+from ..image_utils import ImageInput
+from ..processing_utils import Unpack
+
+
+DEFAULT_SHIELDGEMMA2_POLICIES: Mapping[str, str] = {
+    "dangerous": (
+        "No Dangerous Content: The image shall not contain content that"
+        " facilitates or encourages activities that could cause real-world harm"
+        " (e.g., building firearms and explosive devices, promotion of"
+        " terrorism, instructions for suicide)."
+    ),
+    "sexual": (
+        "No Sexually Explicit content: The image shall not contain content that"
+        " depicts explicit or graphic sexual acts (e.g., pornography, erotic"
+        " nudity, depictions of rape or sexual assault)."
+    ),
+    "violence": (
+        "No Violence/Gore content: The image shall not contain content that"
+        " depicts shocking, sensational, or gratuitous violence (e.g.,"
+        " excessive blood and gore, gratuitous violence against animals,"
+        " extreme injury or moment of death)."
+    ),
+}
+
+
+class ShieldGemma2ProcessorKwargs(Gemma3ProcessorKwargs, total=False):
+    policies: Sequence[str] | None
+    custom_policies: Mapping[str, str] | None
+    _defaults = {
+        "text_kwargs": {"padding": True},
+        "images_kwargs": {"do_pan_and_scan": False},
+    }
+
+
+class ShieldGemma2Processor(Gemma3Processor):
+    def __init__(
+        self,
+        image_processor,
+        tokenizer,
+        chat_template=None,
+        image_seq_length=256,
+        policy_definitions=None,
+        **kwargs,
+    ):
+        super().__init__(image_processor, tokenizer, chat_template, image_seq_length, **kwargs)
+        self.policy_definitions = (
+            DEFAULT_SHIELDGEMMA2_POLICIES if policy_definitions is None else policy_definitions
+        )
+
+    def __call__(
+        self,
+        images: ImageInput | None = None,
+        text=None,
+        **kwargs: Unpack[ShieldGemma2ProcessorKwargs],
+    ) -> BatchFeature:
+        if not images:
+            raise ValueError("ShieldGemma 2 needs images to classify")
+        if not isinstance(images, Sequence):
+            images = [images]
+
+        if not self.chat_template:
+            raise ValueError("ShieldGemma 2 requires the use of a specific chat template")
+
+        common_kwargs = kwargs.setdefault("common_kwargs", {})
+        if "return_tensors" in kwargs:
+            common_kwargs["return_tensors"] = kwargs.pop("return_tensors")
+
+        images_kwargs = kwargs.setdefault("images_kwargs", {})
+        if images_kwargs.get("do_pan_and_scan") is True:
+            images_kwargs["do_pan_and_scan"] = False
+
+        text_kwargs = kwargs.setdefault("text_kwargs", {})
+        if "padding" not in text_kwargs:
+            text_kwargs["padding"] = kwargs.pop("padding", True)
+            text_kwargs["padding_side"] = kwargs.pop("padding_side", "left")
+
+        policy_definitions: Mapping[str, str] = {
+            **self.policy_definitions,
+            **(kwargs.get("custom_policies") or {}),
+        }
+        policies = kwargs.get("policies")
+        if policies is None:
+            policies = list(policy_definitions.keys())
+
+        messages = []
+        expanded_images = []
+        for image in images:
+            if not isinstance(image, list):
+                image = [image]
+            elif len(image) > 1:
+                raise ValueError(
+                    f"ShieldGemma2 can process at most one image per sample, but got {len(image)} images"
+                )
+
+            for policy in policies:
+                if policy not in policy_definitions:
+                    raise ValueError(f"Unknown ShieldGemma2 policy: {policy}")
+                content = []
+                if image:
+                    content.append({"type": "image"})
+                content.append({"type": "text", "text": policy_definitions[policy]})
+                messages.append([{"role": "user", "content": content}])
+                expanded_images.append(image)
+
+        text = self.apply_chat_template(messages, tokenize=False)
+        return super().__call__(images=expanded_images, text=text, **kwargs)
+
+
+__all__ = [
+    "DEFAULT_SHIELDGEMMA2_POLICIES",
+    "ShieldGemma2Processor",
+    "ShieldGemma2ProcessorKwargs",
+]

--- a/paddleformers/transformers/shieldgemma2/processor.py
+++ b/paddleformers/transformers/shieldgemma2/processor.py
@@ -68,7 +68,7 @@ class ShieldGemma2Processor(Gemma3Processor):
         text=None,
         **kwargs: Unpack[ShieldGemma2ProcessorKwargs],
     ) -> BatchFeature:
-        if not images:
+        if images is None or (isinstance(images, Sequence) and len(images) == 0):
             raise ValueError("ShieldGemma 2 needs images to classify")
         if not isinstance(images, Sequence):
             images = [images]

--- a/tests/transformers/gemma3/__init__.py
+++ b/tests/transformers/gemma3/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/transformers/gemma3/test_modeling.py
+++ b/tests/transformers/gemma3/test_modeling.py
@@ -125,6 +125,42 @@ class Gemma3ModelTest(unittest.TestCase):
             (self.model_tester.batch_size, self.model_tester.mm_tokens_per_image, self.model_tester.hidden_size),
         )
 
+    def test_logits_to_keep_tensor_selects_requested_tokens(self):
+        config, input_ids, token_type_ids, pixel_values = self.model_tester.prepare_config_and_inputs()
+        model = Gemma3ForConditionalGeneration(config)
+        model.eval()
+
+        outputs = model(
+            input_ids=input_ids,
+            token_type_ids=token_type_ids,
+            pixel_values=pixel_values,
+            logits_to_keep=paddle.to_tensor([0, 3, 7], dtype="int64"),
+            return_dict=True,
+        )
+
+        self.assertEqual(
+            tuple(outputs.logits.shape),
+            (self.model_tester.batch_size, 3, self.model_tester.vocab_size),
+        )
+
+    def test_generation_drops_pixel_values_after_prefill(self):
+        model = Gemma3ForConditionalGeneration(self.model_tester.get_config())
+        pixel_values = paddle.randn([1, 3, 16, 16], dtype="float32")
+
+        with mock.patch(
+            "paddleformers.generation.utils.GenerationMixin.prepare_inputs_for_generation",
+            return_value={"pixel_values": pixel_values},
+        ):
+            model_inputs = model.prepare_inputs_for_generation(
+                paddle.ones([1, 1], dtype="int64"),
+                past_key_values=object(),
+                pixel_values=pixel_values,
+                use_cache=True,
+                is_first_iteration=False,
+            )
+
+        self.assertIsNone(model_inputs["pixel_values"])
+
     def test_auto_model_registration(self):
         config = self.model_tester.get_config()
 

--- a/tests/transformers/gemma3/test_modeling.py
+++ b/tests/transformers/gemma3/test_modeling.py
@@ -31,11 +31,11 @@ from paddleformers.transformers import (
     Gemma3ForConditionalGeneration,
     Gemma3TextModel,
 )
-from paddleformers.transformers.gemma3_text.configuration import Gemma3TextConfig
 from paddleformers.transformers.gemma3.modeling import (
     _convert_hf_vision_tensor,
     _use_high_precision_cublas_for_fp32,
 )
+from paddleformers.transformers.gemma3_text.configuration import Gemma3TextConfig
 from tests.transformers.test_configuration_common import ConfigTester
 
 
@@ -205,12 +205,8 @@ class Gemma3ModelTest(unittest.TestCase):
     def test_hf_vision_linear_weight_conversion(self):
         tensor = paddle.arange(6, dtype="float32").reshape([2, 3])
 
-        converted = _convert_hf_vision_tensor(
-            "model.vision_tower.encoder.layers.0.mlp.fc1.weight", tensor
-        )
-        unchanged = _convert_hf_vision_tensor(
-            "model.vision_tower.embeddings.position_embedding.weight", tensor
-        )
+        converted = _convert_hf_vision_tensor("model.vision_tower.encoder.layers.0.mlp.fc1.weight", tensor)
+        unchanged = _convert_hf_vision_tensor("model.vision_tower.embeddings.position_embedding.weight", tensor)
 
         self.assertTrue(paddle.equal_all(converted, tensor.transpose([1, 0])))
         self.assertIs(unchanged, tensor)

--- a/tests/transformers/gemma3/test_modeling.py
+++ b/tests/transformers/gemma3/test_modeling.py
@@ -1,0 +1,232 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import paddle
+
+import paddleformers.transformers as transformers_module
+from paddleformers.transformers import (
+    AutoModel,
+    AutoModelForConditionalGeneration,
+    Gemma3Config,
+    Gemma3ForCausalLM,
+    Gemma3ForConditionalGeneration,
+    Gemma3TextModel,
+)
+from paddleformers.transformers.gemma3_text.configuration import Gemma3TextConfig
+from paddleformers.transformers.gemma3.modeling import (
+    _convert_hf_vision_tensor,
+    _use_high_precision_cublas_for_fp32,
+)
+from tests.transformers.test_configuration_common import ConfigTester
+
+
+class Gemma3ModelTester:
+    def __init__(self, parent, batch_size=2, seq_length=8, vocab_size=64, hidden_size=32):
+        self.parent = parent
+        self.batch_size = batch_size
+        self.seq_length = seq_length
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.image_token_index = 5
+        self.mm_tokens_per_image = 4
+
+    def get_config(self):
+        return Gemma3Config(
+            text_config={
+                "vocab_size": self.vocab_size,
+                "hidden_size": self.hidden_size,
+                "intermediate_size": 64,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "head_dim": 8,
+                "max_position_embeddings": 64,
+                "query_pre_attn_scalar": 8,
+                "sliding_window": 16,
+                "pad_token_id": 0,
+            },
+            vision_config={
+                "hidden_size": self.hidden_size,
+                "intermediate_size": 64,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 4,
+                "image_size": 16,
+                "patch_size": 4,
+            },
+            image_token_index=self.image_token_index,
+            mm_tokens_per_image=self.mm_tokens_per_image,
+        )
+
+    def prepare_config_and_inputs(self):
+        config = self.get_config()
+        input_ids = paddle.randint(6, self.vocab_size, shape=[self.batch_size, self.seq_length], dtype="int64")
+        input_ids[:, 1 : 1 + self.mm_tokens_per_image] = self.image_token_index
+        token_type_ids = paddle.zeros_like(input_ids)
+        token_type_ids[:, 1 : 1 + self.mm_tokens_per_image] = 1
+        pixel_values = paddle.randn([self.batch_size, 3, 16, 16], dtype="float32")
+        return config, input_ids, token_type_ids, pixel_values
+
+
+class Gemma3ModelTest(unittest.TestCase):
+    def setUp(self):
+        self.model_tester = Gemma3ModelTester(self)
+        self.config_tester = ConfigTester(self, config_class=Gemma3Config, has_text_modality=False)
+
+    def test_config(self):
+        self.config_tester.run_common_tests()
+
+    def test_config_round_trip(self):
+        config = self.model_tester.get_config()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.save_pretrained(tmpdir)
+            loaded_config = Gemma3Config.from_pretrained(tmpdir)
+
+        self.assertIsInstance(loaded_config, Gemma3Config)
+        self.assertEqual(loaded_config.text_config.model_type, "gemma3_text")
+        self.assertEqual(loaded_config.vision_config.model_type, "siglip_vision_model")
+
+    def test_model_forward(self):
+        config, input_ids, token_type_ids, pixel_values = self.model_tester.prepare_config_and_inputs()
+        model = Gemma3ForConditionalGeneration(config)
+        model.eval()
+
+        outputs = model(
+            input_ids=input_ids,
+            token_type_ids=token_type_ids,
+            pixel_values=pixel_values,
+            return_dict=True,
+        )
+
+        self.assertEqual(
+            tuple(outputs.logits.shape),
+            (self.model_tester.batch_size, self.model_tester.seq_length, self.model_tester.vocab_size),
+        )
+        self.assertEqual(
+            tuple(outputs.image_hidden_states.shape),
+            (self.model_tester.batch_size, self.model_tester.mm_tokens_per_image, self.model_tester.hidden_size),
+        )
+
+    def test_auto_model_registration(self):
+        config = self.model_tester.get_config()
+
+        auto_model = AutoModel.from_config(config)
+        auto_conditional_model = AutoModelForConditionalGeneration.from_config(config)
+
+        self.assertEqual(type(auto_model).__name__, "Gemma3Model")
+        self.assertIsInstance(auto_conditional_model, Gemma3ForConditionalGeneration)
+
+    def test_gemma3_text_auto_model_compatibility(self):
+        text_config = Gemma3TextConfig(
+            vocab_size=64,
+            hidden_size=32,
+            intermediate_size=64,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=8,
+            max_position_embeddings=64,
+        )
+
+        text_model = AutoModel.from_config(text_config)
+
+        self.assertEqual(type(text_model).__name__, "Gemma3TextModel")
+
+    def test_top_level_exports_resolve_to_upstream_gemma3_text(self):
+        self.assertEqual(transformers_module._class_to_module["Gemma3Config"], "gemma3.configuration")
+        self.assertEqual(transformers_module._class_to_module["Gemma3TextConfig"], "gemma3_text.configuration")
+        self.assertEqual(transformers_module._class_to_module["Gemma3TextModel"], "gemma3_text.modeling")
+        self.assertEqual(transformers_module._class_to_module["Gemma3ForCausalLM"], "gemma3_text.modeling")
+        self.assertEqual(Gemma3Config.__module__, "paddleformers.transformers.gemma3.configuration")
+        self.assertEqual(Gemma3ForCausalLM.__module__, "paddleformers.transformers.gemma3_text.modeling")
+
+    def test_multimodal_uses_private_text_backbone(self):
+        model = Gemma3ForConditionalGeneration(self.model_tester.get_config())
+        self.assertEqual(Gemma3TextModel.__module__, "paddleformers.transformers.gemma3_text.modeling")
+        self.assertEqual(
+            model.model.language_model.__class__.__module__,
+            "paddleformers.transformers.gemma3.multimodal_text_modeling",
+        )
+
+    def test_hf_vision_linear_weight_conversion(self):
+        tensor = paddle.arange(6, dtype="float32").reshape([2, 3])
+
+        converted = _convert_hf_vision_tensor(
+            "model.vision_tower.encoder.layers.0.mlp.fc1.weight", tensor
+        )
+        unchanged = _convert_hf_vision_tensor(
+            "model.vision_tower.embeddings.position_embedding.weight", tensor
+        )
+
+        self.assertTrue(paddle.equal_all(converted, tensor.transpose([1, 0])))
+        self.assertIs(unchanged, tensor)
+
+    def test_fp32_gpu_disables_tf32_cublas(self):
+        fake_tensor = SimpleNamespace(
+            dtype=paddle.float32,
+            place=SimpleNamespace(is_gpu_place=lambda: True),
+        )
+        with (
+            mock.patch("paddle.base.core.get_cublas_switch", return_value=True),
+            mock.patch("paddle.base.core.set_cublas_switch") as set_cublas_switch,
+        ):
+            _use_high_precision_cublas_for_fp32(fake_tensor)
+
+        set_cublas_switch.assert_called_once_with(False)
+
+    def test_image_token_mismatch_raises(self):
+        config = self.model_tester.get_config()
+        model = Gemma3ForConditionalGeneration(config)
+        input_ids = paddle.randint(
+            6,
+            self.model_tester.vocab_size,
+            shape=[self.model_tester.batch_size, self.model_tester.seq_length],
+            dtype="int64",
+        )
+        input_ids[:, 1:3] = self.model_tester.image_token_index
+        token_type_ids = paddle.zeros_like(input_ids)
+        token_type_ids[:, 1:3] = 1
+        pixel_values = paddle.randn([self.model_tester.batch_size, 3, 16, 16], dtype="float32")
+
+        with self.assertRaises(ValueError):
+            model(
+                input_ids=input_ids,
+                token_type_ids=token_type_ids,
+                pixel_values=pixel_values,
+                return_dict=True,
+            )
+
+    def test_embedding_accessors(self):
+        config = self.model_tester.get_config()
+        model = Gemma3ForConditionalGeneration(config)
+
+        self.assertIsNotNone(model.get_input_embeddings())
+        self.assertIsNotNone(model.get_output_embeddings())
+
+    def test_paddle_checkpoint_round_trip_honors_dtype(self):
+        model = Gemma3ForConditionalGeneration(self.model_tester.get_config())
+        with tempfile.TemporaryDirectory() as tmpdir:
+            model.config.save_pretrained(tmpdir)
+            paddle.save(model.state_dict(), str(Path(tmpdir) / "model_state.pdparams"))
+            loaded = Gemma3ForConditionalGeneration.from_pretrained(tmpdir, dtype="bfloat16")
+
+        parameter_dtypes = {parameter.dtype for parameter in loaded.parameters()}
+        self.assertEqual(parameter_dtypes, {paddle.bfloat16})

--- a/tests/transformers/shieldgemma2/__init__.py
+++ b/tests/transformers/shieldgemma2/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/transformers/shieldgemma2/test_modeling.py
+++ b/tests/transformers/shieldgemma2/test_modeling.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import tempfile
+import unittest
+
+import paddle
+
+from paddleformers.transformers import (
+    ShieldGemma2Config,
+    ShieldGemma2ForImageClassification,
+)
+from tests.transformers.test_configuration_common import ConfigTester
+
+
+class ShieldGemma2ModelTester:
+    def __init__(self, parent, batch_size=2, seq_length=8, vocab_size=64, hidden_size=32):
+        self.parent = parent
+        self.batch_size = batch_size
+        self.seq_length = seq_length
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.image_token_index = 5
+        self.mm_tokens_per_image = 4
+
+    def get_config(self):
+        return ShieldGemma2Config(
+            text_config={
+                "vocab_size": self.vocab_size,
+                "hidden_size": self.hidden_size,
+                "intermediate_size": 64,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "head_dim": 8,
+                "max_position_embeddings": 64,
+                "rope_theta": 10000.0,
+                "query_pre_attn_scalar": 8,
+                "sliding_window": 16,
+            },
+            vision_config={"hidden_size": 32, "image_size": 16, "patch_size": 4},
+            image_token_index=self.image_token_index,
+            mm_tokens_per_image=self.mm_tokens_per_image,
+            yes_token_index=3,
+            no_token_index=7,
+        )
+
+    def prepare_config_and_inputs(self):
+        config = self.get_config()
+        input_ids = paddle.randint(0, self.vocab_size, shape=[self.batch_size, self.seq_length], dtype="int64")
+        input_ids[:, 1 : 1 + self.mm_tokens_per_image] = self.image_token_index
+        pixel_values = paddle.randn([self.batch_size, 3, 16, 16], dtype="float32")
+        return config, input_ids, pixel_values
+
+
+class ShieldGemma2ModelTest(unittest.TestCase):
+    def setUp(self):
+        self.model_tester = ShieldGemma2ModelTester(self)
+        self.config_tester = ConfigTester(self, config_class=ShieldGemma2Config, has_text_modality=False)
+
+    def test_config(self):
+        self.config_tester.run_common_tests()
+
+    def test_config_round_trip(self):
+        config = self.model_tester.get_config()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.save_pretrained(tmpdir)
+            loaded_config = ShieldGemma2Config.from_pretrained(tmpdir)
+        self.assertIsInstance(loaded_config, ShieldGemma2Config)
+        self.assertEqual(loaded_config.text_config.model_type, "gemma3_text")
+        self.assertEqual(loaded_config.vision_config.model_type, "shieldgemma2_vision")
+
+    def test_model_forward(self):
+        config, input_ids, pixel_values = self.model_tester.prepare_config_and_inputs()
+        model = ShieldGemma2ForImageClassification(config)
+        model.eval()
+
+        outputs = model(input_ids=input_ids, pixel_values=pixel_values, return_dict=True)
+
+        self.assertEqual(outputs.logits.shape, [self.model_tester.batch_size, 2])
+        self.assertEqual(outputs.probabilities.shape, [self.model_tester.batch_size, 2])
+        self.assertTrue(
+            paddle.allclose(
+                outputs.probabilities.sum(axis=-1),
+                paddle.ones([self.model_tester.batch_size], dtype=outputs.probabilities.dtype),
+            ).item()
+        )
+
+    def test_pixel_values_affect_outputs(self):
+        paddle.seed(1234)
+        config, input_ids, _ = self.model_tester.prepare_config_and_inputs()
+        model = ShieldGemma2ForImageClassification(config)
+        model.eval()
+
+        dark_pixels = paddle.zeros([self.model_tester.batch_size, 3, 16, 16], dtype="float32")
+        bright_pixels = paddle.ones([self.model_tester.batch_size, 3, 16, 16], dtype="float32")
+
+        dark_outputs = model(input_ids=input_ids, pixel_values=dark_pixels, return_dict=True)
+        bright_outputs = model(input_ids=input_ids, pixel_values=bright_pixels, return_dict=True)
+
+        self.assertFalse(paddle.allclose(dark_outputs.logits, bright_outputs.logits).item())
+
+    def test_image_token_mismatch_raises(self):
+        config = self.model_tester.get_config()
+        model = ShieldGemma2ForImageClassification(config)
+        input_ids = paddle.randint(
+            0,
+            self.model_tester.vocab_size,
+            shape=[self.model_tester.batch_size, self.model_tester.seq_length],
+            dtype="int64",
+        )
+        input_ids[:, 1:3] = self.model_tester.image_token_index
+        pixel_values = paddle.randn([self.model_tester.batch_size, 3, 16, 16], dtype="float32")
+
+        with self.assertRaises(ValueError):
+            model(input_ids=input_ids, pixel_values=pixel_values, return_dict=True)
+
+    def test_embedding_accessors(self):
+        config = self.model_tester.get_config()
+        model = ShieldGemma2ForImageClassification(config)
+        self.assertIsNotNone(model.get_input_embeddings())
+        self.assertIsNotNone(model.get_output_embeddings())

--- a/tests/transformers/shieldgemma2/test_modeling.py
+++ b/tests/transformers/shieldgemma2/test_modeling.py
@@ -19,6 +19,7 @@ import unittest
 import paddle
 
 from paddleformers.transformers import (
+    AutoModel,
     ShieldGemma2Config,
     ShieldGemma2ForImageClassification,
 )
@@ -81,6 +82,10 @@ class ShieldGemma2ModelTest(unittest.TestCase):
         self.assertIsInstance(loaded_config, ShieldGemma2Config)
         self.assertEqual(loaded_config.text_config.model_type, "gemma3_text")
         self.assertEqual(loaded_config.vision_config.model_type, "shieldgemma2_vision")
+
+    def test_auto_model_registration(self):
+        model = AutoModel.from_config(self.model_tester.get_config())
+        self.assertIsInstance(model, ShieldGemma2ForImageClassification)
 
     def test_model_forward(self):
         config, input_ids, pixel_values = self.model_tester.prepare_config_and_inputs()

--- a/tests/transformers/shieldgemma2/test_processor.py
+++ b/tests/transformers/shieldgemma2/test_processor.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import patch
+
+from paddleformers.transformers import ShieldGemma2Processor
+from paddleformers.transformers.auto.processing import processor_class_from_name
+from paddleformers.transformers.gemma3.processor import Gemma3Processor
+
+
+class _DummyTokenizer:
+    image_token_id = 1
+    image_token = "<image>"
+    boi_token = "<boi>"
+    eoi_token = "<eoi>"
+    init_kwargs = {}
+
+
+class _DummyImageProcessor:
+    pass
+
+
+class ShieldGemma2ProcessorTest(unittest.TestCase):
+    def setUp(self):
+        with patch.object(ShieldGemma2Processor, "check_argument_for_proper_class"):
+            self.processor = ShieldGemma2Processor(
+                _DummyImageProcessor(), _DummyTokenizer(), chat_template="dummy", image_seq_length=2
+            )
+
+    def test_processor_class_registration(self):
+        self.assertIs(processor_class_from_name("ShieldGemma2Processor"), ShieldGemma2Processor)
+
+    def test_policy_expansion_and_defaults(self):
+        rendered_messages = []
+
+        def render(messages, tokenize=False):
+            rendered_messages.extend(messages)
+            return ["rendered"] * len(messages)
+
+        with patch.object(self.processor, "apply_chat_template", side_effect=render), patch.object(
+            Gemma3Processor, "__call__", return_value="encoded"
+        ) as parent_call:
+            output = self.processor(
+                images=["image-a", "image-b"],
+                policies=["dangerous", "custom"],
+                custom_policies={"custom": "Custom policy"},
+                images_kwargs={"do_pan_and_scan": True},
+            )
+
+        self.assertEqual(output, "encoded")
+        self.assertEqual(len(rendered_messages), 4)
+        self.assertEqual(rendered_messages[0][0]["content"][0], {"type": "image"})
+        self.assertEqual(rendered_messages[1][0]["content"][-1]["text"], "Custom policy")
+        call_kwargs = parent_call.call_args.kwargs
+        self.assertEqual(call_kwargs["images"], [["image-a"], ["image-a"], ["image-b"], ["image-b"]])
+        self.assertFalse(call_kwargs["images_kwargs"]["do_pan_and_scan"])
+        self.assertTrue(call_kwargs["text_kwargs"]["padding"])
+
+    def test_processor_rejects_missing_images_or_chat_template(self):
+        with self.assertRaisesRegex(ValueError, "needs images"):
+            self.processor(images=[])
+
+        self.processor.chat_template = None
+        with self.assertRaisesRegex(ValueError, "requires the use"):
+            self.processor(images=["image"])
+
+    def test_processor_rejects_unknown_policy_and_multiple_images(self):
+        with self.assertRaisesRegex(ValueError, "Unknown ShieldGemma2 policy"):
+            self.processor(images=["image"], policies=["missing"])
+
+        with self.assertRaisesRegex(ValueError, "at most one image"):
+            self.processor(images=[["image-a", "image-b"]])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/transformers/shieldgemma2/test_processor.py
+++ b/tests/transformers/shieldgemma2/test_processor.py
@@ -15,6 +15,9 @@
 import unittest
 from unittest.mock import patch
 
+import numpy as np
+import paddle
+
 from paddleformers.transformers import ShieldGemma2Processor
 from paddleformers.transformers.auto.processing import processor_class_from_name
 from paddleformers.transformers.gemma3.processor import Gemma3Processor
@@ -70,6 +73,9 @@ class ShieldGemma2ProcessorTest(unittest.TestCase):
 
     def test_processor_rejects_missing_images_or_chat_template(self):
         with self.assertRaisesRegex(ValueError, "needs images"):
+            self.processor(images=None)
+
+        with self.assertRaisesRegex(ValueError, "needs images"):
             self.processor(images=[])
 
         self.processor.chat_template = None
@@ -82,6 +88,24 @@ class ShieldGemma2ProcessorTest(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "at most one image"):
             self.processor(images=[["image-a", "image-b"]])
+
+    def test_processor_accepts_single_array_or_tensor_image(self):
+        images = [
+            np.zeros((4, 4, 3), dtype=np.uint8),
+            paddle.zeros([3, 4, 4]),
+        ]
+
+        with patch.object(self.processor, "apply_chat_template", return_value=["rendered"]), patch.object(
+            Gemma3Processor, "__call__", return_value="encoded"
+        ) as parent_call:
+            for image in images:
+                with self.subTest(image_type=type(image).__name__):
+                    output = self.processor(images=image)
+
+                    self.assertEqual(output, "encoded")
+                    expanded_images = parent_call.call_args.kwargs["images"]
+                    self.assertEqual(len(expanded_images), len(self.processor.policy_definitions))
+                    self.assertTrue(all(batch[0] is image for batch in expanded_images))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## PR 类型
新增模型支持

## PR 说明
新增 `ShieldGemma2` 在 PaddleFormers 中的支持。

由于 `ShieldGemma2` 依赖 `Gemma3` 主干实现，因此本PR一并携带 `Gemma3` 依赖代码。对应 `gemma3` 支持也已拆分为独立 PR。

本 PR 包含：

- 在 `paddleformers/transformers/shieldgemma2` 下新增模型组网代码
- 在 `paddleformers/transformers/gemma3` 下携带 `ShieldGemma2` 所需依赖实现
- 补充 `AutoConfig` / `AutoModel` 相关注册
- 新增 `tests/transformers/shieldgemma2/test_modeling.py`
- 完成 Torch/HF 与 Paddle 的推理和训练对齐验证

## 推理对齐情况
对同一输入样本进行 Torch/HF 与 Paddle 前向对齐，结果如下：

- `top-10 token ids` 完全一致
- `yes/no` 分类 logits 对齐到 `1e-5` 量级


对应 `top-10 token ids`：
- Paddle: `[103085, 14553, 121486, 157028, 238170, 47609, 36008, 217152, 105916, 73655]`
- Torch/HF: `[103085, 14553, 121486, 157028, 238170, 47609, 36008, 217152, 105916, 73655]`

## ms-swift注册
  1. 在 ms-swift/swift/model/constant.py 里加一个模型类型

    class MLLMModelType:
        ...
        gemma3_vision = 'gemma3_vision'
        shieldgemma2 = 'shieldgemma2'

  2. 在 ms-swift/swift/model/models/gemma.py 里新增注册
模板复用 gemma3_vision

    import os
    from types import MethodType
  
    from transformers import GenerationConfig, PreTrainedModel
  
    from swift.template import TemplateType
    from ..constant import LLMModelType, MLLMModelType
    from ..model_arch import ModelArch
    from ..model_meta import Model, ModelGroup, ModelMeta
    from ..patcher import patch_output_to_input_device
    from ..register import ModelLoader, SentenceTransformersLoader, register_model
  
  
    class ShieldGemma2Loader(ModelLoader):
  
        def get_config(self, model_dir):
            # keep aligned with Gemma3 training path
            self.attn_impl = self.attn_impl or 'eager'
            return super().get_config(model_dir)
  
        def get_model(self, model_dir: str, config, processor, model_kwargs) -> PreTrainedModel:
            from torch import nn
            from transformers import ShieldGemma2ForImageClassification
  
            model = ShieldGemma2ForImageClassification.from_pretrained(
                model_dir,
                config=config,
                trust_remote_code=True,
                **model_kwargs,
            )
  
            # ms-swift sft path expects generation_config on the outer model
            if not hasattr(model, 'generation_config') or model.generation_config is None:
                inner_generation_config = getattr(model.model, 'generation_config', None)
                model.generation_config = inner_generation_config or GenerationConfig.from_model_config(model.config)
  
            # optional: keep validation deterministic
            if os.environ.get('DISABLE_DROPOUT', '1') == '1':
                for module in model.modules():
                    if isinstance(module, nn.Dropout):
                        module.p = 0.0
                    for attr in ('dropout', 'attention_dropout', 'activation_dropout'):
                        if hasattr(module, attr):
                            value = getattr(module, attr)
                            if isinstance(value, (int, float)):
                                setattr(module, attr, 0.0)
  
            original_forward = model.forward
  
            def _forward_with_lm_loss(self, *args, **kwargs):
                # training loss should come from inner Gemma3 conditional generation model
                if kwargs.get('labels', None) is None:
                    return original_forward(*args, **kwargs)
  
                inner_kwargs = {
                    'input_ids': kwargs.get('input_ids'),
                    'attention_mask': kwargs.get('attention_mask'),
                    'position_ids': kwargs.get('position_ids'),
                    'token_type_ids': kwargs.get('token_type_ids'),
                    'pixel_values': kwargs.get('pixel_values'),
                    'inputs_embeds': kwargs.get('inputs_embeds'),
                    'labels': kwargs.get('labels'),
                    'use_cache': False,
                    'return_dict': kwargs.get('return_dict', True),
                }
                inner_kwargs = {k: v for k, v in inner_kwargs.items() if v is not None}
                return self.model(**inner_kwargs)
  
            model.forward = MethodType(_forward_with_lm_loss, model)
            return model
  
  
    register_model(
        ModelMeta(
            MLLMModelType.shieldgemma2,
            [
                ModelGroup([
                    Model('google/shieldgemma-2-4b-it', 'google/shieldgemma-2-4b-it'),
                ]),
            ],
            ShieldGemma2Loader,
            template=TemplateType.gemma3_vision,
            architectures=['ShieldGemma2ForImageClassification'],
            model_arch=ModelArch.llava_hf,
            requires=['transformers>=4.49'],
            task_type='causal_lm',
            tags=['vision'],
        ))
 3. 训练时直接复用 gemma3_vision
 
## 训练对齐情况
使用 GSM8K 数据进行训练对齐验证（）。

| paddle loss | torch loss | diff |
| --- | --- | --- |
| 16.00169373 | 16.49606705 | -0.49437332 |
| 14.71333885 | 16.95349312 | -2.24015427 |
| 12.22286510 | 19.18050003 | -6.95763493 |
| 11.21158791 | 17.87071991 | -6.65913200 |
| 9.66808033 | 18.10136414 | -8.43328381 |
| 8.44376850 | 19.01485062 | -10.57108212 |
| 7.67826653 | 16.51401329 | -8.83574676 |
| 9.85611057 | 18.44094467 | -8.58483410 |
| 8.03356457 | 17.96991920 | -9.93635463 |
| 7.60740328 | 13.71025372 | -6.10285044 |
| 8.77243137 | 11.98634434 | -3.21391297 |
| 5.47642279 | 10.85439682 | -5.37797403 |
| 5.80109024 | 10.15167332 | -4.35058308 |
| 4.89205027 | 9.51164722 | -4.61959695 |
| 4.98916817 | 8.14846134 | -3.15929317 |
| 4.12202406 | 8.63837433 | -4.51635027 |
| 4.26863337 | 5.97669315 | -1.70805978 |
| 7.10579062 | 6.73086739 | 0.37492323 |
| 5.35105228 | 8.19053936 | -2.83948708 |
| 3.56379008 | 5.55994272 | -1.99615264 |
| 3.37518883 | 5.08673048 | -1.71154165 |
| 6.67938042 | 4.69946909 | 1.97991133 |
| 6.33457422 | 5.04648590 | 1.28808832 |
| 3.86823177 | 6.01899004 | -2.15075827 |
| 3.61999869 | 3.50136161 | 0.11863708 |
| 5.57703447 | 5.07118320 | 0.50585127 |
| 5.52485657 | 6.53269911 | -1.00784254 |
| 3.90741539 | 5.76341677 | -1.85600138 |
| 5.30978870 | 5.22436953 | 0.08541917 |
| 6.61713266 | 3.10578084 | 3.51135182 |
| 3.20617509 | 4.87641954 | -1.67024445 |
| 2.99516487 | 4.48868513 | -1.49352026 |
| 5.53285885 | 2.83593726 | 2.69692159 |
| 4.78122711 | 5.17554760 | -0.39432049 |
| 2.10321355 | 3.65890551 | -1.55569196 |
| 4.88998461 | 2.08641648 | 2.80356813 |
| 2.06521869 | 3.32727408 | -1.26205539 |
| 1.92053914 | 2.85104012 | -0.93050098 |
| 3.36463404 | 2.82646298 | 0.53817106 |
| 4.01963854 | 3.67929554 | 0.34034300 |
| 2.65473366 | 5.33922195 | -2.68448829 |
| 2.35188341 | 3.20224285 | -0.85035944 |
| 2.24985266 | 4.37660599 | -2.12675333 |
| 2.99977708 | 2.32494974 | 0.67482734 |
| 2.20928407 | 3.00671077 | -0.79742670 |
| 2.32395935 | 4.41969490 | -2.09573555 |
| 4.42433691 | 3.53861713 | 0.88571978 |
| 2.21135378 | 3.84755135 | -1.63619757 |
| 4.37625074 | 2.29686213 | 2.07938861 |
| 2.24772120 | 2.04504347 | 0.20267773 |
| 2.45447421 | 1.83361006 | 0.62086415 |
| 4.53304338 | 3.72673273 | 0.80631065 |
| 2.49710369 | 2.10875511 | 0.38834858 |
| 3.48686075 | 2.74079490 | 0.74606585 |
| 3.55673051 | 2.15397930 | 1.40275121 |
| 2.35233259 | 3.11158371 | -0.75925112 |
| 2.82058597 | 3.97401214 | -1.15342617 |
| 3.73818088 | 2.48388839 | 1.25429249 |
| 2.83329129 | 1.84142590 | 0.99186539 |
| 3.82988954 | 2.58507085 | 1.24481869 |
| 4.09733868 | 3.51621914 | 0.58111954 |
| 2.09185266 | 4.36878872 | -2.27693606 |
| 1.99270928 | 3.77091718 | -1.77820790 |
| 3.53731775 | 2.86979246 | 0.66752529 |
| 2.35056400 | 3.31573987 | -0.96517587 |
| 1.31469834 | 3.76502347 | -2.45032513 |
| 2.56759191 | 3.31528974 | -0.74769783 |
| 3.16971564 | 2.83173370 | 0.33798194 |
| 2.70302248 | 2.19158316 | 0.51143932 |
| 3.16695642 | 2.82044482 | 0.34651160 |
| 1.68660164 | 3.03851414 | -1.35191250 |
| 3.12188959 | 1.33334994 | 1.78853965 |
| 4.99617386 | 2.54442596 | 2.45174790 |
| 3.52140188 | 3.23061705 | 0.29078483 |
| 2.20802951 | 4.11522722 | -1.90719771 |
| 1.53144503 | 1.60658860 | -0.07514357 |
| 2.28293943 | 2.51524425 | -0.23230482 |
| 1.99344146 | 1.46567798 | 0.52776348 |
| 1.85814416 | 3.14762330 | -1.28947914 |
| 2.49384975 | 2.33078742 | 0.16306233 |
| 3.00237036 | 2.72561526 | 0.27675510 |
| 2.30961776 | 1.85101843 | 0.45859933 |
| 2.36047268 | 3.57117987 | -1.21070719 |
| 2.83624601 | 3.72562003 | -0.88937402 |
| 3.23331094 | 2.25343466 | 0.97987628 |
| 5.01312160 | 4.18181515 | 0.83130645 |
| 3.19645905 | 2.43944168 | 0.75701737 |
| 1.45707142 | 2.23586464 | -0.77879322 |
| 4.30001736 | 2.67853880 | 1.62147856 |
| 3.68523908 | 2.71893525 | 0.96630383 |
| 2.99299622 | 1.03801286 | 1.95498336 |
| 4.10749722 | 3.35801315 | 0.74948407 |
| 2.27043128 | 3.22624874 | -0.95581746 |
| 0.90721697 | 2.50921869 | -1.60200172 |
| 1.42224860 | 2.37878108 | -0.95653248 |
| 2.78236747 | 3.61671495 | -0.83434748 |
| 1.72835886 | 1.27770722 | 0.45065164 |
| 4.10920906 | 2.97133064 | 1.13787842 |

说明：
- 当前模型前向已对齐
- 训练曲线对齐
- 本 PR 携带 `gemma3` 依赖实现，因此会与 `gemma3` PR 存在重叠文件
- 该模型为多模态判别模型，实际使用训练应该采用其他数据集进行，本训练对齐仅为验证