### PR TITLE
[refactor] shard batchsampler align with ms-swift

### DIFF
--- a/paddleformers/cli/train/sft/sft_trainer.py
+++ b/paddleformers/cli/train/sft/sft_trainer.py
@@ -33,7 +33,9 @@ import paddle.distributed as dist
 import paddle.nn as nn
 from datasets import Dataset
 from paddle.distributed import fleet
-from paddle.io import BatchSampler, DataLoader, DistributedBatchSampler
+from paddle.io import DataLoader
+
+from paddleformers.utils.batch_sampler import DistributedBatchSampler
 
 if TYPE_CHECKING:
     try:
@@ -384,22 +386,15 @@ class SFTTrainer(Trainer):
         super(SFTTrainer, self).log(logs, **kwargs)
 
     def get_ptq_dataloader(self, ptq_ds):
-        if self.args.world_size <= 1:
-            ptq_sampler = BatchSampler(
-                dataset=ptq_ds,
-                shuffle=True,
-                batch_size=self.args.per_device_train_batch_size,
-                drop_last=self.args.dataloader_drop_last,
-            )
-        else:
-            ptq_sampler = DistributedBatchSampler(
-                self.train_dataset,
-                batch_size=self.args.per_device_train_batch_size,
-                shuffle=True,
-                num_replicas=self.args.dataset_world_size,
-                rank=self.args.dataset_rank,
-                drop_last=self.args.dataloader_drop_last,
-            )
+        ptq_sampler = DistributedBatchSampler(
+            ptq_ds,
+            batch_size=self.args.per_device_train_batch_size,
+            shuffle=True,
+            num_replicas=self.args.dataset_world_size,
+            rank=self.args.dataset_rank,
+            drop_last=self.args.dataloader_drop_last,
+            data_seed=self.args.seed,
+        )
         ptq_dataloader = DataLoader(
             ptq_ds,
             batch_sampler=ptq_sampler,

--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -137,8 +137,7 @@ from ..transformers.segment_parallel_utils import (
     split_inputs_sequence_dim,
 )
 from ..utils import empty_device_cache, perf_utils
-from ..utils.batch_sampler import DistributedBatchSampler as NlpDistributedBatchSampler
-from ..utils.batch_sampler import MappingBatchSampler, MappingDistributedBatchSampler
+from ..utils.batch_sampler import DistributedBatchSampler
 from ..utils.download import resolve_file_path
 from ..utils.env import (
     EMA_STATE_DIC,
@@ -1874,8 +1873,8 @@ class Trainer:
         self.state.epoch = 0
         epochs_trained = 0
         steps_trained_in_current_epoch = 0
-        consumed_samples = 0
         steps_trained_progress_bar = None
+        _resume_consumed_samples = 0
 
         # Check if continuing training from a checkpoint
         if (
@@ -1884,7 +1883,6 @@ class Trainer:
             and not self.args.ignore_load_lr_and_optim
         ):
             state_path = distributed_file(os.path.join(resume_from_checkpoint, TRAINER_STATE_NAME))
-            # 根据文件扩展名判断使用哪种加载方法
             if state_path.endswith(".json"):
                 self.state = TrainerState.load_from_json(state_path)
             else:
@@ -1919,13 +1917,17 @@ class Trainer:
                     steps_trained_progress_bar = tqdm(total=steps_trained_in_current_epoch)
                     steps_trained_progress_bar.set_description("Skipping the first batches")
             if not args.ignore_data_skip:
+                _resume_consumed_samples = 0
                 if isinstance(train_dataloader, paddle.io.DataLoader) and isinstance(
                     train_dataloader.batch_sampler,
-                    (NlpDistributedBatchSampler, MappingBatchSampler, MappingDistributedBatchSampler),
+                    DistributedBatchSampler,
                 ):
-                    consumed_samples = steps_trained_in_current_epoch * args.train_batch_size * args.dataset_world_size
-                    train_dataloader.batch_sampler.set_epoch(consumed_samples=consumed_samples)
-                    logger.info(f"Set Sampler consumed_samples to {consumed_samples}")
+                    _resume_consumed_samples = (
+                        steps_trained_in_current_epoch * args.train_batch_size * args.dataset_world_size
+                    )
+                    logger.info(
+                        f"Will resume with consumed_samples={_resume_consumed_samples} " f"for epoch {epochs_trained}"
+                    )
 
         epoch_iterator = train_dataloader
         # Use len_dataloader directly instead of len(epoch_iterator) to avoid
@@ -1972,9 +1974,10 @@ class Trainer:
             if (
                 not args.enable_auto_parallel
                 and isinstance(train_dataloader, paddle.io.DataLoader)
-                and isinstance(train_dataloader.batch_sampler, (MappingBatchSampler, MappingDistributedBatchSampler))
+                and isinstance(train_dataloader.batch_sampler, DistributedBatchSampler)
             ):
-                train_dataloader.batch_sampler.set_epoch(epoch, consumed_samples)
+                train_dataloader.batch_sampler.set_epoch(epoch, consumed_samples=_resume_consumed_samples)
+            _resume_consumed_samples = 0
 
             step_control = 0  # used in loop control, reset to 0 after every step
             self.control = self.callback_handler.on_epoch_begin(args, self.state, self.control)
@@ -2001,15 +2004,13 @@ class Trainer:
                 self.callback_handler.on_load_data_end(args, self.state, self.control, inputs=inputs)
 
                 # Skip past any already trained steps if resuming training
-                # for paddleformers.utils.batch_sampler.(NlpDistributedBatchSampler & MappingBatchSampler & MappingDistributedBatchSampler)
                 # We use consumed_samples to reset the status
                 dataloader = train_dataloader
                 if self.args.enable_auto_parallel:
                     dataloader = train_dataloader._dataloader
 
                 if isinstance(dataloader, paddle.io.DataLoader) and isinstance(
-                    dataloader.batch_sampler,
-                    (NlpDistributedBatchSampler, MappingBatchSampler, MappingDistributedBatchSampler),
+                    dataloader.batch_sampler, DistributedBatchSampler
                 ):
                     if step == 0:
                         if steps_trained_progress_bar is not None:
@@ -2312,6 +2313,7 @@ class Trainer:
                 self.control.should_training_stop = True
 
             self.control = self.callback_handler.on_epoch_end(args, self.state, self.control)
+            steps_trained_in_current_epoch = 0
 
             if self.args.enable_auto_parallel:
                 with _exec_mode_guard("dynamic"):
@@ -2321,8 +2323,6 @@ class Trainer:
 
             if self.control.should_training_stop:
                 break
-
-            consumed_samples = 0
 
         if args.past_index and hasattr(self, "_past"):
             # Clean the state at the end of training
@@ -2444,8 +2444,8 @@ class Trainer:
         if self.args.enable_auto_parallel:
             total_batch_size = total_batch_size * self.args.dataset_world_size
 
-        if self.args.enable_auto_parallel or self.args.world_size <= 1:
-            batch_sampler = MappingBatchSampler(
+        if self.args.enable_auto_parallel:
+            batch_sampler = paddle.io.BatchSampler(
                 dataset=self.train_dataset,
                 shuffle=shuffle,
                 batch_size=total_batch_size,
@@ -2454,17 +2454,17 @@ class Trainer:
             # Set _acc_steps for auto_parallel mode to ensure correct __len__ calculation
             # When _acc_steps = gradient_accumulation_steps, the dataloader length will be
             # the number of optimizer steps, not micro-batches
-            if self.args.enable_auto_parallel:
-                batch_sampler._acc_steps = self.args.gradient_accumulation_steps
+            batch_sampler._acc_steps = self.args.gradient_accumulation_steps
             return batch_sampler
 
-        return MappingDistributedBatchSampler(
+        return DistributedBatchSampler(
             self.train_dataset,
             batch_size=total_batch_size,
             shuffle=shuffle,
             num_replicas=self.args.dataset_world_size,
             rank=self.args.dataset_rank,
             drop_last=self.args.dataloader_drop_last,
+            data_seed=self.args.seed,
         )
 
     def _set_state_dict_in_model(self, state_dict):
@@ -2798,38 +2798,31 @@ class Trainer:
     def _get_eval_sampler(self, eval_dataset: Dataset):
         if eval_dataset is None or not has_length(eval_dataset):
             return None
-        if self.args.world_size <= 1:
-            return MappingBatchSampler(
+        if (
+            is_paddlefleet_available() and isinstance(self.model, PaddleFleetPipelineLayer)
+        ) or self.args.pipeline_model_parallel_size > 1:
+            # In pipeline parallelism, batch size will be strictly checked
+            # Use LastBatchPaddingSampler to pad the last batch with the first batch
+            from .trainer_utils import LastBatchPaddingSampler
+
+            return LastBatchPaddingSampler(
                 eval_dataset,
+                num_replicas=self.args.dataset_world_size,
+                rank=self.args.dataset_rank,
                 batch_size=self.args.per_device_eval_batch_size,
                 shuffle=False,
                 drop_last=False,
             )
         else:
-            if (
-                is_paddlefleet_available() and isinstance(self.model, PaddleFleetPipelineLayer)
-            ) or self.args.pipeline_model_parallel_size > 1:
-                # In pipeline parallelism, batch size will be strictly checked
-                # Use LastBatchPaddingSampler to pad the last batch with the first batch
-                from .trainer_utils import LastBatchPaddingSampler
-
-                return LastBatchPaddingSampler(
-                    eval_dataset,
-                    num_replicas=self.args.dataset_world_size,
-                    rank=self.args.dataset_rank,
-                    batch_size=self.args.per_device_eval_batch_size,
-                    shuffle=False,
-                    drop_last=False,
-                )
-            else:
-                return MappingDistributedBatchSampler(
-                    eval_dataset,
-                    num_replicas=self.args.dataset_world_size,
-                    rank=self.args.dataset_rank,
-                    batch_size=self.args.per_device_eval_batch_size,
-                    shuffle=False,
-                    drop_last=False,
-                )
+            return DistributedBatchSampler(
+                eval_dataset,
+                num_replicas=self.args.dataset_world_size,
+                rank=self.args.dataset_rank,
+                batch_size=self.args.per_device_eval_batch_size,
+                shuffle=False,
+                drop_last=False,
+                data_seed=self.args.seed,
+            )
 
     def get_eval_dataloader(self, eval_dataset: Optional[Dataset] = None) -> DataLoader:
         """
@@ -4657,8 +4650,7 @@ class Trainer:
             # on eval limit steps
             num_samples = batch_size * self.args.dataset_world_size * max_eval_iters
             if isinstance(dataloader, _DataLoaderIterBase) and isinstance(
-                dataloader._batch_sampler,
-                (NlpDistributedBatchSampler, MappingBatchSampler, MappingDistributedBatchSampler),
+                dataloader._batch_sampler, DistributedBatchSampler
             ):
                 consumed_samples = (
                     ((self.state.global_step) // args.eval_steps)

--- a/paddleformers/trainer/trainer_utils.py
+++ b/paddleformers/trainer/trainer_utils.py
@@ -56,6 +56,8 @@ from paddle.io import IterableDataset
 from paddle.optimizer.lr import LambdaDecay
 from transformers.tokenization_utils_base import BatchEncoding
 
+from paddleformers.utils.batch_sampler import DistributedBatchSampler
+
 # from ..ops import Topology
 from ..trainer.argparser import strtobool
 from ..transformers.model_utils import (
@@ -1229,7 +1231,7 @@ class IterableDatasetShard(IterableDataset):
             return math.ceil(len(self.dataset) / (self.batch_size * self.num_processes)) * self.batch_size
 
 
-class LastBatchPaddingSampler(paddle.io.DistributedBatchSampler):
+class LastBatchPaddingSampler(DistributedBatchSampler):
     """The sampler which pads the first batch to the last batch"""
 
     def __iter__(self):

--- a/paddleformers/utils/batch_sampler.py
+++ b/paddleformers/utils/batch_sampler.py
@@ -14,210 +14,42 @@
 
 from __future__ import division, print_function
 
-import math
-
-import numpy as np
 import paddle
 
-__all__ = ["MappingBatchSampler", "MappingDistributedBatchSampler", "DistributedBatchSampler"]
-
-
-class RandomSamplerWithSeed(paddle.io.RandomSampler):
-    def __init__(self, data_source, replacement=False, num_samples=None, generator=None) -> None:
-        super().__init__(data_source, replacement=replacement, num_samples=num_samples, generator=generator)
-        self.epoch = 0
-
-    def set_epoch(self, epoch=0):
-        self.epoch = epoch
-
-    def __iter__(self):
-        n = len(self.data_source)
-        num_samples = self.num_samples if self.num_samples is not None else n
-        if self.generator:
-            for i in range(num_samples):
-                try:
-                    index = next(self.generator)
-                except StopIteration:
-                    return
-                yield index
-        else:
-            for index in (
-                np.random.RandomState(self.epoch).choice(np.arange(n), num_samples, replace=self.replacement).tolist()
-            ):
-                yield index
-
-
-class MappingBatchSampler(paddle.io.BatchSampler):
-    def __init__(self, dataset, batch_size, shuffle=False, drop_last=False, consumed_samples=0):
-
-        if shuffle:
-            sampler = RandomSamplerWithSeed(dataset)
-        else:
-            sampler = paddle.io.SequenceSampler(dataset)
-
-        super().__init__(sampler=sampler, batch_size=batch_size, drop_last=drop_last)
-        self.consumed_samples = consumed_samples
-
-    def set_epoch(self, epoch=0, consumed_samples=0):
-        self.epoch = epoch
-        self.consumed_samples = consumed_samples
-        if isinstance(self.sampler, RandomSamplerWithSeed):
-            self.sampler.set_epoch(epoch=epoch)
-
-    def __iter__(self):
-
-        # Yield in batches
-        local_batch_size = self.batch_size * self._acc_steps
-        batch_indices = []
-        for idx in self.sampler:
-            # Skip consumed samples for resume
-            if self.consumed_samples > 0:
-                self.consumed_samples -= 1
-                continue
-            batch_indices.append(idx)
-            if len(batch_indices) == local_batch_size:
-                yield batch_indices
-                batch_indices = []
-        if not self.drop_last and len(batch_indices) > 0:
-            yield batch_indices
-
-
-class MappingDistributedBatchSampler(paddle.io.DistributedBatchSampler):
-    def __init__(
-        self, dataset, batch_size, num_replicas=None, rank=None, shuffle=False, drop_last=False, consumed_samples=0
-    ):
-        super().__init__(
-            dataset, batch_size, num_replicas=num_replicas, rank=rank, shuffle=shuffle, drop_last=drop_last
-        )
-        self.consumed_samples = consumed_samples
-
-    def set_epoch(self, epoch=0, consumed_samples=0):
-        self.epoch = epoch
-        self.consumed_samples = consumed_samples
-
-    def __iter__(self):
-        num_samples = len(self.dataset)
-        indices = np.arange(num_samples).tolist()
-
-        # Add extra samples to make it evenly divisible
-        padding_size = self.total_size - len(indices)
-        if padding_size <= len(indices):
-            indices += indices[:padding_size]
-        else:
-            indices += (indices * math.ceil(padding_size / len(indices)))[:padding_size]
-
-        assert len(indices) == self.total_size
-
-        if self.shuffle:
-            np.random.RandomState(self.epoch).shuffle(indices)
-            self.epoch += 1
-
-        # Subsample for local rank
-        def _get_indices_by_batch_size(indices):
-            subsampled_indices = []
-            last_batch_size = self.total_size % (self.batch_size * self.nranks)
-            assert last_batch_size % self.nranks == 0
-            last_local_batch_size = last_batch_size // self.nranks
-
-            for i in range(
-                self.local_rank * self.batch_size,
-                len(indices) - last_batch_size,
-                self.batch_size * self.nranks,
-            ):
-                subsampled_indices.extend(indices[i : i + self.batch_size])
-
-            indices = indices[len(indices) - last_batch_size :]
-            subsampled_indices.extend(
-                indices[self.local_rank * last_local_batch_size : (self.local_rank + 1) * last_local_batch_size]
-            )
-            return subsampled_indices
-
-        if self.nranks > 1:
-            indices = _get_indices_by_batch_size(indices)
-
-        assert len(indices) == self.num_samples
-
-        assert (
-            self.consumed_samples % self.nranks == 0
-        ), "The consumed_samples should be divided by nranks. consumed_samples=%d, nranks=%s" % (
-            self.consumed_samples,
-            self.nranks,
-        )
-
-        # Skip consumed samples for resume (per-rank)
-        consumed_per_rank = self.consumed_samples // self.nranks
-        indices = indices[consumed_per_rank:]
-
-        # Yield in batches
-        local_batch_size = self.batch_size * self._acc_steps
-        batch_indices = []
-        for idx in indices:
-            batch_indices.append(idx)
-            if len(batch_indices) == local_batch_size:
-                yield batch_indices
-                batch_indices = []
-        if not self.drop_last and len(batch_indices) > 0:
-            yield batch_indices
+__all__ = ["DistributedBatchSampler"]
 
 
 class DistributedBatchSampler(paddle.io.BatchSampler):
     """Sampler that restricts data loading to a subset of the dataset.
 
-    In such case, each process can pass a DistributedBatchSampler instance
-    as a DataLoader sampler, and load a subset of the original dataset that
-    is exclusive to it.
+    Uses interleaved sharding (indices[rank::world_size]) to align with
+    ms-swift's BatchSamplerShard, instead of the contiguous-block strategy
+    used by paddle.io.DistributedBatchSampler.
 
-    .. note::
-        Dataset is assumed to be of constant size.
+    Supports consumed_samples for checkpoint-resume (resume-from-middle-of-epoch).
 
     Args:
-        dataset(paddle.io.Dataset): this could be a `paddle.io.Dataset` implement
-                     or other python object which implemented
-                     `__len__` for BatchSampler to get sample
-                     number of data source.
-        batch_size(int): sample indice number in a mini-batch indices.
-        num_replicas(int, optional): process number in distributed training.
-            If :attr:`num_replicas` is None, :attr:`num_replicas` will be
-            retrieved from :code:`paddle.distributed.ParallenEnv`.
-            Default None.
-        rank(int, optional): the rank of the current process among :attr:`num_replicas`
-            processes. If :attr:`rank` is None, :attr:`rank` is retrieved from
-            :code:`paddle.distributed.ParallenEnv`. Default None.
-        shuffle(bool): whether to shuffle indices order before generating
-            batch indices. Default False.
-        drop_last(bool): whether drop the last incomplete batch dataset size
-            is not divisible by the batch size. Default False
-
-    Examples:
-        .. code-block:: python
-
-            import numpy as np
-
-            from paddle.io import Dataset, DistributedBatchSampler
-
-            # init with dataset
-            class RandomDataset(Dataset):
-                def __init__(self, num_samples):
-                    self.num_samples = num_samples
-
-                def __getitem__(self, idx):
-                    image = np.random.random([784]).astype('float32')
-                    label = np.random.randint(0, 9, (1, )).astype('int64')
-                    return image, label
-
-                def __len__(self):
-                    return self.num_samples
-
-            dataset = RandomDataset(100)
-            sampler = DistributedBatchSampler(dataset, batch_size=64)
-
-            for data in sampler:
-                # do something
-                break
+        dataset(paddle.io.Dataset): dataset to sample from.
+        batch_size(int): sample indices number in a mini-batch.
+        num_replicas(int, optional): number of processes. Defaults to ParallelEnv().nranks.
+        rank(int, optional): rank of current process. Defaults to ParallelEnv().local_rank.
+        shuffle(bool): whether to shuffle. Uses paddle.randperm with seed=base_seed+epoch.
+        drop_last(bool): whether to drop the last incomplete batch.
+        consumed_samples(int): total number of samples already consumed across all ranks
+            (used to resume from a checkpoint mid-epoch).
+        data_seed(int): base random seed. Actual seed per epoch = data_seed + epoch.
     """
 
     def __init__(
-        self, dataset, batch_size, num_replicas=None, rank=None, shuffle=False, drop_last=False, consumed_samples=0
+        self,
+        dataset,
+        batch_size,
+        num_replicas=None,
+        rank=None,
+        shuffle=False,
+        drop_last=False,
+        consumed_samples=0,
+        data_seed=0,
     ):
         self.dataset = dataset
 
@@ -226,6 +58,7 @@ class DistributedBatchSampler(paddle.io.BatchSampler):
         assert isinstance(shuffle, bool), "shuffle should be a boolean value"
         self.shuffle = shuffle
         assert isinstance(drop_last, bool), "drop_last should be a boolean number"
+        self.drop_last = drop_last
 
         from paddle.distributed import ParallelEnv
 
@@ -241,83 +74,76 @@ class DistributedBatchSampler(paddle.io.BatchSampler):
         else:
             self.local_rank = ParallelEnv().local_rank
 
-        self.drop_last = drop_last
-        self.epoch = 0
-
         self.consumed_samples = consumed_samples
+        self.base_seed = data_seed
+        self.curr_seed = data_seed
+        self.epoch = 0
+        self._acc_steps = 1  # Required by LastBatchPaddingSampler and compatible with paddle.io.BatchSampler
+
         if self.dataset is None:
             # In pre-training mode when using distributed dataloader, the input dataset can be None. We should handle this situation.
             self.num_samples = 0
         else:
-            self.num_samples = int(len(self.dataset) * 1.0 / self.nranks)
+            # floor truncation (no padding)
+            total_size = (len(self.dataset) // self.nranks) * self.nranks
+            self.num_samples = total_size // self.nranks
         self.total_size = self.num_samples * self.nranks
-
-    def get_start_end_idx(self):
-        start_idx = self.local_rank * self.batch_size
-        end_idx = start_idx + self.batch_size
-        return start_idx, end_idx
 
     def __iter__(self):
         assert (
             self.consumed_samples % self.nranks == 0
-        ), "The consumed_samples should be divided by nranks. consumed_samples=%d, nranks=%s" % (
+        ), "consumed_samples should be divisible by nranks. consumed_samples=%d, nranks=%d" % (
             self.consumed_samples,
             self.nranks,
         )
-        self.remain_num_samples = int((len(self.dataset) - self.consumed_samples) * 1.0 / self.nranks)
-        self.remain_total_size = self.remain_num_samples * self.nranks
-        self.batch_size_times_rank_size = self.batch_size * self.nranks
 
-        batch_indices = []
-        for idx in range(self.consumed_samples, self.total_size):
-            batch_indices.append(idx)
-            if len(batch_indices) == self.batch_size_times_rank_size:
-                start_idx, end_idx = self.get_start_end_idx()
-                yield batch_indices[start_idx:end_idx]
-                batch_indices = []
-        if not self.drop_last and len(batch_indices) > 0:
-            yield batch_indices
+        # floor truncation (no padding)
+        total_size = (len(self.dataset) // self.nranks) * self.nranks
+
+        if self.shuffle:
+            # need align with torch
+            paddle.seed(self.curr_seed)
+            total_idx = paddle.randperm(total_size).tolist()
+            indices = total_idx[self.local_rank :: self.nranks]  # interleaved shard
+        else:
+            indices = list(range(self.local_rank, total_size, self.nranks))  # interleaved shard
+
+        # Resume from checkpoint: skip already-consumed samples for this rank
+        consumed_per_rank = self.consumed_samples // self.nranks
+        indices = indices[consumed_per_rank:]
+
+        batch = []
+        for idx in indices:
+            batch.append(idx)
+            if len(batch) == self.batch_size:
+                yield batch
+                batch = []
+        if not self.drop_last and len(batch) > 0:
+            yield batch
 
     def __len__(self):
-        num_samples = self.num_samples
-        num_samples += int(not self.drop_last) * (self.batch_size - 1)
-        return num_samples // self.batch_size
+        total_size = (len(self.dataset) // self.nranks) * self.nranks
+        per_rank = total_size // self.nranks
+        consumed_per_rank = self.consumed_samples // self.nranks
+        remaining = per_rank - consumed_per_rank
+        if self.drop_last:
+            return remaining // self.batch_size
+        else:
+            return (remaining + self.batch_size - 1) // self.batch_size
 
     def set_epoch(self, epoch=0, consumed_samples=0):
         """
-        Sets the epoch number. When :attr:`shuffle=True`, this number is used
-        as seeds of random numbers. By default, users may not set this, all
-        replicas (workers) use a different random ordering for each epoch.
-        If set same number at each epoch, this sampler will yield the same
-        ordering at all epoches.
+        Update epoch and consumed_samples.
 
-        Arguments:
-            epoch (int): Epoch number.
+        When shuffle=True, the seed for the next iteration will be base_seed + epoch,
+        consistent with ms-swift's BatchSamplerShard.set_epoch().
 
-        Examples:
-            .. code-block:: python
-
-                from paddle.io import Dataset, DistributedBatchSampler
-
-                # init with dataset
-                class RandomDataset(Dataset):
-                    def __init__(self, num_samples):
-                        self.num_samples = num_samples
-
-                    def __getitem__(self, idx):
-                        image = np.random.random([784]).astype('float32')
-                        label = np.random.randint(0, 9, (1, )).astype('int64')
-                        return image, label
-
-                    def __len__(self):
-                        return self.num_samples
-
-                dataset = RandomDataset(100)
-                sampler = DistributedBatchSampler(dataset, batch_size=64)
-
-                for epoch in range(10):
-                    sampler.set_epoch(epoch)
+        Args:
+            epoch(int): current epoch number.
+            consumed_samples(int): total samples consumed across all ranks so far.
+                Used to resume from a checkpoint mid-epoch.
         """
+        self.curr_seed = self.base_seed + epoch
         self.epoch = epoch
         # if we reset the epoch, the consumed_samples should be set to 0.
         self.consumed_samples = consumed_samples


### PR DESCRIPTION
### PR types

Function optimization

### PR changes

APIs

### Description

重构 BatchSampler 实现，与 ms-swift 对齐。

主要变更：

- **统一 Sampler 实现**：移除了 `MappingBatchSampler`、`MappingDistributedBatchSampler` 和 `RandomSamplerWithSeed`，统一使用重构后`paddleformers/utils`的 `DistributedBatchSampler`
- **数据分片策略对齐**：采用交错分片策略（`indices[rank::world_size]`）替代原有的连续块分片策略，与 ms-swift 的 `BatchSamplerShard` 保持一致
- **简化代码逻辑**：
  - `sft_trainer.py`：移除单机/分布式的分支判断，统一使用 `DistributedBatchSampler`
  - `trainer.py`：简化 sampler 类型判断和 resume 逻辑
- **断点续训迁移**：通过 `consumed_samples` 参数支持从训练中间恢复，根据断点的 step 计算已使用数据的 idx，直接跳过已使用数据，避免空转
- **新增 `data_seed` 参数**：用于控制 shuffle 的随机种子，每个 epoch 的实际种子为 `data_seed + epoch`，与swift对齐