### PR TITLE
fix unexpected tensor place

### DIFF
--- a/paddleformers/trainer/utils/zero_cost_checkpoint.py
+++ b/paddleformers/trainer/utils/zero_cost_checkpoint.py
@@ -391,9 +391,10 @@ class ParamFusionStorageHelper:
     def init_buffer(self, meta):
         if paddle.is_compiled_with_xpu():
             cuda_buffer = paddle.to_tensor(paddle.base.core.LoDTensor._new_shared_xpu(meta))
+            cpu_buffer = cuda_buffer.cpu()
         else:
             cuda_buffer = paddle.to_tensor(paddle.base.core.LoDTensor._new_shared_cuda(meta))
-        cpu_buffer = cuda_buffer.pin_memory()
+            cpu_buffer = cuda_buffer.pin_memory()
         return (cuda_buffer, cpu_buffer)
 
     @imperative_base.no_grad()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
The place of ema_buffer_model_params should be CPU, but got `cuda/xpu` because `paddle.zeros_like` create new tensors on device for pinned place. 

<img width="1580" height="272" alt="image" src="https://github.com/user-attachments/assets/a0357108-361a-4e51-b9dd-2942d8047513" />

It would cause the unexpected device calculation on device in `ema_accumulate`. 

<img width="1816" height="556" alt="image" src="https://github.com/user-attachments/assets/3d8a3081-9ae8-48a7-891a-4691cee62275" />


The PR fix this problem by explicit declaration.

Scipts to reproduce:

```python
import paddle
base_tensor = paddle.zeros([100]).pin_memory()
paddle.set_device("cpu")
param_tensor = paddle.zeros_like(base_tensor)
print(f"The place of param_tensor is {param_tensor.place}")
```

XPU result:
```
XCCL /usr/local/lib/python3.10/site-packages/paddle/base/../libs/libbkcl.so loaded
W0409 21:02:02.013003 1634249 xpu_context.cc:187] Please NOTE: xpu device: 0
The place of param_tensor is Place(xpu:0)
```

GPU result:
```
W0409 21:03:57.246551 38998 gpu_resources.cc:116] Please NOTE: device: 0, GPU Compute Capability: 9.0, Driver API Version: 12.4, Runtime API Version: 12.9
The place of param_tensor is Place(gpu:0)
```