### PR TITLE
【FT】Fix Fault Tolerance in PaddleFleet

### DIFF
--- a/paddleformers/trainer/trainer_utils.py
+++ b/paddleformers/trainer/trainer_utils.py
@@ -2051,9 +2051,12 @@ class EMAStateAssembler:
 
         for k, v in self.model_sharded_state_dict.items():
             if v.local_tensor.dtype == paddle.bfloat16:
-                ema_sharded_state_dict[k] = create_sharded_weight_with_new_local(
-                    k, ema_params_recovered[_rename(k, False)], v
-                )
+                ema_tensor = ema_params_recovered[_rename(k, False)]
+                expected_shape = v.local_shape
+                # Handle grouped_gemm_experts: reshape 3D [num_experts, hidden, intermediate] to 2D [num_experts*hidden, intermediate]
+                if "grouped_gemm_experts" in k:
+                    ema_tensor = paddle.reshape(ema_tensor, expected_shape)
+                ema_sharded_state_dict[k] = create_sharded_weight_with_new_local(k, ema_tensor, v)
 
         ema_state_dict.pop("master_weights")
         del ema_params_recovered
@@ -2079,7 +2082,18 @@ class EMAStateAssembler:
 
         for k, v in extra_params.items():
             assert k in self.model_sharded_state_dict, f"[EMAStateAssembler] {k} not in model_sharded_state_dict"
-            ema_sharded_state_dict[k] = create_sharded_weight_with_new_local(k, v, self.model_sharded_state_dict[k])
+            ref_tensor = self.model_sharded_state_dict[k]
+            expected_shape = ref_tensor.local_shape
+            if "grouped_gemm_experts" in k:
+                v = paddle.reshape(v, expected_shape)
+            ema_sharded_state_dict[k] = create_sharded_weight_with_new_local(k, v, ref_tensor)
+
+        # Fill missing params from model (e.g., e_score_correction_bias not tracked by EMA)
+        for k, v in self.model_sharded_state_dict.items():
+            if k not in ema_sharded_state_dict:
+                logger.debug(f"[EMAStateAssembler] Filling missing param {k} from model")
+                ema_sharded_state_dict[k] = v
+
         return ema_sharded_state_dict
 
     def _save_full_ema_states(self, step, ema_sharded_state_dict):

--- a/paddleformers/trainer/utils/zero_cost_checkpoint.py
+++ b/paddleformers/trainer/utils/zero_cost_checkpoint.py
@@ -212,12 +212,13 @@ def get_fused_param_mappings(optimizer, manipulated_state_dict):
         index += 1
     for k, v in manipulated_state_dict.items():
         if k not in param_mappings:
+            unshard_buffer_index = f"unshard_{k}"
             param_meta = {}
-            param_meta["buffer_index"] = "unshard"
+            param_meta["buffer_index"] = unshard_buffer_index
             param_meta["shape"] = v.shape
             param_meta["name"] = v.name
-            param_meta["tensor_data"] = v.numpy()
             param_mappings[k] = param_meta
+            ipc_meta_mappings[unshard_buffer_index] = v.get_tensor()._share_cuda()
     return param_mappings, ipc_meta_mappings
 
 
@@ -376,7 +377,6 @@ class ParamFusionStorageHelper:
         self.inited_buffers = {}
         self.all_param_numel = 0
         self.model_weights_metas = OrderedDict()
-        self.unshard_params = OrderedDict()
         if len(model_weights_metas) == 0:
             logger.info("No model states need to save in current worker")
             return
@@ -384,12 +384,12 @@ class ParamFusionStorageHelper:
         for k, v in model_weights_metas.items():
             assert isinstance(v, dict), "model_weights_metas must be a dict"
             buffer_index = v["buffer_index"]
-            if buffer_index == "unshard":
-                self.unshard_params[k] = v
-                continue
             if buffer_index not in self.inited_buffers.keys():
                 buffer_tuple = self.init_buffer(buffer_ipc_metas[buffer_index])
                 self.inited_buffers[buffer_index] = buffer_tuple
+            if buffer_index.startswith("unshard_"):
+                self.model_weights_metas[k] = v
+                continue
             v["start"] = int(v["start"])
             v["end"] = int(v["end"])
             v["logical_start"] = self.all_param_numel
@@ -463,12 +463,8 @@ class ParamFusionStorageHelper:
     def state_dict(self):
         state_dict = {}
         for k, v in self.model_weights_metas.items():
-            state_dict[k] = self.restore_tensor_from_meta(v)
-        if dist.get_rank() == 0:
-            for k, meta in self.unshard_params.items():
-                tensor = paddle.to_tensor(meta["tensor_data"])
-                tensor.get_tensor()._set_dims(meta["shape"])
-                tensor.name = meta["name"]
+            tensor = self.restore_tensor_from_meta(v)
+            if tensor is not None:
                 state_dict[k] = tensor
         return state_dict
 
@@ -476,10 +472,18 @@ class ParamFusionStorageHelper:
     def restore_tensor_from_meta(self, tensor_meta):
         shape = tensor_meta["shape"]
         name = tensor_meta["name"]
-        start = tensor_meta["start"]
-        end = tensor_meta["end"]
-        cpu_buffer = self.inited_buffers[tensor_meta["buffer_index"]][1]
-        tensor = cpu_buffer._slice(start, end)
+        buffer_index = tensor_meta["buffer_index"]
+        if buffer_index.startswith("unshard_"):
+            if dist.get_rank() != 0:
+                return None
+            # unshard params not synced, re-copy from shared cuda_buffer
+            cuda_buffer, cpu_buffer = self.inited_buffers[buffer_index]
+            tensor = cuda_buffer.pin_memory()
+        else:
+            start = tensor_meta["start"]
+            end = tensor_meta["end"]
+            cpu_buffer = self.inited_buffers[buffer_index][1]
+            tensor = cpu_buffer._slice(start, end)
         tensor.get_tensor()._set_dims(shape)
         tensor.name = name
         return tensor

--- a/paddleformers/trainer/utils/zero_cost_checkpoint.py
+++ b/paddleformers/trainer/utils/zero_cost_checkpoint.py
@@ -466,11 +466,6 @@ class ParamFusionStorageHelper:
             tensor = self.restore_tensor_from_meta(v)
             if tensor is not None:
                 state_dict[k] = tensor
-        # for k, meta in self.unshard_params.items():
-        #     tensor = paddle.to_tensor(meta["tensor_data"])
-        #     tensor.get_tensor()._set_dims(meta["shape"])
-        #     tensor.name = meta["name"]
-        #     state_dict[k] = tensor
         return state_dict
 
     @imperative_base.no_grad()

--- a/paddleformers/trainer/utils/zero_cost_checkpoint.py
+++ b/paddleformers/trainer/utils/zero_cost_checkpoint.py
@@ -463,9 +463,7 @@ class ParamFusionStorageHelper:
     def state_dict(self):
         state_dict = {}
         for k, v in self.model_weights_metas.items():
-            tensor = self.restore_tensor_from_meta(v)
-            if tensor is not None:
-                state_dict[k] = tensor
+            state_dict[k] = self.restore_tensor_from_meta(v)
         return state_dict
 
     @imperative_base.no_grad()

--- a/paddleformers/trainer/utils/zero_cost_checkpoint.py
+++ b/paddleformers/trainer/utils/zero_cost_checkpoint.py
@@ -214,9 +214,10 @@ def get_fused_param_mappings(optimizer, manipulated_state_dict):
         if k not in param_mappings:
             unshard_buffer_index = f"unshard_{k}"
             param_meta = {}
-            param_meta["buffer_index"] = unshard_buffer_index
+            param_meta["buffer_index"] = "unshard"
             param_meta["shape"] = v.shape
             param_meta["name"] = v.name
+            param_meta["tensor_data"] = v.numpy()
             param_mappings[k] = param_meta
             ipc_meta_mappings[unshard_buffer_index] = v.get_tensor()._share_cuda()
     return param_mappings, ipc_meta_mappings
@@ -377,6 +378,7 @@ class ParamFusionStorageHelper:
         self.inited_buffers = {}
         self.all_param_numel = 0
         self.model_weights_metas = OrderedDict()
+        self.unshard_params = OrderedDict()
         if len(model_weights_metas) == 0:
             logger.info("No model states need to save in current worker")
             return
@@ -384,12 +386,12 @@ class ParamFusionStorageHelper:
         for k, v in model_weights_metas.items():
             assert isinstance(v, dict), "model_weights_metas must be a dict"
             buffer_index = v["buffer_index"]
+            if buffer_index == "unshard":
+                self.unshard_params[k] = v
+                continue
             if buffer_index not in self.inited_buffers.keys():
                 buffer_tuple = self.init_buffer(buffer_ipc_metas[buffer_index])
                 self.inited_buffers[buffer_index] = buffer_tuple
-            if buffer_index.startswith("unshard_"):
-                self.model_weights_metas[k] = v
-                continue
             v["start"] = int(v["start"])
             v["end"] = int(v["end"])
             v["logical_start"] = self.all_param_numel
@@ -463,8 +465,12 @@ class ParamFusionStorageHelper:
     def state_dict(self):
         state_dict = {}
         for k, v in self.model_weights_metas.items():
-            tensor = self.restore_tensor_from_meta(v)
-            if tensor is not None:
+            state_dict[k] = self.restore_tensor_from_meta(v)
+        if dist.get_rank() == 0:
+            for k, meta in self.unshard_params.items():
+                tensor = paddle.to_tensor(meta["tensor_data"])
+                tensor.get_tensor()._set_dims(meta["shape"])
+                tensor.name = meta["name"]
                 state_dict[k] = tensor
         return state_dict
 
@@ -472,18 +478,10 @@ class ParamFusionStorageHelper:
     def restore_tensor_from_meta(self, tensor_meta):
         shape = tensor_meta["shape"]
         name = tensor_meta["name"]
-        buffer_index = tensor_meta["buffer_index"]
-        if buffer_index.startswith("unshard_"):
-            if dist.get_rank() != 0:
-                return None
-            # unshard params not synced, re-copy from shared cuda_buffer
-            cuda_buffer, cpu_buffer = self.inited_buffers[buffer_index]
-            tensor = cuda_buffer.pin_memory()
-        else:
-            start = tensor_meta["start"]
-            end = tensor_meta["end"]
-            cpu_buffer = self.inited_buffers[buffer_index][1]
-            tensor = cpu_buffer._slice(start, end)
+        start = tensor_meta["start"]
+        end = tensor_meta["end"]
+        cpu_buffer = self.inited_buffers[tensor_meta["buffer_index"]][1]
+        tensor = cpu_buffer._slice(start, end)
         tensor.get_tensor()._set_dims(shape)
         tensor.name = name
         return tensor
@@ -1063,7 +1061,7 @@ class ZeroCostCheckpointWorker:
         # Step2.4: save TrainerState
         trainer_state_name_path = os.path.join(output_dir, TRAINER_STATE_NAME)
         if self.device_id == 0:
-            self.trainer_state.save_to_json(trainer_state_name_path)
+            self.trainer_state.save(trainer_state_name_path)
 
         # Step2.5: save RNG State
         if self.rng_state is not None:

--- a/paddleformers/trainer/utils/zero_cost_checkpoint.py
+++ b/paddleformers/trainer/utils/zero_cost_checkpoint.py
@@ -210,9 +210,14 @@ def get_fused_param_mappings(optimizer, manipulated_state_dict):
                 param_meta["end"] = param_meta["start"] + v._numel()
                 param_mappings[k] = param_meta
         index += 1
-    assert len(manipulated_state_dict) == len(
-        param_mappings
-    ), f"manipulated state dict is not fully covered in param mappings, manipulated_state_dict:{manipulated_state_dict.keys()}, param_mappings:{param_mappings.keys()}"
+    for k, v in manipulated_state_dict.items():
+        if k not in param_mappings:
+            param_meta = {}
+            param_meta["buffer_index"] = "unshard"
+            param_meta["shape"] = v.shape
+            param_meta["name"] = v.name
+            param_meta["tensor_data"] = v.numpy()
+            param_mappings[k] = param_meta
     return param_mappings, ipc_meta_mappings
 
 
@@ -371,6 +376,7 @@ class ParamFusionStorageHelper:
         self.inited_buffers = {}
         self.all_param_numel = 0
         self.model_weights_metas = OrderedDict()
+        self.unshard_params = OrderedDict()
         if len(model_weights_metas) == 0:
             logger.info("No model states need to save in current worker")
             return
@@ -378,6 +384,9 @@ class ParamFusionStorageHelper:
         for k, v in model_weights_metas.items():
             assert isinstance(v, dict), "model_weights_metas must be a dict"
             buffer_index = v["buffer_index"]
+            if buffer_index == "unshard":
+                self.unshard_params[k] = v
+                continue
             if buffer_index not in self.inited_buffers.keys():
                 buffer_tuple = self.init_buffer(buffer_ipc_metas[buffer_index])
                 self.inited_buffers[buffer_index] = buffer_tuple
@@ -455,6 +464,12 @@ class ParamFusionStorageHelper:
         state_dict = {}
         for k, v in self.model_weights_metas.items():
             state_dict[k] = self.restore_tensor_from_meta(v)
+        if dist.get_rank() == 0:
+            for k, meta in self.unshard_params.items():
+                tensor = paddle.to_tensor(meta["tensor_data"])
+                tensor.get_tensor()._set_dims(meta["shape"])
+                tensor.name = meta["name"]
+                state_dict[k] = tensor
         return state_dict
 
     @imperative_base.no_grad()
@@ -1044,7 +1059,7 @@ class ZeroCostCheckpointWorker:
         # Step2.4: save TrainerState
         trainer_state_name_path = os.path.join(output_dir, TRAINER_STATE_NAME)
         if self.device_id == 0:
-            self.trainer_state.save(trainer_state_name_path)
+            self.trainer_state.save_to_json(trainer_state_name_path)
 
         # Step2.5: save RNG State
         if self.rng_state is not None:

--- a/paddleformers/trainer/utils/zero_cost_checkpoint.py
+++ b/paddleformers/trainer/utils/zero_cost_checkpoint.py
@@ -472,9 +472,8 @@ class ParamFusionStorageHelper:
         name = tensor_meta["name"]
         buffer_index = tensor_meta["buffer_index"]
         if buffer_index.startswith("unshard_"):
-            # unshard params not synced, re-copy from shared cuda_buffer
-            cuda_buffer, cpu_buffer = self.inited_buffers[buffer_index]
-            tensor = cuda_buffer.pin_memory()
+            # use cpu_buffer directly
+            tensor = self.inited_buffers[buffer_index][1]
         else:
             start = tensor_meta["start"]
             end = tensor_meta["end"]

--- a/paddleformers/trainer/utils/zero_cost_checkpoint.py
+++ b/paddleformers/trainer/utils/zero_cost_checkpoint.py
@@ -313,10 +313,10 @@ class ZeroCostCheckpointEMAProcessor:
                 buffer_index = tensor_meta["buffer_index"]
                 if buffer_index.startswith("unshard_"):
                     continue
-                start = tensor_meta["start"]
-                end = tensor_meta["end"]
                 if buffer_index not in self.ema_buffer_model_params:
                     continue  # non fp32 has no `self.ema_buffer_model_params`
+                start = tensor_meta["start"]
+                end = tensor_meta["end"]
                 cpu_buffer = self.ema_buffer_model_params[buffer_index]
                 tensor = cpu_buffer._slice(start, end).clone()  # slice 出来的 tensor 在执行`paddle.save`会异常慢，此处必须clone
                 tensor.get_tensor()._set_dims(shape)

--- a/paddleformers/trainer/utils/zero_cost_checkpoint.py
+++ b/paddleformers/trainer/utils/zero_cost_checkpoint.py
@@ -310,11 +310,14 @@ class ZeroCostCheckpointEMAProcessor:
             for k, tensor_meta in self.param_fusion_storage_helper.model_weights_metas.items():
                 shape = tensor_meta["shape"]
                 name = tensor_meta["name"]
+                buffer_index = tensor_meta["buffer_index"]
+                if buffer_index.startswith("unshard_"):
+                    continue
                 start = tensor_meta["start"]
                 end = tensor_meta["end"]
-                if tensor_meta["buffer_index"] not in self.ema_buffer_model_params:
+                if buffer_index not in self.ema_buffer_model_params:
                     continue  # non fp32 has no `self.ema_buffer_model_params`
-                cpu_buffer = self.ema_buffer_model_params[tensor_meta["buffer_index"]]
+                cpu_buffer = self.ema_buffer_model_params[buffer_index]
                 tensor = cpu_buffer._slice(start, end).clone()  # slice 出来的 tensor 在执行`paddle.save`会异常慢，此处必须clone
                 tensor.get_tensor()._set_dims(shape)
                 tensor.name = name

--- a/paddleformers/trainer/utils/zero_cost_checkpoint.py
+++ b/paddleformers/trainer/utils/zero_cost_checkpoint.py
@@ -214,10 +214,9 @@ def get_fused_param_mappings(optimizer, manipulated_state_dict):
         if k not in param_mappings:
             unshard_buffer_index = f"unshard_{k}"
             param_meta = {}
-            param_meta["buffer_index"] = "unshard"
+            param_meta["buffer_index"] = unshard_buffer_index
             param_meta["shape"] = v.shape
             param_meta["name"] = v.name
-            param_meta["tensor_data"] = v.numpy()
             param_mappings[k] = param_meta
             ipc_meta_mappings[unshard_buffer_index] = v.get_tensor()._share_cuda()
     return param_mappings, ipc_meta_mappings
@@ -378,7 +377,6 @@ class ParamFusionStorageHelper:
         self.inited_buffers = {}
         self.all_param_numel = 0
         self.model_weights_metas = OrderedDict()
-        self.unshard_params = OrderedDict()
         if len(model_weights_metas) == 0:
             logger.info("No model states need to save in current worker")
             return
@@ -386,12 +384,12 @@ class ParamFusionStorageHelper:
         for k, v in model_weights_metas.items():
             assert isinstance(v, dict), "model_weights_metas must be a dict"
             buffer_index = v["buffer_index"]
-            if buffer_index == "unshard":
-                self.unshard_params[k] = v
-                continue
             if buffer_index not in self.inited_buffers.keys():
                 buffer_tuple = self.init_buffer(buffer_ipc_metas[buffer_index])
                 self.inited_buffers[buffer_index] = buffer_tuple
+            if buffer_index.startswith("unshard_"):
+                self.model_weights_metas[k] = v
+                continue
             v["start"] = int(v["start"])
             v["end"] = int(v["end"])
             v["logical_start"] = self.all_param_numel
@@ -465,23 +463,30 @@ class ParamFusionStorageHelper:
     def state_dict(self):
         state_dict = {}
         for k, v in self.model_weights_metas.items():
-            state_dict[k] = self.restore_tensor_from_meta(v)
-        if dist.get_rank() == 0:
-            for k, meta in self.unshard_params.items():
-                tensor = paddle.to_tensor(meta["tensor_data"])
-                tensor.get_tensor()._set_dims(meta["shape"])
-                tensor.name = meta["name"]
+            tensor = self.restore_tensor_from_meta(v)
+            if tensor is not None:
                 state_dict[k] = tensor
+        # for k, meta in self.unshard_params.items():
+        #     tensor = paddle.to_tensor(meta["tensor_data"])
+        #     tensor.get_tensor()._set_dims(meta["shape"])
+        #     tensor.name = meta["name"]
+        #     state_dict[k] = tensor
         return state_dict
 
     @imperative_base.no_grad()
     def restore_tensor_from_meta(self, tensor_meta):
         shape = tensor_meta["shape"]
         name = tensor_meta["name"]
-        start = tensor_meta["start"]
-        end = tensor_meta["end"]
-        cpu_buffer = self.inited_buffers[tensor_meta["buffer_index"]][1]
-        tensor = cpu_buffer._slice(start, end)
+        buffer_index = tensor_meta["buffer_index"]
+        if buffer_index.startswith("unshard_"):
+            # unshard params not synced, re-copy from shared cuda_buffer
+            cuda_buffer, cpu_buffer = self.inited_buffers[buffer_index]
+            tensor = cuda_buffer.pin_memory()
+        else:
+            start = tensor_meta["start"]
+            end = tensor_meta["end"]
+            cpu_buffer = self.inited_buffers[buffer_index][1]
+            tensor = cpu_buffer._slice(start, end)
         tensor.get_tensor()._set_dims(shape)
         tensor.name = name
         return tensor

--- a/paddleformers/transformers/gpt_provider.py
+++ b/paddleformers/transformers/gpt_provider.py
@@ -17,8 +17,9 @@
 
 import contextlib
 import inspect
+import json
 import logging
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from functools import partial
 from typing import Any, Callable, Literal, Optional, Union
 
@@ -207,6 +208,22 @@ class GPTModelProvider(GPTConfig, ModelProviderMixin[GPTModel]):
                         pass
 
         return model
+
+    def to_json_string(self, use_diff: bool = True, saving_file=False) -> str:
+        config_dict = asdict(self)
+
+        def make_serializable(obj):
+            if isinstance(obj, dict):
+                return {k: make_serializable(v) for k, v in obj.items() if make_serializable(v) is not None}
+            elif isinstance(obj, (list, tuple)):
+                return [make_serializable(item) for item in obj if make_serializable(item) is not None]
+            elif isinstance(obj, (str, int, float, bool, type(None))):
+                return obj
+            else:
+                return None
+
+        serializable_config = make_serializable(config_dict)
+        return json.dumps(serializable_config, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
 
 
 def mtp_block_spec(config: "GPTModelProvider", vp_stage: Optional[int] = None) -> Optional[LayerSpec]:

--- a/paddleformers/transformers/minimax_m2/modeling.py
+++ b/paddleformers/transformers/minimax_m2/modeling.py
@@ -158,7 +158,7 @@ class MiniMaxM2PreTrainedModel(PretrainedModel):
     # NOTE: These aoa_config items will be removed later. The subsequent AOA parsing module will automatically generate the reverse AOA based on the forward (from_pretrained) AOA.
     @classmethod
     def _gen_inv_aoa_config(cls, config: MiniMaxM2Config):
-        model_prefix = "" if cls == cls.base_model_class else "model."
+        model_prefix = "" if cls == getattr(cls, "base_model_class", None) else "model."
         using_sonic_moe = config.using_sonic_moe
         if hasattr(config, "n_routed_experts"):
             num_experts = config.n_routed_experts
@@ -207,27 +207,41 @@ class MiniMaxM2PreTrainedModel(PretrainedModel):
                 # for mtp
                 prefix_offset += ".transformer_layer"
 
-            if config.use_qk_norm:
-                aoa_statements += [
-                    f"{prefix_offset}.self_attn.q_norm.weight -> {prefix}.self_attn.q_norm.weight",
-                    f"{prefix_offset}.self_attn.k_norm.weight -> {prefix}.self_attn.k_norm.weight",
-                ]
-
             aoa_statements += [
                 f"{prefix_offset}.input_layernorm.weight -> {prefix}.input_layernorm.weight",
                 f"{prefix_offset}.post_attention_layernorm.weight -> {prefix}.post_attention_layernorm.weight",
                 f"{prefix_offset}.self_attn.o_proj.weight^T -> {prefix}.self_attn.o_proj.weight",
             ]
-            aoa_statements += [
-                f"{prefix_offset}.self_attn.qkv_proj.weight -> {prefix}.self_attn.q_proj.weight, {prefix}.self_attn.k_proj.weight, {prefix}.self_attn.v_proj.weight , fused_qkv, num_heads={config.num_attention_heads}, num_key_value_groups = {config.num_key_value_heads}",
-            ]
-            aoa_statements += [
-                f"{prefix}.self_attn.{x}_proj.weight^T -> {prefix}.self_attn.{x}_proj.weight" for x in ("q", "k", "v")
-            ]
-            if config.attention_bias:
+
+            if config.q_lora_rank:
+                # MLA attention
                 aoa_statements += [
-                    f"{prefix_offset}.self_attn.qkv_proj.bias -> {prefix}.self_attn.q_proj.bias, {prefix}.self_attn.k_proj.bias, {prefix}.self_attn.v_proj.bias , fused_qkv, num_heads={config.num_attention_heads}, num_key_value_groups = {config.num_key_value_heads}, axis = 0",
+                    f"{prefix_offset}.self_attn.o_proj.weight^T -> {prefix}.self_attn.o_proj.weight",
+                    f"{prefix_offset}.self_attn.q_a_proj.weight^T -> {prefix}.self_attn.q_a_proj.weight",
+                    f"{prefix_offset}.self_attn.q_b_proj.weight^T -> {prefix}.self_attn.q_b_proj.weight",
+                    f"{prefix_offset}.self_attn.kv_a_proj_with_mqa.weight^T -> {prefix}.self_attn.kv_a_proj_with_mqa.weight",
+                    f"{prefix_offset}.self_attn.kv_b_proj.weight^T -> {prefix}.self_attn.kv_b_proj.weight",
+                    f"{prefix_offset}.self_attn.q_a_layernorm.weight -> {prefix}.self_attn.q_a_layernorm.weight",
+                    f"{prefix_offset}.self_attn.kv_a_layernorm.weight -> {prefix}.self_attn.kv_a_layernorm.weight",
                 ]
+            else:
+                if config.use_qk_norm:
+                    aoa_statements += [
+                        f"{prefix_offset}.self_attn.q_norm.weight -> {prefix}.self_attn.q_norm.weight",
+                        f"{prefix_offset}.self_attn.k_norm.weight -> {prefix}.self_attn.k_norm.weight",
+                    ]
+
+                aoa_statements += [
+                    f"{prefix_offset}.self_attn.qkv_proj.weight -> {prefix}.self_attn.q_proj.weight, {prefix}.self_attn.k_proj.weight, {prefix}.self_attn.v_proj.weight , fused_qkv, num_heads={config.num_attention_heads}, num_key_value_groups = {config.num_key_value_heads}",
+                ]
+                aoa_statements += [
+                    f"{prefix}.self_attn.{x}_proj.weight^T -> {prefix}.self_attn.{x}_proj.weight"
+                    for x in ("q", "k", "v")
+                ]
+                if config.attention_bias:
+                    aoa_statements += [
+                        f"{prefix_offset}.self_attn.qkv_proj.bias -> {prefix}.self_attn.q_proj.bias, {prefix}.self_attn.k_proj.bias, {prefix}.self_attn.v_proj.bias , fused_qkv, num_heads={config.num_attention_heads}, num_key_value_groups = {config.num_key_value_heads}, axis = 0",
+                    ]
 
         # All layers are MoE (first_k_dense_replace=0)
         for layer_idx in range(config.first_k_dense_replace, num_hidden_layers + num_nextn_predict_layers):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
修复容错系统
1、部分参数build_skip_comm_buffer，zcc中未适配
* e_score_correction_bias 设置了build_skip_comm_buffer，"color": "skip_comm"，为stop_gradient，不在 sharding 通信的 fused buffer 中，不会被加入 param_mappings。
* 修复：ZCC中识别unshard的参数，也保存在param_mappings，标记"buffer_index": "unfused"，save时直接保存。

2、grouped_gemm_experts 中的EMA问题
* grouped_gemm在保存EMA ckpt的时候shape未恢复
* 修复：保存EMA时，将grouped_gemm参数恢复为原来的维度

3、MLA的AOA配置问题
* 模型开启了MLA，最新合入的AOA配置未适配MLA
* 修复：补充了MLA的AOA配置

4、GPTModelProvider缺少to_json_string
* 以GPTModelProvider的方式配置模型，config缺少to_json_string
* 修复：补充to_json_string

验证 ZCC 下接续精度对齐