### PR TITLE
[Compatibility] replace torch proxy compat aliases with public APIs

### DIFF
--- a/paddleformers/transformers/kimi_k25/media_utils.py
+++ b/paddleformers/transformers/kimi_k25/media_utils.py
@@ -141,7 +141,7 @@ def _read_video_paddlecodec(
         import paddle
 
         del sys.modules["torchcodec"]
-        paddle.compat.enable_torch_proxy(scope={"torchcodec"})
+        paddle.enable_compat(scope={"torchcodec"})
         from torchcodec.decoders import VideoDecoder
 
         sys.modules["torchcodec"] = None
@@ -187,7 +187,7 @@ def _read_video_paddlecodec(
         .to("cuda")
     )
     logger.info(f"paddlecodec:  {video_src=}, {total_frames=}, {video_fps=}, time={time.time() - st:.3f}s")
-    paddle.compat.disable_torch_proxy()
+    paddle.disable_compat()
 
     frame_time_info = {
         "video_start": 0,

--- a/paddleformers/transformers/qwen2_vl/vision_process.py
+++ b/paddleformers/transformers/qwen2_vl/vision_process.py
@@ -320,7 +320,7 @@ def _read_video_paddlecodec(
         import sys
 
         del sys.modules["torchcodec"]
-        paddle.compat.enable_torch_proxy(scope={"torchcodec"})
+        paddle.enable_compat(scope={"torchcodec"})
         from torchcodec.decoders import VideoDecoder
 
         sys.modules["torchcodec"] = None
@@ -360,7 +360,7 @@ def _read_video_paddlecodec(
     sample_fps = nframes / max(total_frames, 1e-6) * video_fps
     video = decoder.get_frames_at(indices=idx).data.contiguous().to("cuda")
     logger.info(f"paddlecodec:  {video_path=}, {total_frames=}, {video_fps=}, time={time.time() - st:.3f}s")
-    paddle.compat.disable_torch_proxy()
+    paddle.disable_compat()
 
     video_metadata = dict(
         fps=video_fps,

--- a/paddleformers/transformers/video_utils.py
+++ b/paddleformers/transformers/video_utils.py
@@ -366,7 +366,7 @@ def read_video_paddlecodec(
         import sys
 
         del sys.modules["torchcodec"]
-        paddle.compat.enable_torch_proxy(scope={"torchcodec"})
+        paddle.enable_compat(scope={"torchcodec"})
         from torchcodec.decoders import VideoDecoder
 
         sys.modules["torchcodec"] = None
@@ -415,7 +415,7 @@ def read_video_paddlecodec(
     indices = sample_indices_fn(metadata=metadata, **kwargs)
     video = decoder.get_frames_at(indices=indices).data.contiguous().to("cuda")
     logger.info(f"paddlecodec:  {video_path=}, {total_num_frames=}, {video_fps=}, time={time.time() - st:.3f}s")
-    paddle.compat.disable_torch_proxy()
+    paddle.disable_compat()
     metadata.frames_indices = indices
     return video, metadata
 


### PR DESCRIPTION
### 背景
`paddle.enable_compat` / `paddle.disable_compat` 已是公开 API，`paddle.compat.enable_torch_proxy` / `paddle.compat.disable_torch_proxy` 只是早期兼容别名，后续将移除。

### 本次修改
- 将 `paddleformers/transformers/kimi_k25/media_utils.py` 中的 torch proxy 启停调用切换到公开 API
- 将 `paddleformers/transformers/video_utils.py` 中的 torch proxy 启停调用切换到公开 API
- 将 `paddleformers/transformers/qwen2_vl/vision_process.py` 中的 torch proxy 启停调用切换到公开 API

### 说明
- 仓库内未检索到需要一并调整的文档、测试或示例中的旧 API 用法
- 本次只做最小必要的 API 清理，不改动其余逻辑

### 验证
- `grep -R "enable_torch_proxy" -n . || true`
- `grep -R "disable_torch_proxy" -n . || true`
- `python3 -m compileall paddleformers/transformers/kimi_k25/media_utils.py paddleformers/transformers/video_utils.py paddleformers/transformers/qwen2_vl/vision_process.py`
