### PR TITLE
[refactor] sharding strategy

### DIFF
--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -2450,6 +2450,7 @@ class Trainer:
                 shuffle=shuffle,
                 batch_size=total_batch_size,
                 drop_last=self.args.dataloader_drop_last,
+                data_seed=self.args.seed,
             )
             # Set _acc_steps for auto_parallel mode to ensure correct __len__ calculation
             # When _acc_steps = gradient_accumulation_steps, the dataloader length will be
@@ -2465,6 +2466,7 @@ class Trainer:
             num_replicas=self.args.dataset_world_size,
             rank=self.args.dataset_rank,
             drop_last=self.args.dataloader_drop_last,
+            data_seed=self.args.seed,
         )
 
     def _set_state_dict_in_model(self, state_dict):

--- a/paddleformers/utils/batch_sampler.py
+++ b/paddleformers/utils/batch_sampler.py
@@ -14,17 +14,15 @@
 
 from __future__ import division, print_function
 
-import math
-
-import numpy as np
 import paddle
 
 __all__ = ["MappingBatchSampler", "MappingDistributedBatchSampler", "DistributedBatchSampler"]
 
 
 class RandomSamplerWithSeed(paddle.io.RandomSampler):
-    def __init__(self, data_source, replacement=False, num_samples=None, generator=None) -> None:
+    def __init__(self, data_source, replacement=False, num_samples=None, generator=None, data_seed=None) -> None:
         super().__init__(data_source, replacement=replacement, num_samples=num_samples, generator=generator)
+        self.base_seed = data_seed or 0
         self.epoch = 0
 
     def set_epoch(self, epoch=0):
@@ -32,26 +30,17 @@ class RandomSamplerWithSeed(paddle.io.RandomSampler):
 
     def __iter__(self):
         n = len(self.data_source)
-        num_samples = self.num_samples if self.num_samples is not None else n
-        if self.generator:
-            for i in range(num_samples):
-                try:
-                    index = next(self.generator)
-                except StopIteration:
-                    return
-                yield index
-        else:
-            for index in (
-                np.random.RandomState(self.epoch).choice(np.arange(n), num_samples, replace=self.replacement).tolist()
-            ):
-                yield index
+        # Aligned with ms-swift: use base_seed + epoch as seed
+        paddle.seed(self.base_seed + self.epoch)
+        for index in paddle.randperm(n).tolist():
+            yield index
 
 
 class MappingBatchSampler(paddle.io.BatchSampler):
-    def __init__(self, dataset, batch_size, shuffle=False, drop_last=False, consumed_samples=0):
+    def __init__(self, dataset, batch_size, shuffle=False, drop_last=False, consumed_samples=0, data_seed=None):
 
         if shuffle:
-            sampler = RandomSamplerWithSeed(dataset)
+            sampler = RandomSamplerWithSeed(dataset, data_seed=data_seed)
         else:
             sampler = paddle.io.SequenceSampler(dataset)
 
@@ -84,58 +73,34 @@ class MappingBatchSampler(paddle.io.BatchSampler):
 
 class MappingDistributedBatchSampler(paddle.io.DistributedBatchSampler):
     def __init__(
-        self, dataset, batch_size, num_replicas=None, rank=None, shuffle=False, drop_last=False, consumed_samples=0
+        self,
+        dataset,
+        batch_size,
+        num_replicas=None,
+        rank=None,
+        shuffle=False,
+        drop_last=False,
+        consumed_samples=0,
+        data_seed=None,
     ):
         super().__init__(
             dataset, batch_size, num_replicas=num_replicas, rank=rank, shuffle=shuffle, drop_last=drop_last
         )
         self.consumed_samples = consumed_samples
+        self.base_seed = data_seed or 0
+        self.total_size = len(self.dataset) // self.nranks * self.nranks  # floor truncate, no padding
 
     def set_epoch(self, epoch=0, consumed_samples=0):
         self.epoch = epoch
         self.consumed_samples = consumed_samples
 
     def __iter__(self):
-        num_samples = len(self.dataset)
-        indices = np.arange(num_samples).tolist()
-
-        # Add extra samples to make it evenly divisible
-        padding_size = self.total_size - len(indices)
-        if padding_size <= len(indices):
-            indices += indices[:padding_size]
-        else:
-            indices += (indices * math.ceil(padding_size / len(indices)))[:padding_size]
-
-        assert len(indices) == self.total_size
-
         if self.shuffle:
-            np.random.RandomState(self.epoch).shuffle(indices)
-            self.epoch += 1
-
-        # Subsample for local rank
-        def _get_indices_by_batch_size(indices):
-            subsampled_indices = []
-            last_batch_size = self.total_size % (self.batch_size * self.nranks)
-            assert last_batch_size % self.nranks == 0
-            last_local_batch_size = last_batch_size // self.nranks
-
-            for i in range(
-                self.local_rank * self.batch_size,
-                len(indices) - last_batch_size,
-                self.batch_size * self.nranks,
-            ):
-                subsampled_indices.extend(indices[i : i + self.batch_size])
-
-            indices = indices[len(indices) - last_batch_size :]
-            subsampled_indices.extend(
-                indices[self.local_rank * last_local_batch_size : (self.local_rank + 1) * last_local_batch_size]
-            )
-            return subsampled_indices
-
-        if self.nranks > 1:
-            indices = _get_indices_by_batch_size(indices)
-
-        assert len(indices) == self.num_samples
+            paddle.seed(self.base_seed + self.epoch)  # global seed, todo
+            total_idx = paddle.randperm(self.total_size).tolist()
+            total_idx = total_idx[self.local_rank :: self.nranks]  # Interleaved sharding
+        else:
+            total_idx = list(range(self.local_rank, self.total_size, self.nranks))
 
         assert (
             self.consumed_samples % self.nranks == 0
@@ -146,12 +111,12 @@ class MappingDistributedBatchSampler(paddle.io.DistributedBatchSampler):
 
         # Skip consumed samples for resume (per-rank)
         consumed_per_rank = self.consumed_samples // self.nranks
-        indices = indices[consumed_per_rank:]
+        total_idx = total_idx[consumed_per_rank:]
 
         # Yield in batches
         local_batch_size = self.batch_size * self._acc_steps
         batch_indices = []
-        for idx in indices:
+        for idx in total_idx:
             batch_indices.append(idx)
             if len(batch_indices) == local_batch_size:
                 yield batch_indices


### PR DESCRIPTION

### PR types
Function optimization

### PR changes
APIs

### Description
重构 `BatchSampler` 中的 sharding 策略，与 ms-swift 对齐。

**主要变更：**

1. **`RandomSamplerWithSeed` 重构**
   - 新增 `data_seed` 参数，替换原有基于 `np.random.RandomState` 的随机实现
   - 改用 `paddle.seed(base_seed + epoch)` + `paddle.randperm(n)` 生成随机索引，与 ms-swift 保持一致
   - 移除对 `numpy` 的依赖
2. **`MappingDistributedBatchSampler` sharding 策略重构**
   - 原策略：先 padding 至 `total_size`，再按 `batch_size * nranks` 块状切分给各 rank
   - 新策略：`total_size` 改为 floor truncate（不做 padding），采用 **interleaved sharding**（`total_idx[local_rank::nranks]`），与 ms-swift 对齐
   - 移除对 `numpy` 和 `math` 的依赖，大幅简化代码（净减少 ~60 行）
3. **`MappingBatchSampler` / `MappingDistributedBatchSampler`**
   - 新增 `data_seed` 参数并透传至 `RandomSamplerWithSeed`
4. **`Trainer` 透传 seed**
   - `_get_train_sampler` 中调用两种 sampler 时均传入 `data_seed=self.args.seed`，保证训练可复现