### PR TITLE
Set profile timers from PaddleFleet in Trainer init

### DIFF
--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -434,6 +434,10 @@ class Trainer:
         if not args.skip_profile_timer:
             set_timers()
         self.timers = get_timers()
+        if is_paddlefleet_available():
+            from paddlefleet.training.global_vars import set_profile_timers
+
+            set_profile_timers(self.timers)
         self.runtime_timer = RuntimeTimer("RuntimeTimer")
 
         self.model_wrapped = model

--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,7 @@ try:
         install_requires=REQUIRED_PACKAGES,
         entry_points={"console_scripts": get_console_scripts()},
         extras_require={
-            "paddlefleet": ["paddlefleet==0.3.0.dev20260416"],
+            "paddlefleet": ["paddlefleet==0.3.0.dev20260419"],
         },
         python_requires=">=3.8",
         classifiers=[


### PR DESCRIPTION
## Summary
- When PaddleFleet is available, call `set_profile_timers(self.timers)` during Trainer initialization so that PaddleFleet can share the same timer instances used by the Trainer.

## Changes
- `paddleformers/trainer/trainer.py`: After `self.timers = get_timers()`, add a conditional block that imports and calls `set_profile_timers` from `paddlefleet.training.global_vars` when PaddleFleet is available.