### PR TITLE
[release/1.1][PR4315] Set profile timers from PaddleFleet in Trainer init

### DIFF
--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -427,6 +427,10 @@ class Trainer:
         if not args.skip_profile_timer:
             set_timers()
         self.timers = get_timers()
+        if is_paddlefleet_available():
+            from paddlefleet.training.global_vars import set_profile_timers
+
+            set_profile_timers(self.timers)
         self.runtime_timer = RuntimeTimer("RuntimeTimer")
 
         self.model_wrapped = model

--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,7 @@ try:
         install_requires=REQUIRED_PACKAGES,
         entry_points={"console_scripts": get_console_scripts()},
         extras_require={
-            "paddlefleet": ["paddlefleet==0.3.0.dev20260419"],
+            "paddlefleet": ["paddlefleet==0.2.0.post20260420+5e0892e90d1"],
         },
         python_requires=">=3.8",
         classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,7 @@ try:
         install_requires=REQUIRED_PACKAGES,
         entry_points={"console_scripts": get_console_scripts()},
         extras_require={
-            "paddlefleet": ["paddlefleet==0.2.0.post20260416+99c99c690d8"],
+            "paddlefleet": ["paddlefleet==0.3.0.dev20260419"],
         },
         python_requires=">=3.8",
         classifiers=[


### PR DESCRIPTION
## Summary
- cherry-pick PR #4315 到 release/1.1
- 在 Trainer 初始化时将 timers 同步到 PaddleFleet
- 同步更新 paddlefleet extra 依赖版本

## Test plan
- [x] python3 -m py_compile paddleformers/trainer/trainer.py setup.py
- [x] git diff --check

Merged in dev: #4315