### PR TITLE
Zcc adapter Muon

### DIFF
--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -254,6 +254,33 @@ from paddle.distributed import in_auto_parallel_align_mode
 from paddle.distributed.fleet.utils import mix_precision_utils
 from paddle.io.dataloader.dataloader_iter import _DataLoaderIterBase
 
+
+def _is_muon_sharding_optimizer(optimizer):
+    opt = optimizer
+    while opt is not None:
+        if type(opt).__name__ == "MuonShardingOptimizer":
+            return True
+        opt = getattr(opt, "_inner_opt", None)
+    return False
+
+
+def _unwrap_muon_sharding_optimizer(optimizer):
+    opt = optimizer
+    while opt is not None:
+        if type(opt).__name__ == "MuonShardingOptimizer":
+            return opt
+        opt = getattr(opt, "_inner_opt", None)
+    return None
+
+
+def _get_muon_2d_param_names(muon_opt):
+    names = set()
+    for _color_key, params in muon_opt._params_2d_by_color.items():
+        for p in params:
+            names.add(p.name)
+    return names
+
+
 __all__ = ["Trainer"]
 
 MODEL_NAME = "model"
@@ -1218,8 +1245,12 @@ class Trainer:
         enable_bf16_opt = (
             not isinstance(self.model, LoRAModel)
             and self.args.bf16
-            and isinstance(self.optimizer._inner_opt, DygraphShardingOptimizerV2)
+            and (
+                isinstance(self.optimizer._inner_opt, DygraphShardingOptimizerV2)
+                or _is_muon_sharding_optimizer(self.optimizer)
+            )
         )
+
         logger.debug(f"sharded_model_from_ema: {self.args.sharded_model_from_ema}")
         logger.debug(f"enable_bf16_opt: {enable_bf16_opt}")
 
@@ -1261,47 +1292,83 @@ class Trainer:
         if enable_bf16_opt:
             opt_state_dict = self.optimizer.state_dict()
 
-            def recover_params_from_master_weight(opt_state_dict, group):
-                master_weights = opt_state_dict["master_weights"]
-                tmp = OrderedDict()
-                master_weights, tmp = (tmp, master_weights)
-                # cast to before
-                for k, v in tmp.items():
-                    name = v.name
-                    master_weights[k] = paddle.cast(to_device(v), paddle.bfloat16).cpu()
-                    master_weights[k].name = name
+            def _restore_master_weights_single(master_weights, group, structure_name_map, restore_func):
+                nms = reshard_util.NodeModelState(group=group)
+                nms_tmp = reshard_util.NodeModelState(group=group)
+                nms_tmp.add_master_weights(master_weights)
+                nms_tmp.pack_keys(structure_name_map)
+                nms.merge_from(nms_tmp, max(group.rank, 0))
+                del nms_tmp
+                nms = restore_func(nms, self.model, self.optimizer)
+                nms.unpack_keys()
+                return reshard_util.all_gather_state_dict(nms.master_weights, lambda x: True, group)
 
-                structure_name_map = {k: v.name for (k, v) in self.model.state_dict().items()}
-                node_model_state = reshard_util.NodeModelState(group=group)
-                node_model_state_tmp = reshard_util.NodeModelState(group=group)
-                node_model_state_tmp.add_master_weights(master_weights)
-                node_model_state_tmp.pack_keys(structure_name_map)
-                node_model_state.merge_from(node_model_state_tmp, max(group.rank, 0))
-                del node_model_state_tmp
-                sharding_strategy = reshard_util.get_sharding_strategy(self.optimizer)
-                logger.debug(f"sharding_strategy: {sharding_strategy}")
-                restore_func = (
-                    reshard_util.sharding_v1.restore
-                    if sharding_strategy == SHARDING_STRATEGY_V1
-                    else reshard_util.sharding_v2.restore
-                )
-                node_model_state = restore_func(node_model_state, self.model, self.optimizer)
-                node_model_state.unpack_keys()
-                master_weights = node_model_state.master_weights
-
-                master_weights = reshard_util.all_gather_state_dict(master_weights, lambda x: True, group)
-
+            def _assign_master_weights_to_model(master_weights):
                 model_state_dict = self.model.state_dict()
                 for key, param in model_state_dict.items():
                     if param.name in master_weights and param.dtype == paddle.bfloat16:
                         logger.debug(
-                            f"key {key}, convert master weights {param.name} shape {master_weights[param.name].shape} to param {param.name} shape{param.shape}"
+                            f"key {key}, convert master weights {param.name} "
+                            f"shape {master_weights[param.name].shape} to param "
+                            f"{param.name} shape{param.shape}"
                         )
                         assert (
                             param.shape == master_weights[param.name].shape
                         ), f"got {param.shape} vs {master_weights[param.name].shape}"
                         master_weight = paddle.reshape(master_weights[param.name], param.shape)
                         paddle.assign(paddle.cast(to_device(master_weight), paddle.bfloat16), model_state_dict[key])
+
+            def recover_params_from_master_weight(opt_state_dict, group):
+                master_weights = opt_state_dict["master_weights"]
+                tmp = OrderedDict()
+                master_weights, tmp = (tmp, master_weights)
+                # cast to bf16 and move to cpu
+                for k, v in tmp.items():
+                    name = v.name
+                    master_weights[k] = paddle.cast(to_device(v), paddle.bfloat16).cpu()
+                    master_weights[k].name = name
+
+                structure_name_map = {k: v.name for (k, v) in self.model.state_dict().items()}
+
+                muon_opt = _unwrap_muon_sharding_optimizer(self.optimizer)
+                if muon_opt is not None:
+                    param_2d_names = _get_muon_2d_param_names(muon_opt)
+                    logger.debug(f"Muon recovery: {len(param_2d_names)} 2D params detected")
+
+                    mw_2d = OrderedDict()
+                    mw_1d = OrderedDict()
+                    for k, v in master_weights.items():
+                        if k in param_2d_names:
+                            mw_2d[k] = v
+                        else:
+                            mw_1d[k] = v
+
+                    all_master_weights = OrderedDict()
+                    if mw_2d:
+                        restored_2d = _restore_master_weights_single(
+                            mw_2d, group, structure_name_map, reshard_util.sharding_v1.restore
+                        )
+                        all_master_weights.update(restored_2d)
+                    if mw_1d:
+                        restored_1d = _restore_master_weights_single(
+                            mw_1d, group, structure_name_map, reshard_util.sharding_v2.restore
+                        )
+                        all_master_weights.update(restored_1d)
+
+                    master_weights = all_master_weights
+                else:
+                    sharding_strategy = reshard_util.get_sharding_strategy(self.optimizer)
+                    logger.debug(f"sharding_strategy: {sharding_strategy}")
+                    restore_func = (
+                        reshard_util.sharding_v1.restore
+                        if sharding_strategy == SHARDING_STRATEGY_V1
+                        else reshard_util.sharding_v2.restore
+                    )
+                    master_weights = _restore_master_weights_single(
+                        master_weights, group, structure_name_map, restore_func
+                    )
+
+                _assign_master_weights_to_model(master_weights)
 
             with paddle.no_grad():
                 if paddle.distributed.is_initialized():

--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -188,7 +188,11 @@ from .trainer_utils import (  # set_hyrbid_parallel_seed,
     TrainerMemoryTracker,
     TrainOutput,
     _exec_mode_guard,
+    _get_muon_2d_param_names,
     _insert_sync,
+    _is_muon_sharding_optimizer,
+    _restore_master_weights_single,
+    _unwrap_muon_sharding_optimizer,
     download_recovery_ckpt_from_pdc,
     find_batch_size,
     get_last_checkpoint,
@@ -253,33 +257,6 @@ if is_datasets_available():
 from paddle.distributed import in_auto_parallel_align_mode
 from paddle.distributed.fleet.utils import mix_precision_utils
 from paddle.io.dataloader.dataloader_iter import _DataLoaderIterBase
-
-
-def _is_muon_sharding_optimizer(optimizer):
-    opt = optimizer
-    while opt is not None:
-        if type(opt).__name__ == "MuonShardingOptimizer":
-            return True
-        opt = getattr(opt, "_inner_opt", None)
-    return False
-
-
-def _unwrap_muon_sharding_optimizer(optimizer):
-    opt = optimizer
-    while opt is not None:
-        if type(opt).__name__ == "MuonShardingOptimizer":
-            return opt
-        opt = getattr(opt, "_inner_opt", None)
-    return None
-
-
-def _get_muon_2d_param_names(muon_opt):
-    names = set()
-    for _color_key, params in muon_opt._params_2d_by_color.items():
-        for p in params:
-            names.add(p.name)
-    return names
-
 
 __all__ = ["Trainer"]
 
@@ -1292,17 +1269,6 @@ class Trainer:
         if enable_bf16_opt:
             opt_state_dict = self.optimizer.state_dict()
 
-            def _restore_master_weights_single(master_weights, group, structure_name_map, restore_func):
-                nms = reshard_util.NodeModelState(group=group)
-                nms_tmp = reshard_util.NodeModelState(group=group)
-                nms_tmp.add_master_weights(master_weights)
-                nms_tmp.pack_keys(structure_name_map)
-                nms.merge_from(nms_tmp, max(group.rank, 0))
-                del nms_tmp
-                nms = restore_func(nms, self.model, self.optimizer)
-                nms.unpack_keys()
-                return reshard_util.all_gather_state_dict(nms.master_weights, lambda x: True, group)
-
             def _assign_master_weights_to_model(master_weights):
                 model_state_dict = self.model.state_dict()
                 for key, param in model_state_dict.items():
@@ -1346,12 +1312,22 @@ class Trainer:
                     all_master_weights = OrderedDict()
                     if mw_2d:
                         restored_2d = _restore_master_weights_single(
-                            mw_2d, group, structure_name_map, reshard_util.sharding_v1.restore
+                            mw_2d,
+                            self.model,
+                            self.optimizer,
+                            group,
+                            structure_name_map,
+                            reshard_util.sharding_v1.restore,
                         )
                         all_master_weights.update(restored_2d)
                     if mw_1d:
                         restored_1d = _restore_master_weights_single(
-                            mw_1d, group, structure_name_map, reshard_util.sharding_v2.restore
+                            mw_1d,
+                            self.model,
+                            self.optimizer,
+                            group,
+                            structure_name_map,
+                            reshard_util.sharding_v2.restore,
                         )
                         all_master_weights.update(restored_1d)
 
@@ -1365,7 +1341,7 @@ class Trainer:
                         else reshard_util.sharding_v2.restore
                     )
                     master_weights = _restore_master_weights_single(
-                        master_weights, group, structure_name_map, restore_func
+                        master_weights, self.model, self.optimizer, group, structure_name_map, restore_func
                     )
 
                 _assign_master_weights_to_model(master_weights)

--- a/paddleformers/trainer/trainer_utils.py
+++ b/paddleformers/trainer/trainer_utils.py
@@ -1709,6 +1709,15 @@ class HFFormatFullParamSaver:
         return total_saved_size
 
 
+def _is_muon_sharding_optimizer(optimizer):
+    opt = optimizer
+    while opt is not None:
+        if type(opt).__name__ == "MuonShardingOptimizer":
+            return True
+        opt = getattr(opt, "_inner_opt", None)
+    return False
+
+
 def _unwrap_muon_sharding_optimizer(optimizer):
     opt = optimizer
     while opt is not None:

--- a/paddleformers/trainer/trainer_utils.py
+++ b/paddleformers/trainer/trainer_utils.py
@@ -1709,35 +1709,84 @@ class HFFormatFullParamSaver:
         return total_saved_size
 
 
+def _unwrap_muon_sharding_optimizer(optimizer):
+    opt = optimizer
+    while opt is not None:
+        if type(opt).__name__ == "MuonShardingOptimizer":
+            return opt
+        opt = getattr(opt, "_inner_opt", None)
+    return None
+
+
+def _get_muon_2d_param_names(muon_opt):
+    names = set()
+    for _color_key, params in muon_opt._params_2d_by_color.items():
+        for p in params:
+            names.add(p.name)
+    return names
+
+
+def _restore_master_weights_single(master_weights, model, optimizer, group, structure_name_map, restore_func):
+    nms = reshard_util.NodeModelState(group=group)
+    nms_tmp = reshard_util.NodeModelState(group=group)
+    nms_tmp.add_master_weights(master_weights)
+    nms_tmp.pack_keys(structure_name_map)
+    nms.merge_from(nms_tmp, max(group.rank, 0))
+    del nms_tmp
+    nms = restore_func(nms, model, optimizer)
+    nms.unpack_keys()
+    return reshard_util.all_gather_state_dict(nms.master_weights, lambda x: True, group)
+
+
 def recover_params_from_master_weight(ema_state_dict, model, optimizer, group):
     master_weights = ema_state_dict["master_weights"]
     tmp = OrderedDict()
     (master_weights, tmp) = (tmp, master_weights)
-    # cast to before
+    # cast to bf16 and move to cpu
     for (k, v) in tmp.items():
         name = v.name
         master_weights[k] = paddle.cast(to_device(v), paddle.bfloat16).cpu()
         master_weights[k].name = name
 
     structure_name_map = {k: v.name for (k, v) in model.state_dict().items()}
-    node_model_state = reshard_util.NodeModelState(group=group)
-    node_model_state_tmp = reshard_util.NodeModelState(group=group)
-    node_model_state_tmp.add_master_weights(master_weights)
-    node_model_state_tmp.pack_keys(structure_name_map)
-    node_model_state.merge_from(node_model_state_tmp, max(group.rank, 0))
-    del node_model_state_tmp
-    sharding_strategy = reshard_util.get_sharding_strategy(optimizer)
-    logger.debug(f"sharding_strategy: {sharding_strategy}")
-    restore_func = (
-        reshard_util.sharding_v1.restore
-        if sharding_strategy == SHARDING_STRATEGY_V1
-        else reshard_util.sharding_v2.restore
-    )
-    node_model_state = restore_func(node_model_state, model, optimizer)
-    node_model_state.unpack_keys()
-    master_weights = node_model_state.master_weights
 
-    master_weights = reshard_util.all_gather_state_dict(master_weights, lambda x: True, group)
+    muon_opt = _unwrap_muon_sharding_optimizer(optimizer)
+    if muon_opt is not None:
+        param_2d_names = _get_muon_2d_param_names(muon_opt)
+        logger.debug(f"Muon EMA recovery: {len(param_2d_names)} 2D params detected")
+
+        mw_2d = OrderedDict()
+        mw_1d = OrderedDict()
+        for k, v in master_weights.items():
+            if k in param_2d_names:
+                mw_2d[k] = v
+            else:
+                mw_1d[k] = v
+
+        all_master_weights = OrderedDict()
+        if mw_2d:
+            restored_2d = _restore_master_weights_single(
+                mw_2d, model, optimizer, group, structure_name_map, reshard_util.sharding_v1.restore
+            )
+            all_master_weights.update(restored_2d)
+        if mw_1d:
+            restored_1d = _restore_master_weights_single(
+                mw_1d, model, optimizer, group, structure_name_map, reshard_util.sharding_v2.restore
+            )
+            all_master_weights.update(restored_1d)
+
+        master_weights = all_master_weights
+    else:
+        sharding_strategy = reshard_util.get_sharding_strategy(optimizer)
+        logger.debug(f"sharding_strategy: {sharding_strategy}")
+        restore_func = (
+            reshard_util.sharding_v1.restore
+            if sharding_strategy == SHARDING_STRATEGY_V1
+            else reshard_util.sharding_v2.restore
+        )
+        master_weights = _restore_master_weights_single(
+            master_weights, model, optimizer, group, structure_name_map, restore_func
+        )
 
     model_state_dict = model.state_dict()
     ema_param_state_dict = OrderedDict()

--- a/paddleformers/trainer/utils/zero_cost_checkpoint.py
+++ b/paddleformers/trainer/utils/zero_cost_checkpoint.py
@@ -86,6 +86,7 @@ from ...utils.env import (
 from ...utils.fault_tolerance import FC_DUMP_ERROR, PC_DUMP_ERROR
 from ...utils.log import logger
 from ...utils.pdc_sdk import FLASH_DEVICE
+from ..trainer_utils import _is_muon_sharding_optimizer
 from . import reshard as reshard_util
 from .reshard import (
     SHARDING_STRATEGY_V1,
@@ -93,15 +94,6 @@ from .reshard import (
     split_model_state,
     split_opt_state,
 )
-
-
-def _is_muon_sharding_optimizer(optimizer):
-    opt = optimizer
-    while opt is not None:
-        if type(opt).__name__ == "MuonShardingOptimizer":
-            return True
-        opt = getattr(opt, "_inner_opt", None)
-    return False
 
 
 def _unwrap_opt_for_fused_states(optimizer):

--- a/paddleformers/trainer/utils/zero_cost_checkpoint.py
+++ b/paddleformers/trainer/utils/zero_cost_checkpoint.py
@@ -55,7 +55,7 @@ from paddle.incubate.tensor.manipulation import (
     async_offload_with_offset,
     create_async_load,
 )
-from paddle.optimizer.fusion_utils import FusionStorageHelper
+from paddle.optimizer.fusion_utils import FusionStorageHelper, _share_tensor_ipc_meta
 
 from paddleformers.trainer.trainer_callback import TrainerCallback
 from paddleformers.trainer.utils.sharding_io import GroupGetter
@@ -93,6 +93,26 @@ from .reshard import (
     split_model_state,
     split_opt_state,
 )
+
+
+def _is_muon_sharding_optimizer(optimizer):
+    opt = optimizer
+    while opt is not None:
+        if type(opt).__name__ == "MuonShardingOptimizer":
+            return True
+        opt = getattr(opt, "_inner_opt", None)
+    return False
+
+
+def _unwrap_opt_for_fused_states(optimizer):
+    opt = optimizer
+    while hasattr(opt, "_inner_opt"):
+        inner = opt._inner_opt
+        inner_name = type(inner).__name__
+        if inner_name in ("MuonShardingOptimizer", "DygraphShardingOptimizerV2", "DygraphShardingOptimizer"):
+            return inner
+        opt = inner
+    return opt
 
 
 def md5(tensor):
@@ -193,13 +213,13 @@ def get_fused_param_mappings(optimizer, manipulated_state_dict):
     param_mappings = {}
     ipc_meta_mappings = {}
     index = 0
+    is_muon = _is_muon_sharding_optimizer(optimizer)
+    logger.info(f"[ZCC Manager] Is MuonShardingOptimizer: {is_muon}")
+
     sharding_comm_buffers = optimizer._comm_buffer_list
     for buffer in sharding_comm_buffers:
         ipc_meta_mappings[str(index)] = buffer.param_buffer_ipc_meta
         for k, v in manipulated_state_dict.items():
-            logger.info(
-                f"check vname: {v.name}; buffer._sharding_param_grad_view: {buffer._sharding_param_grad_view.keys()}"
-            )
             if v.name in buffer._sharding_param_grad_view:
                 assert k not in param_mappings, f"{k} has already been mapped, which is unexpected."
                 param_meta = {}
@@ -210,15 +230,81 @@ def get_fused_param_mappings(optimizer, manipulated_state_dict):
                 param_meta["end"] = param_meta["start"] + v._numel()
                 param_mappings[k] = param_meta
         index += 1
-    for k, v in manipulated_state_dict.items():
-        if k not in param_mappings:
-            unshard_buffer_index = f"unshard_{k}"
-            param_meta = {}
-            param_meta["buffer_index"] = unshard_buffer_index
-            param_meta["shape"] = v.shape
-            param_meta["name"] = v.name
-            param_mappings[k] = param_meta
-            ipc_meta_mappings[unshard_buffer_index] = v.get_tensor()._share_cuda()
+
+    if not is_muon:
+        for k, v in manipulated_state_dict.items():
+            if k not in param_mappings:
+                unshard_buffer_index = f"unshard_{k}"
+                param_meta = {}
+                param_meta["buffer_index"] = unshard_buffer_index
+                param_meta["shape"] = v.shape
+                param_meta["name"] = v.name
+                param_mappings[k] = param_meta
+                ipc_meta_mappings[unshard_buffer_index] = v.get_tensor()._share_cuda()
+
+    if is_muon:
+        sharding_rank = optimizer._sharding_rank
+        local_2d_params = list(optimizer._rank2params_2d.get(sharding_rank, []))
+        if optimizer._moe_sharding_world_size > 1:
+            local_2d_moe = list(optimizer._rank2params_2d_moe.get(optimizer._moe_sharding_rank, []))
+        else:
+            local_2d_moe = list(optimizer._rank2params_2d_moe.get(0, []))
+        local_2d_params.extend(local_2d_moe)
+
+        # TODO(xingmingyyj) : handle multi to one
+        local_2d_name_to_param = {p.name: p for p in local_2d_params}
+
+        for k, v in manipulated_state_dict.items():
+            if k in param_mappings:
+                continue
+            if v.name in local_2d_name_to_param:
+                param = local_2d_name_to_param[v.name]
+                ipc_meta = _share_tensor_ipc_meta(param)
+                ipc_meta_mappings[str(index)] = ipc_meta
+                param_meta = {
+                    "buffer_index": str(index),
+                    "shape": list(param.shape),
+                    "name": param.name,
+                    "start": 0,
+                    "end": param._numel(),
+                }
+                param_mappings[k] = param_meta
+                index += 1
+
+    # Third Muon block: map remaining params (e.g. stop_gradient parameters) via
+    # optimizer._parameter_list. Note that persistable registered buffers are NOT in
+    # _parameter_list and would not be mapped here — see the comment in
+    # _muon_manipulate_state_dict() for details.
+    if is_muon:
+        all_param_by_name = {p.name: p for p in optimizer._parameter_list}
+        if hasattr(optimizer, "_origin_parameter_list"):
+            for p in optimizer._origin_parameter_list:
+                if p.name not in all_param_by_name:
+                    all_param_by_name[p.name] = p
+
+        for k, v in manipulated_state_dict.items():
+            if k in param_mappings:
+                continue
+            if v.name in all_param_by_name:
+                param = all_param_by_name[v.name]
+                ipc_meta = _share_tensor_ipc_meta(param)
+                ipc_meta_mappings[str(index)] = ipc_meta
+                param_meta = {
+                    "buffer_index": str(index),
+                    "shape": list(param.shape),
+                    "name": param.name,
+                    "start": 0,
+                    "end": param._numel(),
+                }
+                param_mappings[k] = param_meta
+                index += 1
+
+    # If this assertion fails under Muon, it is likely because the model contains persistable
+    # registered buffers that are included in manipulated_state_dict but cannot be mapped via
+    # optimizer._parameter_list. See the comment in _muon_manipulate_state_dict() for details.
+    assert len(manipulated_state_dict) == len(
+        param_mappings
+    ), f"manipulated state dict is not fully covered in param mappings, manipulated_state_dict:{manipulated_state_dict.keys()}, param_mappings:{param_mappings.keys()}"
     return param_mappings, ipc_meta_mappings
 
 
@@ -271,7 +357,7 @@ class ZeroCostCheckpointEMAProcessor:
 
     def ema_reset(self):
         self.ema_buffer = None
-        self.ema_buffer_modele_params = None
+        self.ema_buffer_model_params = None
 
     @imperative_base.no_grad()
     def ema_accumulate(self, global_step, loss, zcc_ema_loss_threshold):
@@ -415,7 +501,7 @@ class ParamFusionStorageHelper:
             cuda_buffer = paddle.to_tensor(paddle.base.core.LoDTensor._new_shared_xpu(meta))
         else:
             cuda_buffer = paddle.to_tensor(paddle.base.core.LoDTensor._new_shared_cuda(meta))
-        cpu_buffer = cuda_buffer.pin_memory()
+        cpu_buffer = cuda_buffer.cpu()
         return (cuda_buffer, cpu_buffer)
 
     @imperative_base.no_grad()
@@ -513,6 +599,7 @@ class ZeroCostCheckpointCallback(TrainerCallback):
     """
 
     def __init__(self, args, zcc_manager, timer, sharding_io):
+        self.args = args
         self.manager = zcc_manager
         self.runtime_timer = timer
         self.user_file_list = []
@@ -593,17 +680,17 @@ class ZeroCostCheckpointCallback(TrainerCallback):
         return static_objects
 
     def maybe_update_zcc_worker(self, args, model, optimizer, global_step):
-        # logger.info(f"check should update :{optimizer.fused_buffer_version} vs {self.manager.cache_version}")
-        if optimizer.fused_buffer_version == self.manager.cache_version:
+        inner_opt = _unwrap_opt_for_fused_states(optimizer)
+        if inner_opt.fused_buffer_version == self.manager.cache_version:
             return
         logger.info("ZCC checkpoint workers need upgrade.")
         self._cache_meta_for_sharded_save(model, optimizer)
         param_mappings, ipc_meta_mappings = get_fused_param_mappings(optimizer, self.manipulated_state_dict)
         self.optimizer_states_meta = (
-            optimizer.fused_states_accumulators_meta,
-            optimizer.fused_states_master_weights_meta,
+            inner_opt.fused_states_accumulators_meta,
+            inner_opt.fused_states_master_weights_meta,
             None,
-            optimizer.fused_states_buffer_ipc_meta,
+            inner_opt.fused_states_buffer_ipc_meta,
         )
         self.model_states_meta = (param_mappings, ipc_meta_mappings)
         self.optimizer_states_name_path = _add_variant(PADDLE_OPTIMIZER_NAME, args.optimizer_name_suffix)
@@ -612,25 +699,90 @@ class ZeroCostCheckpointCallback(TrainerCallback):
         dynamic_objects = self._pack_dynamic_objects()
         static_objects = self._pack_static_objects(args)
 
-        self.manager.update_zcc_workers(optimizer.fused_buffer_version, dynamic_objects, static_objects, global_step)
-        logger.info(f"[ZCC Callback] after first update:{optimizer.fused_states_buffer_ipc_meta}")
+        self.manager.update_zcc_workers(inner_opt.fused_buffer_version, dynamic_objects, static_objects, global_step)
+        logger.info(f"[ZCC Callback] after first update:{inner_opt.fused_states_buffer_ipc_meta}")
 
-    def _cache_meta_for_sharded_save(self, model, unused):
+    def _muon_manipulate_state_dict(self, model, optimizer):
+        state_dict = model.state_dict()
+        filtered = OrderedDict()
+        sharding_rank = optimizer._sharding_rank
+
+        local_2d_names = set()
+        for p in optimizer._rank2params_2d.get(sharding_rank, []):
+            local_2d_names.add(p.name)
+        moe_rank = optimizer._moe_sharding_rank if optimizer._moe_sharding_world_size > 1 else 0
+        for p in optimizer._rank2params_2d_moe.get(moe_rank, []):
+            local_2d_names.add(p.name)
+
+        all_2d_names = set()
+        for color_params in optimizer._params_2d_by_color.values():
+            for p in color_params:
+                all_2d_names.add(p.name)
+        all_1d_names = set(p.name for p in optimizer._params_1d)
+
+        for k, v in state_dict.items():
+            if v.name in local_2d_names:
+                filtered[k] = v
+            elif v.name in all_2d_names:
+                continue
+            elif v.name in all_1d_names:
+                filtered[k] = v
+            else:
+                # Parameters of type stop_gradient are saved by rank 0 by default.
+                # NOTE: persistable registered buffers (via register_buffer with persistable=True)
+                # also fall into this branch since they appear in model.state_dict() but are not
+                # in _params_2d_by_color or _params_1d. These buffers are NOT in
+                # optimizer._parameter_list, so get_fused_param_mappings() cannot create IPC
+                # mappings for them, which will cause the assertion there to fail. Currently the
+                # models used with Muon do not have persistable registered buffers, so this is
+                # not an issue. If a model with persistable buffers needs Muon + ZCC support,
+                # this branch and get_fused_param_mappings() must be updated accordingly.
+                if sharding_rank == 0:
+                    filtered[k] = v
+
+        inner_opt = optimizer._inner_opt
+        if inner_opt._multi_precision:
+            master_weight_names = set(inner_opt._master_weights.keys())
+            sharding_group = optimizer._hcg.get_sharding_parallel_group()
+            if sharding_group.nranks > 1:
+                tmp = []
+                paddle.distributed.all_gather_object(tmp, list(master_weight_names), group=sharding_group)
+                master_weight_names = set(name for item in tmp for name in item)
+            for k in list(filtered.keys()):
+                if filtered[k].name in master_weight_names:
+                    del filtered[k]
+
+        return filtered
+
+    def _cache_meta_for_sharded_save(self, model, optimizer):
         logger.info("Start caching metas for sharded save...")
-        (
-            self.manipulated_state_dict,
-            self.manipulated_config_to_save,
-            self.manipulated_weight_suffix,
-        ) = self.sharding_io.manipulate_state_dict_and_config(model, merge_tensor_parallel=False)
-        logger.info("Cache manipulated static dict done.")
-        if self.manipulated_config_to_save is None:
+        if _is_muon_sharding_optimizer(optimizer):
+            self.manipulated_state_dict = self._muon_manipulate_state_dict(model, optimizer)
+            self.manipulated_weight_suffix = self.args.sharded_name_suffix()
             model_to_save = unwrap_model(model)
             dtype = get_parameter_dtype(model_to_save)
             model_to_save.config.dtype = str(dtype).split(".")[1]
             self.manipulated_config_to_save = copy.deepcopy(model_to_save.config)
             self.manipulated_config_to_save.architectures = [clean_model_class_name(model_to_save.__class__.__name__)]
             self.manipulated_config_to_save = self.manipulated_config_to_save.to_json_string(use_diff=True)
-            logger.info("Cache manipulated model config done")
+            logger.info("Cache manipulated state dict done (Muon path).")
+        else:
+            (
+                self.manipulated_state_dict,
+                self.manipulated_config_to_save,
+                self.manipulated_weight_suffix,
+            ) = self.sharding_io.manipulate_state_dict_and_config(model, merge_tensor_parallel=False)
+            logger.info("Cache manipulated static dict done.")
+            if self.manipulated_config_to_save is None:
+                model_to_save = unwrap_model(model)
+                dtype = get_parameter_dtype(model_to_save)
+                model_to_save.config.dtype = str(dtype).split(".")[1]
+                self.manipulated_config_to_save = copy.deepcopy(model_to_save.config)
+                self.manipulated_config_to_save.architectures = [
+                    clean_model_class_name(model_to_save.__class__.__name__)
+                ]
+                self.manipulated_config_to_save = self.manipulated_config_to_save.to_json_string(use_diff=True)
+                logger.info("Cache manipulated model config done")
         self.model_meta = self.sharding_io.gather_distributed_model_meta()
         logger.info("Cache distributed model meta done.")
 
@@ -1449,17 +1601,22 @@ class DistInfoCollectorValidator:
         nranks = dist.get_world_size()
         if not self.args.use_hybrid_parallel or nranks <= 1:
             return None
-        if not reshard_util.is_sharding_opt(optimizer):
+        is_muon = _is_muon_sharding_optimizer(optimizer)
+        if not reshard_util.is_sharding_opt(optimizer) and not is_muon:
             return None
 
-        sharding_strategy = reshard_util.get_sharding_strategy(optimizer)
+        sharding_strategy = None
         param2rank = {}
         pp_overlap = False
-        if sharding_strategy == SHARDING_STRATEGY_V1:
-            optimizer = unwrap_optimizer(optimizer, DygraphShardingOptimizer)
-            param2rank = {k: v for (k, v) in optimizer._param2rank.items()}
+        if is_muon:
+            sharding_strategy = "MuonSharding"
         else:
-            pp_overlap = unwrap_optimizer(optimizer, DygraphShardingOptimizerV2).pp_overlap
+            sharding_strategy = reshard_util.get_sharding_strategy(optimizer)
+            if sharding_strategy == SHARDING_STRATEGY_V1:
+                optimizer = unwrap_optimizer(optimizer, DygraphShardingOptimizer)
+                param2rank = {k: v for (k, v) in optimizer._param2rank.items()}
+            else:
+                pp_overlap = unwrap_optimizer(optimizer, DygraphShardingOptimizerV2).pp_overlap
 
         structure_name_mapping = {}
         param_meta = {}
@@ -1716,18 +1873,66 @@ class ZeroCostCheckpointCallbackFcBased(ZeroCostCheckpointCallback):
 
         return state_dict
 
+    def _muon_manipulate_sharded_state_dict(self, model, optimizer):
+        sharded_state_dict = dict(sorted(model.sharded_state_dict().items()))
+        sharding_rank = optimizer._sharding_rank
+
+        local_2d_names = set()
+        for p in optimizer._rank2params_2d.get(sharding_rank, []):
+            local_2d_names.add(p.name)
+        moe_rank = optimizer._moe_sharding_rank if optimizer._moe_sharding_world_size > 1 else 0
+        for p in optimizer._rank2params_2d_moe.get(moe_rank, []):
+            local_2d_names.add(p.name)
+
+        all_2d_names = set()
+        for color_params in optimizer._params_2d_by_color.values():
+            for p in color_params:
+                all_2d_names.add(p.name)
+        all_1d_names = set(p.name for p in optimizer._params_1d)
+
+        filtered = OrderedDict()
+        for k, sw in sharded_state_dict.items():
+            static_name = sw.local_tensor.name
+            if static_name in local_2d_names:
+                filtered[k] = sw
+            elif static_name in all_2d_names:
+                continue
+            elif static_name in all_1d_names:
+                filtered[k] = sw
+            else:
+                if sharding_rank == 0:
+                    filtered[k] = sw
+
+        inner_opt = optimizer._inner_opt
+        if inner_opt._multi_precision:
+            master_weight_names = set(inner_opt._master_weights.keys())
+            sharding_group = optimizer._hcg.get_sharding_parallel_group()
+            if sharding_group.nranks > 1:
+                tmp = []
+                paddle.distributed.all_gather_object(tmp, list(master_weight_names), group=sharding_group)
+                master_weight_names = set(name for item in tmp for name in item)
+            for k in list(filtered.keys()):
+                if filtered[k].local_tensor.name in master_weight_names:
+                    del filtered[k]
+
+        return filtered
+
     def _cache_meta_for_sharded_save(self, model, optimizer):
         logger.info("Start caching metas for sharded save...")
-        (self.manipulated_state_dict) = self._manipulate_state_dict_and_config(model, optimizer)
 
-        def recover_sharded_state_dict():
-            filtered_sharded_state_dict = {}
-            model_sharded_state_dict = model.sharded_state_dict()
-            for k, v in self.manipulated_state_dict.items():
-                filtered_sharded_state_dict[k] = model_sharded_state_dict[k]
-            return filtered_sharded_state_dict
+        if _is_muon_sharding_optimizer(optimizer):
+            self.manipulated_state_dict = self._muon_manipulate_sharded_state_dict(model, optimizer)
+        else:
+            (self.manipulated_state_dict) = self._manipulate_state_dict_and_config(model, optimizer)
 
-        self.manipulated_state_dict = recover_sharded_state_dict()
+            def recover_sharded_state_dict():
+                filtered_sharded_state_dict = {}
+                model_sharded_state_dict = model.sharded_state_dict()
+                for k, v in self.manipulated_state_dict.items():
+                    filtered_sharded_state_dict[k] = model_sharded_state_dict[k]
+                return filtered_sharded_state_dict
+
+            self.manipulated_state_dict = recover_sharded_state_dict()
 
         logger.info("Cache manipulated static dict done.")
 
@@ -1784,6 +1989,7 @@ class ZeroCostCheckpointCallbackFcBased(ZeroCostCheckpointCallback):
     def _gen_unified_name(self, optimizer, model_sharded_state_dict):
         param_slice_info = {}
         padded_param = set()
+
         for buffer in optimizer._comm_buffer_list:
             for (
                 param_name,
@@ -1842,25 +2048,18 @@ class ZeroCostCheckpointCallbackFcBased(ZeroCostCheckpointCallback):
             struct_name = static_to_struct_mapping[static_name]
             unified_name = f"{struct_name}.{optim_state_type}"
 
-            flattened_range = param_slice_info[static_name]
-
-            # if flattened_range.stop - flattened_range.start == 0:
-            #     continue
             optimizer_unified_name_mapping[key] = unified_name
-            unified_slice_info[unified_name] = flattened_range
+            if static_name in param_slice_info:
+                unified_slice_info[unified_name] = param_slice_info[static_name]
 
         if master_weights is not None:
             for key, _ in master_weights.items():
                 struct_name = static_to_struct_mapping[key]
                 unified_name = f"{struct_name}.w_0"
 
-                flattened_range = param_slice_info[key]
-
-                # if flattened_range.stop - flattened_range.start == 0:
-                #     continue
-
                 optimizer_unified_name_mapping[key] = unified_name
-                unified_slice_info[unified_name] = flattened_range
+                if key in param_slice_info:
+                    unified_slice_info[unified_name] = param_slice_info[key]
 
         return optimizer_unified_name_mapping, unified_slice_info
 
@@ -1886,26 +2085,27 @@ class ZeroCostCheckpointCallbackFcBased(ZeroCostCheckpointCallback):
         return dynamic_objecs
 
     def maybe_update_zcc_worker(self, args, model, optimizer, global_step):
-        # logger.info(f"check should update :{optimizer.fused_buffer_version} vs {self.manager.cache_version}")
-        if optimizer.fused_buffer_version == self.manager.cache_version:
+        inner_opt = _unwrap_opt_for_fused_states(optimizer)
+
+        if inner_opt.fused_buffer_version == self.manager.cache_version:
             return
 
         logger.info("ZCC checkpoint workers need upgrade.")
         self._cache_meta_for_sharded_save(model, optimizer)
         param_mappings, ipc_meta_mappings = get_fused_param_mappings(optimizer, self.manipulated_state_dict)
         self.optimizer_states_meta = (
-            optimizer.fused_states_accumulators_meta,
-            optimizer.fused_states_master_weights_meta,
+            inner_opt.fused_states_accumulators_meta,
+            inner_opt.fused_states_master_weights_meta,
             None,
-            optimizer.fused_states_buffer_ipc_meta,
+            inner_opt.fused_states_buffer_ipc_meta,
         )
 
         self.model_states_meta = (param_mappings, ipc_meta_mappings)
         dynamic_objects = self._pack_dynamic_objects()
         static_objects = self._pack_static_objects(args)
 
-        self.manager.update_zcc_workers(optimizer.fused_buffer_version, dynamic_objects, static_objects, global_step)
-        logger.info(f"[ZCC Callback] after first update:{optimizer.fused_states_buffer_ipc_meta}")
+        self.manager.update_zcc_workers(inner_opt.fused_buffer_version, dynamic_objects, static_objects, global_step)
+        logger.info(f"[ZCC Callback] after first update:{inner_opt.fused_states_buffer_ipc_meta}")
 
 
 class ZeroCostCheckpointWorkerFcBased(ZeroCostCheckpointWorker):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Zcc Adapter Muon
1. Zcc supports saving Muon optimizer states and online EMA parameter merging.
2. The Muon optimizer supports restoring bf16 weights from master_weight.
3. Fixed the issue of incorrect GPU operations in Zcc Ema.
