### PR TITLE
Fix model_config summary logging for GPT provider

### DIFF
--- a/paddleformers/transformers/gpt_provider.py
+++ b/paddleformers/transformers/gpt_provider.py
@@ -50,6 +50,7 @@ from paddlefleet.gpt_builders import gpt_builder
 
 from paddleformers.transformers.model_utils import PretrainedModel
 
+from .auto.configuration import AutoConfig
 from .model_provider import ModelProviderMixin
 
 logger = logging.getLogger(__name__)
@@ -60,6 +61,10 @@ class GPTModel(FleetGPTModel, PretrainedModel):
     GPTModel class that inherits from FleetGPTModel.
     This class requires paddlefleet to be installed.
     """
+
+    # Mark PaddleFleet GPT models as config-backed so VisualDL/TensorBoard can
+    # emit `model_config` text summaries for provider-based pipeline models.
+    config_class = AutoConfig
 
     def get_input_embeddings(self):
         """获取 embedding.embed_tokens 层"""


### PR DESCRIPTION
## Summary
- 给 `paddleformers.transformers.gpt_provider.GPTModel` 补 `config_class = AutoConfig`
- 让 provider-based PaddleFleet GPT 路径满足 `constructed_from_pretrained_config()` 条件
- 使 VisualDL/TensorBoard 能输出 `model_config/text_summary`

## Test plan
- [x] `python -m py_compile paddleformers/transformers/gpt_provider.py`
- [x] 重跑 PaddleFleet 训练并确认 event 文件中出现 `model_config/text_summary`