### PR TITLE
[Deps] Pin paddlecodec to `>=0.2, <0.3` for Paddle 3.4 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ huggingface_hub>=0.19.2
 protobuf>=3.20.2
 visualdl
 safetensors
-paddlecodec; sys_platform == 'linux'
+paddlecodec>=0.2, <0.3; sys_platform == 'linux'
 fast_dataindex>=0.1.1 ; platform_system == "Linux"
 aistudio-sdk>=0.3.0
 jinja2


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what this PR does -->

固定 formers 依赖的 paddlecodec 到 `0.2`，用于 Paddle 3.4 ABI