### PR TITLE
fix_Qwen3VLVisionProvider_fa_version_bug

### DIFF
--- a/paddleformers/transformers/qwen3_vl/modeling_fleet.py
+++ b/paddleformers/transformers/qwen3_vl/modeling_fleet.py
@@ -991,7 +991,9 @@ class Qwen3VLProvider(TransformerConfig):
     def from_config(cls, config):
         res = super().from_config(config)
         res.vision_config = Qwen3VLVisionProvider.from_config(config.vision_config)
+        res.vision_config.fa_version = config.fa_version
         res.text_config = Qwen3VLTextProvider.from_config(config.text_config)
+
         res.vision_config.normalization = "LayerNorm"
         res.vision_config.gated_linear_unit = False
         res.text_config.multimodal_embedding = True


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->

- 原因：

Qwen3VLModel分为视觉模型和语言模型，视觉模型用的是Qwen3VLVisionProvider config， 语言模型用的Qwen3VLTextProvider config，这两套 config 是分开构建的，在 from_config 里：

```
res.vision_config = Qwen3VLVisionProvider.from_config(config.vision_config)  # 视觉
res.text_config   = Qwen3VLTextProvider.from_config(config.text_config)       # 语言
```


Qwen3VLTextProvider.from_config(config.text_config) 传入的是 config.text_config，而 fa_version=4 就存在 text_config.__dict__ 里，所以 register_attributes 遍历时能找到它,
Qwen3VLVisionProvider.from_config(config.vision_config) 传入的是 config.vision_config，它是 Qwen3VLVisionConfig 对象，没有 fa_version 这个字段，所以默认值是2


- 解决办法：

在构建完 vision_config 之后，显式用 config.fa_version 赋值