### PR TITLE
[fix] step control & acc divide logic

### DIFF
--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -1990,12 +1990,6 @@ class Trainer:
         steps_in_epoch = (
             len_dataloader if len_dataloader is not None else args.max_steps * args.gradient_accumulation_steps
         )
-        if len_dataloader is not None:
-            if self.args.gradient_accumulation_steps > len_dataloader:
-                logger.warning(
-                    f"changing accumulation step from `{self.args.gradient_accumulation_steps}` to `{len_dataloader}` to avoid, cross epoch accumulate"
-                )
-                self.args.gradient_accumulation_steps = len_dataloader
 
         self.callback_handler.model = self.model
         self.callback_handler.optimizer = self.optimizer
@@ -2025,6 +2019,8 @@ class Trainer:
         if self.resume_from_custom_func is not None:
             self.resume_from_custom_func(model)
 
+        step_control = 0  # used in loop control, reset at each epoch boundary via forced flush
+        self.current_gradient_accumulation_steps = args.gradient_accumulation_steps
         for epoch in range(epochs_trained, num_train_epochs):
             if (
                 not args.enable_auto_parallel
@@ -2032,8 +2028,6 @@ class Trainer:
                 and isinstance(train_dataloader.batch_sampler, (MappingBatchSampler, MappingDistributedBatchSampler))
             ):
                 train_dataloader.batch_sampler.set_epoch(epoch, consumed_samples)
-
-            step_control = 0  # used in loop control, reset to 0 after every step
             self.control = self.callback_handler.on_epoch_begin(args, self.state, self.control)
 
             step = -1
@@ -2097,9 +2091,9 @@ class Trainer:
                     # skip this step
 
                     if (step_control + 1) % self.args.gradient_accumulation_steps == 0 or (
-                        # last step in epoch but step is always smaller than gradient_accumulation_steps
-                        steps_in_epoch <= args.gradient_accumulation_steps
-                        and (step + 1) == steps_in_epoch
+                        # last step in epoch: flush remaining accumulated gradients
+                        (step + 1)
+                        == steps_in_epoch
                     ):
                         # update current global step and skip step
                         self.state.global_step += 1
@@ -2152,6 +2146,13 @@ class Trainer:
 
                 for inputs in inputs_list:
                     if step_control % args.gradient_accumulation_steps == 0:
+                        # Compute actual accumulation steps for this group
+                        # (may be less than gradient_accumulation_steps at end of epoch)
+                        remaining_steps_in_epoch = steps_in_epoch - step
+
+                        self.current_gradient_accumulation_steps = min(
+                            args.gradient_accumulation_steps, remaining_steps_in_epoch
+                        )
                         self.control = self.callback_handler.on_step_begin(args, self.state, self.control)
                         self.timers and self.timers("forward-backward").start()
 
@@ -2160,11 +2161,11 @@ class Trainer:
                         # stage2 and stage3 should not no_sync, because the is no DDP wrapper and no_sync API
                         # hybrid_parallel (tp or pp or sharding stage 1) should not no_sync
                         available_no_sync = hasattr(model, "no_sync")
+                        do_sync_step = (step_control + 1) % args.gradient_accumulation_steps == 0 or (
+                            step + 1
+                        ) == steps_in_epoch
                         is_no_sync = (
-                            (
-                                ((step_control + 1) % args.gradient_accumulation_steps != 0)
-                                and args._no_sync_in_gradient_accumulation
-                            )
+                            ((not do_sync_step) and args._no_sync_in_gradient_accumulation)
                             or args.recompute_granularity is not None
                             or args.use_expert_parallel
                         ) and available_no_sync
@@ -2234,9 +2235,8 @@ class Trainer:
                     disable_accumulation = False
 
                     if (step_control + 1) % args.gradient_accumulation_steps == 0 or (
-                        # last step in epoch but step is always smaller than gradient_accumulation_steps
-                        steps_in_epoch <= args.gradient_accumulation_steps
-                        and (step + 1) == steps_in_epoch
+                        # last step in epoch: flush remaining accumulated gradients
+                        (step + 1) == steps_in_epoch
                         or disable_accumulation
                     ):
                         # assert if loss is invalid
@@ -2341,7 +2341,7 @@ class Trainer:
                         logger.info(
                             f"[DataLoad global_step: {self.state.global_step}] "
                             f"data_load_time: {_data_load_time_for_global_step * 1000:.2f} ms "
-                            f"(accumulated over {args.gradient_accumulation_steps} micro-batches)"
+                            f"(accumulated over {self.current_gradient_accumulation_steps} micro-batches)"
                         )
                         self._print_timer()
                         # Reset data loading timer for next global_step
@@ -3737,7 +3737,7 @@ class Trainer:
         Return:
             `paddle.Tensor`: The tensor with training loss on this batch.
         """
-        if is_paddlefleet_available() and self.using_fleet_model:
+        if is_paddlefleet_available() and self.using_fleet_model and self.args.pipeline_model_parallel_size > 1:
             return self.training_pipeline_step(model, inputs)
 
         if self.args.pipeline_model_parallel_size > 1:
@@ -3756,7 +3756,7 @@ class Trainer:
         else:
             loss.backward()
         if self.args.gradient_accumulation_steps > 1:
-            loss = loss / self.args.gradient_accumulation_steps
+            loss = loss / getattr(self, "current_gradient_accumulation_steps", self.args.gradient_accumulation_steps)
 
         if not self.args.enable_auto_parallel:
             return loss.detach()

--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -2019,7 +2019,6 @@ class Trainer:
         if self.resume_from_custom_func is not None:
             self.resume_from_custom_func(model)
 
-        step_control = 0  # used in loop control, reset at each epoch boundary via forced flush
         self.current_gradient_accumulation_steps = args.gradient_accumulation_steps
         for epoch in range(epochs_trained, num_train_epochs):
             if (
@@ -2028,6 +2027,7 @@ class Trainer:
                 and isinstance(train_dataloader.batch_sampler, (MappingBatchSampler, MappingDistributedBatchSampler))
             ):
                 train_dataloader.batch_sampler.set_epoch(epoch, consumed_samples)
+            step_control = 0
             self.control = self.callback_handler.on_epoch_begin(args, self.state, self.control)
 
             step = -1
@@ -2093,7 +2093,7 @@ class Trainer:
                     if (step_control + 1) % self.args.gradient_accumulation_steps == 0 or (
                         # last step in epoch: flush remaining accumulated gradients
                         (step + 1)
-                        == steps_in_epoch
+                        >= steps_in_epoch
                     ):
                         # update current global step and skip step
                         self.state.global_step += 1
@@ -2163,7 +2163,7 @@ class Trainer:
                         available_no_sync = hasattr(model, "no_sync")
                         do_sync_step = (step_control + 1) % args.gradient_accumulation_steps == 0 or (
                             step + 1
-                        ) == steps_in_epoch
+                        ) >= steps_in_epoch
                         is_no_sync = (
                             ((not do_sync_step) and args._no_sync_in_gradient_accumulation)
                             or args.recompute_granularity is not None
@@ -2234,11 +2234,9 @@ class Trainer:
 
                     disable_accumulation = False
 
-                    if (step_control + 1) % args.gradient_accumulation_steps == 0 or (
-                        # last step in epoch: flush remaining accumulated gradients
-                        (step + 1) == steps_in_epoch
-                        or disable_accumulation
-                    ):
+                    _cond_acc = (step_control + 1) % args.gradient_accumulation_steps == 0
+                    _cond_epoch_end = (step + 1) >= steps_in_epoch
+                    if _cond_acc or (_cond_epoch_end or disable_accumulation):
                         # assert if loss is invalid
                         self._check_loss_valid(tr_loss)
 
@@ -2368,6 +2366,72 @@ class Trainer:
                 )
                 self.control.should_training_stop = True
 
+            # Epoch tail: flush partial accumulated gradients as an optimizer step.
+            # When len(dataloader) is not a multiple of gradient_accumulation_steps,
+            # the tail micro-batches have accumulated gradients but never triggered
+            # an optimizer step inside the loop.  Do it now so global_step advances.
+            if step_control > 0:
+                logger.info(
+                    f"[epoch_tail_flush] Flushing {step_control} accumulated micro-batch "
+                    f"gradients at epoch {epoch} end as optimizer step."
+                )
+                _tail_parameters_list = None
+                if not args.enable_auto_parallel:
+                    if hasattr(self.optimizer, "_hcg"):
+                        hybrid_parallel_scale_param_grad(list(model.parameters()), self.optimizer._hcg)
+
+                    if (args.recompute_granularity is not None or args.use_expert_parallel) and available_no_sync:
+                        fused_allreduce_gradients_no_sync(list(model.parameters()), None)
+                    elif dp_master_grad:
+                        fused_allreduce_gradients_no_sync(list(model.parameters()), None)
+
+                    enable_dp_comm_overlap = self.args.pipeline_model_parallel_size > 1 and args.dp_comm_overlap
+                    if isinstance(self.optimizer, HybridParallelOptimizer) and not self.do_grad_scaling:
+                        _tail_parameters_list = _obtain_optimizer_parameters_list(self.optimizer._inner_opt)
+                        if not enable_dp_comm_overlap:
+                            if self.optimizer._sharding_enable:
+                                self.optimizer._inner_opt.reduce_gradients(
+                                    list(_tail_parameters_list), self.optimizer._hcg
+                                )
+                            if self.optimizer._dp_enable or getattr(self.optimizer, "_sep_enable", False):
+                                fused_allreduce_gradients_no_sync(list(_tail_parameters_list), self.optimizer._hcg)
+
+                # Scale gradients by actual micro-batch count (not gradient_accumulation_steps)
+                if not args.enable_auto_parallel and self.args.gradient_accumulation_steps > 1:
+                    paddle.device.synchronize()
+                    parameters = model._layers.parameters() if hasattr(model, "_layers") else model.parameters()
+                    for p in parameters:
+                        with paddle.no_grad():
+                            if hasattr(p, "main_grad") and p.main_grad is not None:
+                                assert p.grad is None
+                                p.main_grad.scale_(1.0 / step_control)
+                            elif p.grad is not None:
+                                p.grad.scale_(1.0 / step_control)
+
+                self.callback_handler.on_optimizer_begin(
+                    args, self.state, self.control, scaler=self.scaler if self.do_grad_scaling else None
+                )
+                self.optimizer_step(args, model=model, parameters_list=_tail_parameters_list)
+                self.callback_handler.on_optimizer_end(
+                    args, self.state, self.control, scaler=self.scaler if self.do_grad_scaling else None
+                )
+
+                self.state.global_step += 1
+                logger.info(
+                    f"[epoch_tail_flush] optimizer step done! epoch={epoch} "
+                    f"step_control={step_control} new_global_step={self.state.global_step}"
+                )
+                self.state.epoch = epoch + 1.0
+                self.control = self.callback_handler.on_step_end(args, self.state, self.control)
+                self._maybe_log_save_evaluate(tr_loss, model, epoch, ignore_keys_for_eval, inputs=inputs)
+                logger.info(
+                    f"[DataLoad global_step: {self.state.global_step}] "
+                    f"data_load_time: {_data_load_time_for_global_step * 1000:.2f} ms "
+                    f"(accumulated over {step_control} micro-batches, epoch tail)"
+                )
+                _data_load_time_for_global_step = 0.0
+                step_control = 0
+
             self.control = self.callback_handler.on_epoch_end(args, self.state, self.control)
 
             if self.args.enable_auto_parallel:
@@ -2380,6 +2444,7 @@ class Trainer:
                 break
 
             consumed_samples = 0
+            steps_trained_in_current_epoch = 0
 
         if args.past_index and hasattr(self, "_past"):
             # Clean the state at the end of training


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
APIs

### Description
**修复 Trainer 中 step 控制逻辑与梯度累积除法逻辑的问题**

**问题背景：**

1. **跨 epoch 梯度累积问题（step_control 初始化位置错误）** 
原来 `step_control = 0` 在每个 epoch 循环内部初始化，实际上会在每个 epoch 开始时重置，无法跨 epoch 边界正确管理梯度刷新。修复后移到 epoch 循环外初始化，并在每个 epoch 末尾强制 flush 剩余累积梯度。
2. **epoch 末尾梯度更新变更** 
原来会在一个global_step内攒够acc_step之后再刷新，出现跨epoch的情况，为和transformers对齐，修复为 `(step+1) == steps_in_epoch`，即在每个 epoch 最后一步时均强制刷新剩余梯度。同时，在 epoch 末尾，引入 `current_gradient_accumulation_steps`，在每个 accumulation group 开始时动态计算实际累积步数（取 `gradient_accumulation_steps` 与 epoch 剩余步数的较小值），并在 loss 归一化和日志记录中使用该动态值。
3. **移除不必要的 gradient_accumulation_steps 自动截断逻辑** 
删除了原来对 `gradient_accumulation_steps > len_dataloader` 时自动修改参数的 warning 和强制截断，由上述 epoch 末尾 flush 逻辑自然处理边界情况。
4. **pipeline 模型 training_step 路由修复** 
修复 `training_step` 中对 `training_pipeline_step` 的调用条件，增加 `pipeline_model_parallel_size > 1` 判断，避免非流水线并行场景下误走 pipeline 分支造成paddle/distributed/fleet/meta_parallel/pipeline_parallel.py", line 276, in _load_micro_batch_impl
    assert len(data) == self._acc_steps, (
AssertionError: length of data should be 1, but it is【xx】的问题