### PR TITLE
[Deps] pin paddlecodec to `>=0.1, <0.2` for Paddle 3.3 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ protobuf>=3.20.2
 visualdl
 safetensors
 decord
-paddlecodec; sys_platform == 'linux'
+paddlecodec>=0.1, <0.2; sys_platform == 'linux'
 fast_dataindex>=0.1.1 ; platform_system == "Linux"
 aistudio-sdk>=0.3.0
 jinja2

--- a/scripts/regression/ci_model_unittest.sh
+++ b/scripts/regression/ci_model_unittest.sh
@@ -92,7 +92,7 @@ else
         echo "file_name: ${file_name}, ext: ${file_name##*.}"
         
         [[ -f "$file_name" ]] || continue
-        if [[ "$ext" == "py" ]] || [[ "$ext" == "yml" ]] || [[ "$base_name" == "requirements.txt" ]]; then
+        if [[ "$ext" == "py" ]] || [[ "$ext" == "yml" ]] || [[ "$file_name" == "requirements.txt" ]]; then
             FLAGS_enable_CI=true
             break
         fi

--- a/scripts/regression/ci_model_unittest.sh
+++ b/scripts/regression/ci_model_unittest.sh
@@ -92,7 +92,7 @@ else
         echo "file_name: ${file_name}, ext: ${file_name##*.}"
         
         [[ -f "$file_name" ]] || continue
-        if [[ "$ext" == "py" ]]; then
+        if [[ "$ext" == "py" ]] || [[ "$ext" == "yml" ]] || [[ "$base_name" == "requirements.txt" ]]; then
             FLAGS_enable_CI=true
             break
         fi

--- a/scripts/unit_test/ci_unittest.sh
+++ b/scripts/unit_test/ci_unittest.sh
@@ -101,7 +101,7 @@ else
         ext="${file_name##*.}"
         echo "file_name: ${file_name}, ext: ${file_name##*.}"
         [[ -f "$file_name" ]] || continue
-        if [[ "$ext" == "py" ]] || [[ "$ext" == "yml" ]] || [[ "$base_name" == "requirements.txt" ]]; then
+        if [[ "$ext" == "py" ]] || [[ "$ext" == "yml" ]] || [[ "$file_name" == "requirements.txt" ]]; then
             FLAGS_enable_CI=true
             break
         fi

--- a/scripts/unit_test/ci_unittest.sh
+++ b/scripts/unit_test/ci_unittest.sh
@@ -101,7 +101,7 @@ else
         ext="${file_name##*.}"
         echo "file_name: ${file_name}, ext: ${file_name##*.}"
         [[ -f "$file_name" ]] || continue
-        if [[ "$ext" == "py" ]]; then
+        if [[ "$ext" == "py" ]] || [[ "$ext" == "yml" ]] || [[ "$base_name" == "requirements.txt" ]]; then
             FLAGS_enable_CI=true
             break
         fi


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Others

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

Others

### Description
<!-- Describe what this PR does -->

固定 formers 依赖的 paddlecodec 到 `0.1`，用于 Paddle 3.3 ABI

cherry-pick of #4348