### PR TITLE
[Qwen3Moe] Add pad_token_id fallback

### DIFF
--- a/paddleformers/transformers/qwen3_moe/configuration.py
+++ b/paddleformers/transformers/qwen3_moe/configuration.py
@@ -219,9 +219,7 @@ class Qwen3MoeConfig(PretrainedConfig):
         self.mlp_only_layers = [] if mlp_only_layers is None else mlp_only_layers
         self.moe_subbatch_token_num_before_dispatch = moe_subbatch_token_num_before_dispatch
 
-        if kwargs.get("pad_token_id", None) is None and kwargs.get(
-            "bos_token_id", None
-        ) is not None:
+        if kwargs.get("pad_token_id", None) is None and kwargs.get("bos_token_id", None) is not None:
             kwargs["pad_token_id"] = kwargs["bos_token_id"]
 
         super().__init__(

--- a/paddleformers/transformers/qwen3_moe/configuration.py
+++ b/paddleformers/transformers/qwen3_moe/configuration.py
@@ -219,6 +219,11 @@ class Qwen3MoeConfig(PretrainedConfig):
         self.mlp_only_layers = [] if mlp_only_layers is None else mlp_only_layers
         self.moe_subbatch_token_num_before_dispatch = moe_subbatch_token_num_before_dispatch
 
+        if kwargs.get("pad_token_id", None) is None and kwargs.get(
+            "bos_token_id", None
+        ) is not None:
+            kwargs["pad_token_id"] = kwargs["bos_token_id"]
+
         super().__init__(
             tie_word_embeddings=tie_word_embeddings,
             **kwargs,


### PR DESCRIPTION
## 背景

Qwen3Moe 的配置在部分模型目录中没有显式写入 `pad_token_id`，但 tokenizer 的 padding token 与 `bos_token_id` 对齐。下游从 `AutoConfig` 构造 provider 时如果拿不到 pad id，会导致 Fleet 侧无法区分真实 padding token，进而影响 MoE embedding padding mask。

## 改动

- 当 `Qwen3MoeConfig` 未提供 `pad_token_id` 且存在 `bos_token_id` 时，将 `pad_token_id` fallback 为 `bos_token_id`。
- 保持已显式配置 `pad_token_id` 的模型行为不变。

## 验证

- `python -m py_compile PaddleFormers/paddleformers/transformers/qwen3_moe/configuration.py`
- Qwen3 config/provider smoke：`cfg.pad_token_id=151643`，`provider.pad_token_id=151643`。

<div align="right">
   <sup>This PR is co-authored with @codex (gpt-5.5 xhigh)</sup>
</div>