### PR TITLE
[FinetuningArgs] Support compute_type=float32 for full precision training

### DIFF
--- a/paddleformers/cli/hparams/finetuning_args.py
+++ b/paddleformers/cli/hparams/finetuning_args.py
@@ -331,6 +331,10 @@ class FinetuningArguments(
             }
         elif self.compute_type == "nf4":
             self.weight_quantize_algo = {"nf4": DEFAULT_QUANTIZE_LAYERS}
+        elif self.compute_type == "float32":
+            self.bf16 = False
+            self.fp16 = False
+            self.weight_quantize_algo = None
         else:
             raise ValueError(f"Unknown compute_type: {self.compute_type}")
 


### PR DESCRIPTION
## 问题

`FinetuningArguments.__post_init__` 中未处理 `compute_type='float32'` 的情况，使用时会抛出：

```
ValueError: Unknown compute_type: float32
```

## 修复

在 `paddleformers/cli/hparams/finetuning_args.py` 中添加 `float32` 分支：

```python
elif self.compute_type == "float32":
    self.bf16 = False
    self.fp16 = False
    self.weight_quantize_algo = None
```

## 使用场景

在训练配置文件中指定 `compute_type: float32` 即可使用纯 float32 精度训练，适用于：
- 数值对齐验证（与 HuggingFace/Swift 对比训练 loss）
- 调试场景（避免 bf16/fp16 精度误差干扰）
