### PR TITLE
Fix up and gate fused axis error

### DIFF
--- a/paddleformers/transformers/kimi_k2/modeling.py
+++ b/paddleformers/transformers/kimi_k2/modeling.py
@@ -68,7 +68,7 @@ class KimiK2PretrainedModel(PretrainedModel):
         # layer 0 config.first_k_dense_replace
         aoa_config["aoa_statements"] += [
             "model.layers.0.mlp.down_proj.weight^T -> model.layers.0.mlp.down_proj.weight",
-            "model.layers.0.mlp.gate_proj.weight^T ,model.layers.0.mlp.up_proj.weight^T ->  model.layers.0.mlp.up_gate_proj.weight, axis=1",
+            "model.layers.0.mlp.gate_proj.weight^T ,model.layers.0.mlp.up_proj.weight^T ->  model.layers.0.mlp.up_gate_proj.weight, fused_ffn",
         ]
 
         # layer 1 -> num_hidden_layers


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->
修复 kimi 模型 AOA 权重转换配置错误。
问题：Dense Layer 和 Shared Expert 使用 `axis=1` 配置会导致 TP 切分时 up_proj 权重数据丢失。
原因： `axis=1` 采用"先融合再切分"策略，gate^T 和 up^T 融合后 TP 切分只取前 intermediate_size 列，up^T 数据被丢弃。
修复： 将配置改为 `fused_ffn`，采用"先切分再融合"策略，确保每个 GPU 正确获得 gate/tp + up/tp 的权重数据。