### PR TITLE
fix SFTDataset :  refine num_proc and num_workers co-existence check

### DIFF
--- a/paddleformers/datasets/SFTDataset.py
+++ b/paddleformers/datasets/SFTDataset.py
@@ -90,8 +90,6 @@ class BaseSFTDataset:
         # check
         if not self.dataset_num_proc:
             self.dataset_num_proc = 1
-        if self.dataset_num_proc > 1 and self.dataloader_num_workers > 0:
-            raise ValueError("dataset_num_proc and dataloader_num_workers can not be set simultaneously now.")
         if self.truncate_packing and not self.is_pretraining:
             logger.warning_once("Truncate packing is only valid in pretraining data flow")
         if self.is_pretraining and self.packing and self.truncate_packing:
@@ -948,6 +946,8 @@ class BaseSFTDataset:
 class IteratorSFTDataset(BaseSFTDataset, IterableDataset):
     def __init__(self, **dataset_config):
         super().__init__(**dataset_config)
+        if self.dataset_num_proc > 1 and self.dataloader_num_workers > 0:
+            raise ValueError("dataset_num_proc and dataloader_num_workers cannot be set simultaneously.")
 
     def __iter__(self):
         if self.is_valid:
@@ -960,6 +960,11 @@ class IteratorSFTDataset(BaseSFTDataset, IterableDataset):
 class MapSFTDataset(BaseSFTDataset, Dataset):
     def __init__(self, **dataset_config):
         super().__init__(**dataset_config)
+        if self.dataset_num_proc > 1 and self.dataloader_num_workers > 0:
+            logger.warning(
+                "dataset_num_proc and dataloader_num_workers are both set, "
+                "which may cause confusion and potential performance issues."
+            )
 
         self.packed_idx_cache_dir = dataset_config.get("packed_idx_cache_dir", None)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
Bug fixes

### PR changes
APIs

### Description
修改了针对参数的错误检查逻辑，现在 MapSFTDataset 下只会提出警告，不会报不必要的错误。但是仍然不建议同时开启dataset_num_proc 和 dataset_num_workers ，同时开启会导致性能开销增加。
Refine the co-existence check for `dataset_num_proc` and `dataloader_num_workers`:
- IteratorSFTDataset: keep raising ValueError (genuine conflict during training)
- MapSFTDataset: emit warning instead of error (no real conflict, they operate in different phases)

Previously the check was commented out entirely (line 93-94). Now it's properly split by dataset type.
