### PR TITLE
[Qwen2MoE] Fix gradient alignment: remove fake_path and use clear_grad(set_to_zero=False)

### DIFF
--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -1791,7 +1791,11 @@ class Trainer:
                     for buffer in buffers:
                         buffer._clear_grad_storage()
         else:
-            self.optimizer.clear_grad()
+            # Use set_to_zero=False so that parameters not activated in the next step
+            # keep grad=None rather than a zero tensor. With set_to_zero=True (the default),
+            # AdamW would still apply weight_decay to inactive MoE experts (grad=0 tensor ≠ grad=None),
+            # causing weight divergence from PyTorch/HF which does not update inactive experts at all.
+            self.optimizer.clear_grad(set_to_zero=False)
 
     def _get_meshes_for_loader(self):
         return self.global_mesh.get_mesh_with_dim("pp")[0]

--- a/paddleformers/transformers/qwen2_moe/modeling.py
+++ b/paddleformers/transformers/qwen2_moe/modeling.py
@@ -342,29 +342,25 @@ class Qwen2MoeSparseMoeBlock(nn.Layer):
             expert_mask = paddle.nn.functional.one_hot(selected_experts, num_classes=self.num_experts).permute(2, 1, 0)
             # [num_experts, topk, bs*seq]
             tokens_per_expert = expert_mask.reshape([expert_mask.shape[0], -1]).sum(axis=-1)
-            # Loop over all available experts in the model and perform the computation on each expert
-            for expert_idx in range(self.num_experts):
+            # Only iterate over experts that have at least one assigned token.
+            # This avoids fake_path (running inactive experts with zero input) which produced
+            # grad=0 tensors for inactive expert weights, causing AdamW weight decay to diverge
+            # from PyTorch/HF where inactive experts have grad=None and are not updated.
+            expert_hit = paddle.greater(
+                expert_mask.sum(axis=(-1, -2)), paddle.zeros([1], dtype=expert_mask.dtype)
+            ).nonzero()
+            for expert_idx in expert_hit:
+                expert_idx = int(expert_idx[0])  # must be Python int for LayerList indexing
                 expert_layer = self.experts[expert_idx]
                 top_x, idx = paddle.where(expert_mask[expert_idx])
                 # Index the correct hidden states and compute the expert hidden state for
                 # the current expert. We need to make sure to multiply the output hidden
                 # states by `routing_weights` on the corresponding tokens (top-1 and top-2)
-                if tokens_per_expert[expert_idx] <= 0.1:
-                    if self.training and paddle.is_grad_enabled():
-                        fake_top_x = paddle.zeros(1, dtype=paddle.int64)
-                        fakse_current_state = hidden_states[fake_top_x, None].reshape([-1, hidden_states.shape[-1]])
-                        fake_state = expert_layer(fakse_current_state * 0)
-                        final_hidden_states.index_add_(
-                            index=fake_top_x, axis=0, value=fake_state.to(hidden_states.dtype)
-                        )
-                    else:
-                        continue
-                else:
-                    current_state = hidden_states[idx, None].reshape([-1, hidden_states.shape[-1]])
-                    current_hidden_states = expert_layer(current_state) * routing_weights[idx, top_x].unsqueeze(-1)
-                    final_hidden_states.index_add_(
-                        index=idx.reshape([-1]), axis=0, value=current_hidden_states.to(hidden_states.dtype)
-                    )
+                current_state = hidden_states[idx, None].reshape([-1, hidden_states.shape[-1]])
+                current_hidden_states = expert_layer(current_state) * routing_weights[idx, top_x].unsqueeze(-1)
+                final_hidden_states.index_add_(
+                    index=idx.reshape([-1]), axis=0, value=current_hidden_states.to(hidden_states.dtype)
+                )
 
         shared_expert_output = self.shared_expert(hidden_states)
         shared_expert_output = F.sigmoid(self.shared_expert_gate(hidden_states)) * shared_expert_output


### PR DESCRIPTION
## Problem

When training Qwen2MoE with PaddleFormers, post-optimizer weights diverge from HuggingFace (PyTorch) starting from step 2. Two root causes were identified, both related to MoE expert activation behavior.

## Root Causes & Fixes

### Fix 1: Remove fake_path from `Qwen2MoeSparseMoeBlock` (`modeling.py`)

The original code iterated over all 64 experts for every step, using a "fake path" for inactive ones:
```python
fake_state = expert_layer(fake_current_state * 0)  # runs the full MLP with zero input
```

This produced **grad=0 tensors** for all inactive expert parameters. AdamW treats `grad=0` differently from `grad=None` — it still applies `weight_decay` to parameters with `grad=0`, causing inactive expert weights to slowly drift away from the HuggingFace reference after each optimizer step.

**Fix**: Replace the all-experts loop + fake_path with `nonzero()`-based iteration that only processes experts with at least one assigned token — matching the HF implementation exactly and keeping inactive expert gradients as `None`.

```python
# Before: loop over all 64 experts, fake_path for inactive ones
for expert_idx in range(self.num_experts):
    if tokens_per_expert[expert_idx] <= 0.1:
        fake_state = expert_layer(x * 0)  # produces grad=0, diverges from HF

# After: only process active experts, inactive stay grad=None
expert_hit = paddle.greater(...).nonzero()
for expert_idx in expert_hit:
    expert_idx = int(expert_idx[0])
    ...
```

### Fix 2: `clear_grad(set_to_zero=False)` in `trainer.py`

The default `clear_grad()` (equivalent to `set_to_zero=True`) zeros out all gradients at the end of each step, which revives the `grad=0` problem for the next step even after Fix 1. Using `set_to_zero=False` keeps `grad=None` for parameters that were not activated, so AdamW correctly skips them — matching PyTorch/HF behavior.

This fix is consistent with the same change already applied for Qwen3MoE in PR #4358.

## Verification

Tested on `Qwen2-57B-A14B-Instruct` (reduced to 3 hidden layers for speed). Training loss aligned with Swift/HuggingFace reference across 50 steps (MAE = 0.0, bit-exact).

## Related

- PR #4358: same `clear_grad(set_to_zero=False)` fix for Qwen3MoE