### PR TITLE
refactor(fp8): merge clear_origin_weight_when_offline_quant into offline_quant_expert_weight

### DIFF
--- a/examples/config/pt/eb45_pretrain/300b_4_nodes_ce.yaml
+++ b/examples/config/pt/eb45_pretrain/300b_4_nodes_ce.yaml
@@ -115,7 +115,6 @@ ernie_model_config:
         recompute_fwd_gate_up: [6, 7, 8, 11, 12, 13, 16, 17, 18]
         dequant_input: true
         offline_quant_expert_weight: true
-        clear_origin_weight_when_offline_quant: true
     fp8_fused_ops_configs:
         stack_quant: true
         swiglu_probs_bwd: true

--- a/examples/config/pt/eb45_pretrain/300b_8_gpus_ci.yaml
+++ b/examples/config/pt/eb45_pretrain/300b_8_gpus_ci.yaml
@@ -107,7 +107,6 @@ ernie_model_config:
         recompute_fwd_gate_up: [6, 7, 8, 11, 12, 13, 16, 17, 18]
         dequant_input: true
         offline_quant_expert_weight: true
-        clear_origin_weight_when_offline_quant: true
     fp8_fused_ops_configs:
         stack_quant: true
         swiglu_probs_bwd: true

--- a/examples/config/pt/eb45_pretrain/300b_96gpus_small_acc.yaml
+++ b/examples/config/pt/eb45_pretrain/300b_96gpus_small_acc.yaml
@@ -110,7 +110,6 @@ ernie_model_config:
         recompute_fwd_gate_up: [6, 7, 8, 11, 12, 13, 16, 17, 18]
         dequant_input: true
         offline_quant_expert_weight: true
-        clear_origin_weight_when_offline_quant: true
     fp8_fused_ops_configs:
         stack_quant: true
         swiglu_probs_bwd: true

--- a/examples/experiments/deepseek_v3_pretrain/config/configuration.py
+++ b/examples/experiments/deepseek_v3_pretrain/config/configuration.py
@@ -185,7 +185,6 @@ class DeepseekV2FastConfig(PretrainedConfig):
         fakse_gate_restrict_balance=False,
         adaptive_remained_O1_recompute_ratio=0,
         offline_quant_expert_weight=True,
-        clear_origin_weight_when_offline_quant=True,
         mlp_bwd_subbatch_rows=0,
         mlp_fwd_subbatch_rows=0,
         output_subbatch_rows=0,
@@ -259,7 +258,6 @@ class DeepseekV2FastConfig(PretrainedConfig):
         self.fakse_gate_restrict_balance = fakse_gate_restrict_balance
         self.adaptive_remained_O1_recompute_ratio = adaptive_remained_O1_recompute_ratio
         self.offline_quant_expert_weight = offline_quant_expert_weight
-        self.clear_origin_weight_when_offline_quant = clear_origin_weight_when_offline_quant
         self.mlp_bwd_subbatch_rows = mlp_bwd_subbatch_rows
         self.mlp_fwd_subbatch_rows = mlp_fwd_subbatch_rows
         self.output_subbatch_rows = output_subbatch_rows

--- a/examples/experiments/deepseek_v3_pretrain/modeling.py
+++ b/examples/experiments/deepseek_v3_pretrain/modeling.py
@@ -452,7 +452,7 @@ class DeepseekV2MoE(MoELayer):
             using_post_norm_recompute=self.using_post_norm_recompute,
         )
 
-        if config.offline_quant_expert_weight and config.clear_origin_weight_when_offline_quant:
+        if config.offline_quant_expert_weight:
             expert_w1_list = [expert.w1 for expert in self.experts if expert is not None]
             expert_w2_list = [expert.w2 for expert in self.experts if expert is not None]
             for p in expert_w1_list:

--- a/examples/experiments/ernie_pretrain/ernie/src/callbacks/fp8_quant_weight_callback.py
+++ b/examples/experiments/ernie_pretrain/ernie/src/callbacks/fp8_quant_weight_callback.py
@@ -38,15 +38,11 @@ class FP8QuantWeightCallback(TrainerCallback):
         # offline quant fp8 weight
         if enable_in_dict_config(model.config.fp8_mem_configs, "offline_quant_expert_weight"):
             logger.info("offline quant expert weight from bf16 to fp8.")
-            clear_origin_weight = enable_in_dict_config(
-                model.config.fp8_mem_configs, "clear_origin_weight_when_offline_quant"
-            )
 
             if not g_shard_bypass_dygraph_optimizer or skip_count == 0:
                 model.fp8_quant_weight()
 
-            if clear_origin_weight:
-                logger.info("clear origin bf16 weight after fp8 quant.")
-                optimizer.clear_param_storage("moe_expert")
+            logger.info("clear origin bf16 weight after fp8 quant.")
+            optimizer.clear_param_storage("moe_expert")
 
         skip_count += 1

--- a/examples/experiments/ernie_pretrain/models/ernie/configuration.py
+++ b/examples/experiments/ernie_pretrain/models/ernie/configuration.py
@@ -315,7 +315,6 @@ class ErnieMoEConfig(PretrainedConfig):
             "recompute_fwd_gate_up": False,
             "dequant_input": False,
             "offline_quant_expert_weight": False,
-            "clear_origin_weight_when_offline_quant": False,
         }
         update_nested_dict(default_fp8_mem_configs, fp8_mem_configs)
         self.fp8_mem_configs = default_fp8_mem_configs

--- a/examples/experiments/ernie_pretrain/models/moe/moe_layer.py
+++ b/examples/experiments/ernie_pretrain/models/moe/moe_layer.py
@@ -488,7 +488,7 @@ class MOELayer(nn.Layer):
         if self.is_ep_moe:
             moe_grad_group = fleet.get_hybrid_communicate_group().get_moe_sharding_parallel_group()
             expert_color = {"color": "moe_expert", "group": moe_grad_group}
-        elif self.config.offline_quant_expert_weight and self.config.clear_origin_weight_when_offline_quant:
+        elif self.config.offline_quant_expert_weight:
             expert_color = {"color": "moe_expert"}
 
         if expert_color is not None:

--- a/examples/experiments/ernie_pretrain/yamls/ERNIE-4p5-300B-A47B/ci_ce/pretrain_4_nodes_ce.yaml
+++ b/examples/experiments/ernie_pretrain/yamls/ERNIE-4p5-300B-A47B/ci_ce/pretrain_4_nodes_ce.yaml
@@ -38,7 +38,6 @@ model_args:
             recompute_fwd_gate_up: [6, 7, 8, 11, 12, 13, 16, 17, 18]
             dequant_input: true
             offline_quant_expert_weight: true
-            clear_origin_weight_when_offline_quant: true
         fp8_fused_ops_configs:
             stack_quant: true
             swiglu_probs_bwd: true

--- a/examples/experiments/ernie_pretrain/yamls/ERNIE-4p5-300B-A47B/ci_ce/pretrain_8_gpus_ci.yaml
+++ b/examples/experiments/ernie_pretrain/yamls/ERNIE-4p5-300B-A47B/ci_ce/pretrain_8_gpus_ci.yaml
@@ -40,7 +40,6 @@ model_args:
             recompute_fwd_gate_up: [6, 7, 8, 11, 12, 13, 16, 17, 18]
             dequant_input: true
             offline_quant_expert_weight: true
-            clear_origin_weight_when_offline_quant: true
         fp8_fused_ops_configs:
             stack_quant: true
             swiglu_probs_bwd: true

--- a/examples/experiments/ernie_pretrain/yamls/ERNIE-4p5-300B-A47B/pretrain_96_gpus_small_acc.yaml
+++ b/examples/experiments/ernie_pretrain/yamls/ERNIE-4p5-300B-A47B/pretrain_96_gpus_small_acc.yaml
@@ -35,7 +35,6 @@ model_args:
             recompute_fwd_gate_up: [6, 7, 8, 11, 12, 13, 16, 17, 18]
             dequant_input: true
             offline_quant_expert_weight: true
-            clear_origin_weight_when_offline_quant: true
         fp8_fused_ops_configs:
             stack_quant: true
             swiglu_probs_bwd: true

--- a/paddleformers/cli/hparams/model_args.py
+++ b/paddleformers/cli/hparams/model_args.py
@@ -40,7 +40,6 @@ class FP8MemConfigs:
     recompute_fwd_gate_up: Union[bool, List[int]] = False
     dequant_input: bool = False
     offline_quant_expert_weight: bool = False
-    clear_origin_weight_when_offline_quant: bool = False
 
 
 @dataclass

--- a/paddleformers/cli/train/deepseek_v3_pretrain/configuration.py
+++ b/paddleformers/cli/train/deepseek_v3_pretrain/configuration.py
@@ -184,7 +184,6 @@ class DeepseekV2FastConfig(PretrainedConfig):
         fakse_gate_restrict_balance=False,
         adaptive_remained_O1_recompute_ratio=0,
         offline_quant_expert_weight=True,
-        clear_origin_weight_when_offline_quant=True,
         mlp_bwd_subbatch_rows=0,
         mlp_fwd_subbatch_rows=0,
         output_subbatch_rows=0,
@@ -258,7 +257,6 @@ class DeepseekV2FastConfig(PretrainedConfig):
         self.fakse_gate_restrict_balance = fakse_gate_restrict_balance
         self.adaptive_remained_O1_recompute_ratio = adaptive_remained_O1_recompute_ratio
         self.offline_quant_expert_weight = offline_quant_expert_weight
-        self.clear_origin_weight_when_offline_quant = clear_origin_weight_when_offline_quant
         self.mlp_bwd_subbatch_rows = mlp_bwd_subbatch_rows
         self.mlp_fwd_subbatch_rows = mlp_fwd_subbatch_rows
         self.output_subbatch_rows = output_subbatch_rows

--- a/paddleformers/cli/train/deepseek_v3_pretrain/modeling.py
+++ b/paddleformers/cli/train/deepseek_v3_pretrain/modeling.py
@@ -453,7 +453,7 @@ class DeepseekV2MoE(MoELayer):
             using_post_norm_recompute=self.using_post_norm_recompute,
         )
 
-        if config.offline_quant_expert_weight and config.clear_origin_weight_when_offline_quant:
+        if config.offline_quant_expert_weight:
             expert_w1_list = [expert.w1 for expert in self.experts if expert is not None]
             expert_w2_list = [expert.w2 for expert in self.experts if expert is not None]
             for p in expert_w1_list:

--- a/paddleformers/cli/train/ernie_pretrain/models/ernie/configuration.py
+++ b/paddleformers/cli/train/ernie_pretrain/models/ernie/configuration.py
@@ -314,7 +314,6 @@ class ErnieMoEConfig(PretrainedConfig):
             "recompute_fwd_gate_up": False,
             "dequant_input": False,
             "offline_quant_expert_weight": False,
-            "clear_origin_weight_when_offline_quant": False,
         }
         update_nested_dict(default_fp8_mem_configs, fp8_mem_configs)
         self.fp8_mem_configs = default_fp8_mem_configs

--- a/paddleformers/cli/train/ernie_pretrain/models/moe/moe_layer.py
+++ b/paddleformers/cli/train/ernie_pretrain/models/moe/moe_layer.py
@@ -496,7 +496,7 @@ class MOELayer(nn.Layer):
         if self.is_ep_moe:
             moe_grad_group = fleet.get_hybrid_communicate_group().get_moe_sharding_parallel_group()
             expert_color = {"color": "moe_expert", "group": moe_grad_group}
-        elif self.config.offline_quant_expert_weight and self.config.clear_origin_weight_when_offline_quant:
+        elif self.config.offline_quant_expert_weight:
             expert_color = {"color": "moe_expert"}
 
         if expert_color is not None:

--- a/paddleformers/cli/train/ernie_pretrain/src/callbacks/fp8_quant_weight_callback.py
+++ b/paddleformers/cli/train/ernie_pretrain/src/callbacks/fp8_quant_weight_callback.py
@@ -38,15 +38,11 @@ class FP8QuantWeightCallback(TrainerCallback):
         # offline quant fp8 weight
         if enable_in_dict_config(model.config.fp8_mem_configs, "offline_quant_expert_weight"):
             logger.info("offline quant expert weight from bf16 to fp8.")
-            clear_origin_weight = enable_in_dict_config(
-                model.config.fp8_mem_configs, "clear_origin_weight_when_offline_quant"
-            )
 
             if not g_shard_bypass_dygraph_optimizer or skip_count == 0:
                 model.fp8_quant_weight()
 
-            if clear_origin_weight:
-                logger.info("clear origin bf16 weight after fp8 quant.")
-                optimizer.clear_param_storage("moe_expert")
+            logger.info("clear origin bf16 weight after fp8 quant.")
+            optimizer.clear_param_storage("moe_expert")
 
         skip_count += 1

--- a/paddleformers/transformers/fp8_utils.py
+++ b/paddleformers/transformers/fp8_utils.py
@@ -55,10 +55,8 @@ def get_sm_num():
     return 112
 
 
-def set_parameter_color(
-    parameters, color, group=None, offline_quant_expert_weight=True, clear_origin_weight_when_offline_quant=True
-):
-    if offline_quant_expert_weight and clear_origin_weight_when_offline_quant:
+def set_parameter_color(parameters, color, group=None, offline_quant_expert_weight=True):
+    if offline_quant_expert_weight:
         if group is None:
             for p in parameters:
                 if hasattr(p, "color") and p.color is not None:

--- a/tests/ai_edited_test/cli/test_ai_model_args.py
+++ b/tests/ai_edited_test/cli/test_ai_model_args.py
@@ -51,7 +51,6 @@ class TestFP8MemConfigs(unittest.TestCase):
         self.assertFalse(args.recompute_fwd_gate_up)
         self.assertFalse(args.dequant_input)
         self.assertFalse(args.offline_quant_expert_weight)
-        self.assertFalse(args.clear_origin_weight_when_offline_quant)
 
 
 class TestFP8FusedOpsConfigs(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Merge the two FP8 offline-quant switches `offline_quant_expert_weight` and `clear_origin_weight_when_offline_quant` into a single `offline_quant_expert_weight`.
- New semantics: when `offline_quant_expert_weight=True`, BF16 expert weights are always cleared after quantization (previously you had to also set `clear_origin_weight_when_offline_quant=True`).
- This aligns PaddleFormers with the behavior already used in ernie-core, where only `offline_quant_expert_weight` is checked.

## Motivation

Keeping BF16 weights around after FP8 quantization has no real use case — callers that enable offline quantization always want the BF16 storage released to free memory. Maintaining a second guard flag only created room for misconfiguration (e.g. YAMLs enabling offline quant but forgetting the clear flag, leaving BF16 memory occupied).

## Behavioral impact

Configs that previously set only `offline_quant_expert_weight: True` (without the clear flag) will now additionally clear BF16 expert storage. This matches what ernie-core has always done and is the intended path; no known config depends on keeping BF16 weights around.

## Test plan

- [x] `pre-commit run --all-files` on changed files.
- [ ] Internal CI/CE suite covering ERNIE-4.5 300B A47B pretrain configs that use offline FP8 quant.
- [ ] Verify on a small MoE run that BF16 expert storage is released after step 0 when `offline_quant_expert_weight: True`.

Co-authored-by: Claude <noreply@anthropic.com>