### PR TITLE
Rename `enable_timer` to `timer`

### DIFF
--- a/examples/experiments/ernie_pretrain/yamls/ERNIE-4p5-21B-A3B/pretrain_8_gpus.yaml
+++ b/examples/experiments/ernie_pretrain/yamls/ERNIE-4p5-21B-A3B/pretrain_8_gpus.yaml
@@ -93,7 +93,7 @@ trainer_args:
 
     ignore_data_skip: 0
     same_data: True
-    enable_timer: 1
+    timer: 1
     skip_profile_timer: False
     skip_load_data_seq_cache: 1
 


### PR DESCRIPTION
`examples/experiments/ernie_pretrain/yamls/ERNIE-4p5-21B-A3B/pretrain_8_gpus.yaml` 里把 `enable_timer: 1` 写在 `trainer_args` 顶层。但 `TrainingArguments` 并没有 `enable_timer` 字段，PP timer 真正读的是顶层 `timer: bool`（`dygraph_pp_configs["enable_timer"] = self.timer`），所以这个 flag 一直被静默忽略。

本 PR 将其改为 `timer: 1`，让示例按预期开启 PP timer。