### PR TITLE
Drop dead benchmark switch from trainer configs

### DIFF
--- a/paddleformers/cli/hparams/finetuning_args.py
+++ b/paddleformers/cli/hparams/finetuning_args.py
@@ -255,10 +255,6 @@ class FinetuningArguments(
         default=0.0,
         metadata={"help": "dropout probability for attention layers"},
     )
-    benchmark: bool = field(
-        default=False,
-        metadata={"help": "Whether to run benchmark by autotuner. True for from_scratch."},
-    )
 
     # performance
     compute_type: str = field(

--- a/paddleformers/cli/train/dpo/dpo_argument.py
+++ b/paddleformers/cli/train/dpo/dpo_argument.py
@@ -46,10 +46,6 @@ class DPOTrainingArguments(TrainingArguments):
         default=False,
         metadata={"help": "Whether to run benchmark by autotuner. True for from_scratch."},
     )
-    benchmark: bool = field(
-        default=False,
-        metadata={"help": "Whether to run benchmark by autotuner. True for from_scratch."},
-    )
     use_intermediate_api: bool = field(
         default=False,
         metadata={"help": "Flag indicating whether to use the intermediate API for model."},
@@ -68,18 +64,6 @@ class DPOTrainingArguments(TrainingArguments):
             self.overwrite_output_dir = True
             self.load_best_model_at_end = False
             self.report_to = []
-            self.save_strategy = IntervalStrategy.NO
-            self.evaluation_strategy = IntervalStrategy.NO
-            if not self.disable_tqdm:
-                self.logging_steps = 1
-                self.logging_strategy = IntervalStrategy.STEPS
-        if self.benchmark:
-            self.do_train = True
-            self.do_export = False
-            self.do_predict = False
-            self.do_eval = False
-            self.overwrite_output_dir = True
-            self.load_best_model_at_end = False
             self.save_strategy = IntervalStrategy.NO
             self.evaluation_strategy = IntervalStrategy.NO
             if not self.disable_tqdm:

--- a/paddleformers/cli/train/dpo/workflow.py
+++ b/paddleformers/cli/train/dpo/workflow.py
@@ -450,7 +450,7 @@ def run_dpo(
     if training_args.do_train:
         train_result = trainer.train(resume_from_checkpoint=last_checkpoint)
 
-        if not training_args.autotuner_benchmark and not training_args.benchmark:
+        if not training_args.autotuner_benchmark:
             trainer.save_model(merge_tensor_parallel=training_args.tensor_model_parallel_size > 1, last_fc_to_hf=True)
             trainer.log_metrics("train", train_result.metrics)
             trainer.save_metrics("train", train_result.metrics)

--- a/paddleformers/cli/train/sft/sft_config.py
+++ b/paddleformers/cli/train/sft/sft_config.py
@@ -28,7 +28,6 @@ __all__ = ["SFTConfig"]
 @llmmetaclass
 @add_start_docstrings(TrainingArguments.__doc__)
 class SFTConfig(TrainingArguments):
-    benchmark: bool = field(default=False, metadata={"help": "Whether runs benchmark"})
     # NOTE(gongenlei): new add autotuner_benchmark
     autotuner_benchmark: bool = field(
         default=False,
@@ -89,16 +88,6 @@ class SFTConfig(TrainingArguments):
         # NOTE(gongenlei): new add autotuner_benchmark
         if self.autotuner_benchmark:
             self.max_steps = 5
-            self.do_train = True
-            self.do_export = False
-            self.do_predict = False
-            self.do_eval = False
-            self.overwrite_output_dir = True
-            self.load_best_model_at_end = False
-            self.report_to = []
-            self.save_strategy = IntervalStrategy.NO
-            self.evaluation_strategy = IntervalStrategy.NO
-        if self.benchmark:
             self.do_train = True
             self.do_export = False
             self.do_predict = False

--- a/paddleformers/cli/train/sft/workflow.py
+++ b/paddleformers/cli/train/sft/workflow.py
@@ -750,27 +750,22 @@ def run_sft(
         train_result = trainer.train(resume_from_checkpoint=checkpoint)
         if model_args.neftune:
             neft_post_hook_handle.remove()
-        if training_args.benchmark:
-            total_tokens = (
-                data_args.max_seq_len
-                * training_args.per_device_train_batch_size
-                * training_args.dataset_world_size
-                * training_args.gradient_accumulation_steps
-                * training_args.max_steps
-            )
-            total_tokens_per_second_per_gpu = (
-                total_tokens / train_result.metrics["train_runtime"] / training_args.world_size
-            )
-            logger.info(f"Total_Tokens_per_second_per_gpu: {total_tokens_per_second_per_gpu} ")
-            logger.info("Benchmark done.")
-        else:
-            if not training_args.autotuner_benchmark:
-                trainer.save_model(
-                    merge_tensor_parallel=training_args.tensor_model_parallel_size > 1, last_fc_to_hf=True
-                )
-                trainer.log_metrics("train", train_result.metrics)
-                trainer.save_metrics("train", train_result.metrics)
-                trainer.save_state()
+        total_tokens = (
+            data_args.max_seq_len
+            * training_args.per_device_train_batch_size
+            * training_args.dataset_world_size
+            * training_args.gradient_accumulation_steps
+            * training_args.max_steps
+        )
+        total_tokens_per_second_per_gpu = (
+            total_tokens / train_result.metrics["train_runtime"] / training_args.world_size
+        )
+        logger.info(f"Total_Tokens_per_second_per_gpu: {total_tokens_per_second_per_gpu} ")
+        if not training_args.autotuner_benchmark:
+            trainer.save_model(merge_tensor_parallel=training_args.tensor_model_parallel_size > 1, last_fc_to_hf=True)
+            trainer.log_metrics("train", train_result.metrics)
+            trainer.save_metrics("train", train_result.metrics)
+            trainer.save_state()
 
 
 def create_peft_model(model_args, training_args, dtype, model):

--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -2621,9 +2621,7 @@ class Trainer:
 
             seq_length = None
             model_flops_per_token = None
-            if (getattr(self, "is_pretraining", False) or getattr(self.args, "benchmark", False)) and hasattr(
-                self.model, "config"
-            ):
+            if getattr(self, "is_pretraining", False) and hasattr(self.model, "config"):
                 seq_length = getattr(self.model.config, "seq_length", None)
                 try:
                     model_flops_per_token = self.model.get_hardware_flops()

--- a/tests/ai_edited_test/cli/test_ai_finetuning_args.py
+++ b/tests/ai_edited_test/cli/test_ai_finetuning_args.py
@@ -111,7 +111,6 @@ class TestFinetuningArgumentsFieldDefaults(unittest.TestCase):
         self.assertEqual(fields["compute_type"], "bf16")
         self.assertEqual(fields["use_fp8"], False)
         self.assertEqual(fields["use_recompute_mtp"], False)
-        self.assertEqual(fields["benchmark"], False)
         self.assertEqual(fields["autotuner_benchmark"], False)
         self.assertEqual(fields["dataset_num_proc"], None)
         self.assertEqual(fields["dataset_batch_size"], 1000)

--- a/tests/config/ci/glm45_pt.yaml
+++ b/tests/config/ci/glm45_pt.yaml
@@ -79,7 +79,6 @@ continue_training: false
 # args
 router_aux_loss_coef: 0.001
 
-benchmark: false
 moe_router_force_load_balancing: true
 moe_token_dispatcher_type: "deepep"
 gated_linear_unit: true

--- a/tests/config/ci/glm45_pt_fp8.yaml
+++ b/tests/config/ci/glm45_pt_fp8.yaml
@@ -71,7 +71,6 @@ load_checkpoint_format: flex_checkpoint
 continue_training: false
 dataloader_shuffle: false
 
-benchmark: false
 moe_router_force_load_balancing: true
 moe_token_dispatcher_type: "deepep"
 gated_linear_unit: true

--- a/tests/config/ci/glm45_pt_grouped_gemm.yaml
+++ b/tests/config/ci/glm45_pt_grouped_gemm.yaml
@@ -68,7 +68,6 @@ load_checkpoint_format: flex_checkpoint
 continue_training: false
 dataloader_shuffle: false
 
-benchmark: false
 moe_router_force_load_balancing: true
 moe_token_dispatcher_type: "deepep"
 gated_linear_unit: true

--- a/tests/config/ci/glm45_single_pt-test.yaml
+++ b/tests/config/ci/glm45_single_pt-test.yaml
@@ -64,7 +64,6 @@ save_checkpoint_format: flex_checkpoint
 load_checkpoint_format: flex_checkpoint
 continue_training: false
 
-benchmark: true
 moe_router_force_load_balancing: true
 moe_token_dispatcher_type: "deepep"
 gated_linear_unit: true

--- a/tests/config/ci/qwen3vl_sft_moe.yaml
+++ b/tests/config/ci/qwen3vl_sft_moe.yaml
@@ -93,7 +93,6 @@ load_checkpoint_format: flex_checkpoint
 continue_training: True
 dataloader_shuffle: false
 
-benchmark: false
 report_to: none
 dataloader_num_workers: 0
 

--- a/tests/config/ci/qwen3vl_sft_moe_a100.yaml
+++ b/tests/config/ci/qwen3vl_sft_moe_a100.yaml
@@ -81,7 +81,6 @@ save_checkpoint_format: flex_checkpoint
 load_checkpoint_format: flex_checkpoint
 continue_training: True
 dataloader_shuffle: false
-benchmark: false
 report_to: none
 dataloader_num_workers: 4
 prefetch_factor: 8


### PR DESCRIPTION
## 变更
- 删除 `FinetuningArguments` / `SFTConfig` / `DPOTrainingArguments` 的 `benchmark` 字段及相关分支
- SFT 的 tokens/sec/GPU 日志改为默认打印；SFT / DPO 的 `save_model` 等收尾不再被 `benchmark` 拦截（仍由 `autotuner_benchmark` 控制）
- 移除 `trainer.py:2624` 中的 dead `getattr(..., "benchmark", ...)`
- 清理 `tests/config/ci/*.yaml` 中的 `benchmark: false`

`autotuner_benchmark` 未动。

## 测试
- [ ] `python -m pytest tests/ai_edited_test/cli/test_ai_finetuning_args.py`
- [ ] `python -m pytest tests/trainer/test_argparser.py`
