### PR TITLE
Remove timer training argument

### DIFF
--- a/examples/experiments/ernie_pretrain/ernie/pretrain.py
+++ b/examples/experiments/ernie_pretrain/ernie/pretrain.py
@@ -347,12 +347,11 @@ def main():
     if getattr(config.trainer_args, "dp_comm_overlap", False):
         logger.warning("Pipeline dp_comm_overlap and FusedLinearWithGradAdd can not be used at the same time.")
 
-    if getattr(config.trainer_args, "timer", False):
-        from paddle.distributed.fleet.meta_parallel.pipeline_parallel import (
-            PipelineParallel,
-        )
+    from paddle.distributed.fleet.meta_parallel.pipeline_parallel import (
+        PipelineParallel,
+    )
 
-        PipelineParallel.timer_printer = lambda _: None
+    PipelineParallel.timer_printer = lambda _: None
 
     def formatv(v):
         if isinstance(v, ListConfig):

--- a/examples/experiments/ernie_pretrain/yamls/ERNIE-4p5-21B-A3B/pretrain_8_gpus.yaml
+++ b/examples/experiments/ernie_pretrain/yamls/ERNIE-4p5-21B-A3B/pretrain_8_gpus.yaml
@@ -93,7 +93,6 @@ trainer_args:
 
     ignore_data_skip: 0
     same_data: True
-    enable_timer: 1
     skip_profile_timer: False
     skip_load_data_seq_cache: 1
 

--- a/paddleformers/cli/train/ernie_pretrain/workflow.py
+++ b/paddleformers/cli/train/ernie_pretrain/workflow.py
@@ -356,12 +356,11 @@ def run_ernie_pretrain(model_args, data_args, generating_args, training_args):
     if getattr(training_args, "dp_comm_overlap", False):
         logger.warning("Pipeline dp_comm_overlap and FusedLinearWithGradAdd can not be used at the same time.")
 
-    if getattr(training_args, "timer", False):
-        from paddle.distributed.fleet.meta_parallel.pipeline_parallel import (
-            PipelineParallel,
-        )
+    from paddle.distributed.fleet.meta_parallel.pipeline_parallel import (
+        PipelineParallel,
+    )
 
-        PipelineParallel.timer_printer = lambda _: None
+    PipelineParallel.timer_printer = lambda _: None
 
     def formatv(v):
         if isinstance(v, ListConfig):

--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -82,9 +82,7 @@ _obtain_optimizer_parameters_list = obtain_optimizer_parameters_list
 from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer.dygraph_sharding_optimizer import (
     DygraphShardingOptimizerV2,
 )
-from paddle.distributed.fleet.meta_parallel.pipeline_parallel import (
-    PipelineParallel,
-)
+from paddle.distributed.fleet.meta_parallel.pipeline_parallel import PipelineParallel
 from paddle.distributed.fleet.utils.hybrid_parallel_util import (
     fused_allreduce_gradients,
 )

--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -82,6 +82,9 @@ _obtain_optimizer_parameters_list = obtain_optimizer_parameters_list
 from paddle.distributed.fleet.meta_optimizers.dygraph_optimizer.dygraph_sharding_optimizer import (
     DygraphShardingOptimizerV2,
 )
+from paddle.distributed.fleet.meta_parallel.pipeline_parallel import (
+    PipelineParallel,
+)
 from paddle.distributed.fleet.utils.hybrid_parallel_util import (
     fused_allreduce_gradients,
 )
@@ -445,6 +448,7 @@ class Trainer:
 
             set_profile_timers(self.timers)
         self.runtime_timer = RuntimeTimer("RuntimeTimer")
+        PipelineParallel.timer_printer = lambda _: None
 
         self.model_wrapped = model
         self.model = model
@@ -2545,9 +2549,8 @@ class Trainer:
 
             paddle_pipeline_timers = paddle_get_timers()
             for name, timer in paddle_pipeline_timers.timers.items():
-                elapsed_time = timer.elapsed(reset=False) * 1000.0
+                elapsed_time = timer.elapsed(reset=True) * 1000.0
                 paddle_timer_info += f" | {name}: {elapsed_time:.2f}"
-            paddle_pipeline_timers.log(paddle_pipeline_timers.timers.keys(), reset=True)
         except AssertionError:  # paddle timer not enabled
             pass
 

--- a/paddleformers/trainer/training_args.py
+++ b/paddleformers/trainer/training_args.py
@@ -35,7 +35,7 @@ from ..utils.env import PREFIX_CHECKPOINT_DIR
 from ..utils.import_utils import is_paddlefleet_available
 from ..utils.log import logger
 from ..utils.pdc_sdk import FLASH_DEVICE
-from ..utils.tools import paddle_device
+from ..utils.tools import get_env_device, paddle_device
 from .trainer_utils import (
     IntervalStrategy,
     OptimizerNames,
@@ -1972,7 +1972,7 @@ class TrainingArguments:
                         "delay_scale_loss": True,  # TODO[Waynezee]: remove this config in the future
                         "dp_comm_overlap": enable_dp_comm_overlap,
                         "sharding_comm_overlap": self.enable_sharding_comm_overlap,
-                        "enable_timer": True,
+                        "enable_timer": get_env_device() != "xpu",
                         "release_gradients": self.pp_release_grads or self.release_grads,
                         "overlap_p2p_comm": self.overlap_p2p_comm,
                         "clear_every_step_cache": self.clear_every_step_cache,

--- a/paddleformers/trainer/training_args.py
+++ b/paddleformers/trainer/training_args.py
@@ -1514,12 +1514,6 @@ class TrainingArguments:
             "help": "Enable splitting backward pass into stages to balance computation and reduce peak memory usage in model parallelism."
         },
     )
-    timer: bool = field(
-        default=False,
-        metadata={
-            "help": "Enable timing for pipeline parallel stages to profile and optimize communication/computation overlap."
-        },
-    )
     stage1_tensor_fusion: bool = field(
         default=False,
         metadata={
@@ -1926,7 +1920,6 @@ class TrainingArguments:
                                 "enable_delay_scale_loss",
                                 "enable_dp_comm_overlap",
                                 "enable_sharding_comm_overlap",
-                                "enable_timer",
                                 "enable_release_grads",
                                 "enable_clear_every_step_cache",
                                 "enable_overlap_p2p_comm",
@@ -1979,7 +1972,7 @@ class TrainingArguments:
                         "delay_scale_loss": True,  # TODO[Waynezee]: remove this config in the future
                         "dp_comm_overlap": enable_dp_comm_overlap,
                         "sharding_comm_overlap": self.enable_sharding_comm_overlap,
-                        "enable_timer": self.timer,
+                        "enable_timer": True,
                         "release_gradients": self.pp_release_grads or self.release_grads,
                         "overlap_p2p_comm": self.overlap_p2p_comm,
                         "clear_every_step_cache": self.clear_every_step_cache,
@@ -2403,7 +2396,6 @@ class TrainingArguments:
                             "enable_delay_scale_loss",
                             # "enable_dp_comm_overlap",       # no implementation for auto_parallel
                             # "enable_sharding_comm_overlap", # no implementation for auto_parallel
-                            # "enable_timer",                 # no implementation for auto_parallel
                             # "disable_batch_p2p_comm",       # no implementation for auto_parallel
                             "enable_split_backward",
                             "auto_parallel_sync_shared_params",

--- a/tests/integration_test/check_loss.py
+++ b/tests/integration_test/check_loss.py
@@ -43,7 +43,7 @@ def parse_log_file(file_path):
     Parses the log file to extract global_step and loss.
     Returns a dict: {step: loss}
     """
-    loss_pattern = re.compile(r"loss:\s*([0-9\.]+)")
+    loss_pattern = re.compile(r"(?:^|-\s*)loss:\s*([0-9\.]+)")
     step_pattern = re.compile(r"global_step:\s*(\d+)")
 
     loss_dict = {}


### PR DESCRIPTION
- 删除用户侧 `TrainingArguments.timer` 开关，并移除 `enable_timer` 的外部配置入口和样例 YAML 中的无效配置。
- Pipeline Parallel timer 改为框架内部默认管理：非 XPU 默认开启，XPU 通过 `get_env_device() != "xpu"` 保持关闭。
- Ernie pretrain 入口和 Trainer 默认接管 `PipelineParallel.timer_printer`，屏蔽 Paddle 自带的裸 `time (ms)` timer 日志。
- `_print_timer` 直接读取并 reset Paddle pipeline timers，只保留统一的 `[Profile global_step] ... recv_forward...` 输出。
- 收紧 `check_loss.py` 的 loss 匹配，避免误匹配其他日志字段。