### PR TITLE
[codex] Replace moe_use_aux_free with topk_method

### DIFF
--- a/examples/config/pt/eb45_pretrain/300b_2016_gpus.yaml
+++ b/examples/config/pt/eb45_pretrain/300b_2016_gpus.yaml
@@ -98,7 +98,7 @@ ernie_model_config:
     use_rms_qkv_recompute: true
 
     moe_logging: True
-    moe_use_aux_free: true
+    topk_method: noaux_tc
     use_recompute: false
     use_fp8_mlp: true
     use_fp8_fuse_node: true

--- a/examples/config/pt/eb45_pretrain/300b_4_nodes_ce.yaml
+++ b/examples/config/pt/eb45_pretrain/300b_4_nodes_ce.yaml
@@ -106,7 +106,7 @@ ernie_model_config:
     use_rms_qkv_recompute: true
 
     moe_logging: True
-    moe_use_aux_free: true
+    topk_method: noaux_tc
     use_recompute: false
     use_fp8_mlp: true
     use_fp8_fuse_node: true

--- a/examples/config/pt/eb45_pretrain/300b_8_gpus_ci.yaml
+++ b/examples/config/pt/eb45_pretrain/300b_8_gpus_ci.yaml
@@ -98,7 +98,7 @@ ernie_model_config:
     use_async_a2a: false
     use_rms_qkv_recompute: true
     moe_logging: True
-    moe_use_aux_free: true
+    topk_method: noaux_tc
     use_recompute: false
     use_fp8_mlp: true
     use_fp8_fuse_node: true

--- a/examples/config/pt/eb45_pretrain/300b_96gpus.yaml
+++ b/examples/config/pt/eb45_pretrain/300b_96gpus.yaml
@@ -99,7 +99,7 @@ ernie_model_config:
     use_rms_qkv_recompute: true
 
     moe_logging: True
-    moe_use_aux_free: true
+    topk_method: noaux_tc
     use_recompute: false
     use_fp8_mlp: true
     use_fp8_fuse_node: true

--- a/examples/config/pt/eb45_pretrain/300b_96gpus_small_acc.yaml
+++ b/examples/config/pt/eb45_pretrain/300b_96gpus_small_acc.yaml
@@ -101,7 +101,7 @@ ernie_model_config:
     use_rms_qkv_recompute: true
 
     moe_logging: True
-    moe_use_aux_free: true
+    topk_method: noaux_tc
     use_recompute: false
     use_fp8_mlp: true
     use_fp8_fuse_node: true

--- a/examples/experiments/ernie_pretrain/ernie/pretrain.py
+++ b/examples/experiments/ernie_pretrain/ernie/pretrain.py
@@ -660,7 +660,7 @@ def main():
     callbacks += [GlobalRNGCallback()]
     callbacks += [OrthogonalCallback(ortho_loss_lambda)] if args.use_ortho_loss_callback else []
 
-    if getattr(cfg, "moe_use_aux_free", 0.0) > 0.0:
+    if cfg.topk_method == "noaux_tc":
         logger.info("adding aux free callback")
         callbacks += [MoECorrectionBiasAdjustCallback(args.moe_router_bias_update_rate, args.sequence_parallel)]
 

--- a/examples/experiments/ernie_pretrain/model_configs/ERNIE-4p5-21B-A3B/model_config.json
+++ b/examples/experiments/ernie_pretrain/model_configs/ERNIE-4p5-21B-A3B/model_config.json
@@ -50,7 +50,7 @@
   "moe_group_orthogonal_loss": true,
   "moe_orthogonal_loss_lambda": 1e-3,
   "moe_layer_interval": 1,
-  "moe_use_aux_free": true,
+  "topk_method": "noaux_tc",
   "using_precision_check": false,
   "fp8_mem_configs": {
       "shared_expert": false

--- a/examples/experiments/ernie_pretrain/model_configs/ERNIE-4p5-300B-A47B/model_config.json
+++ b/examples/experiments/ernie_pretrain/model_configs/ERNIE-4p5-300B-A47B/model_config.json
@@ -41,6 +41,7 @@
   "moe_intermediate_size": 3584,
   "moe_capacity": [8,8,8],
   "moe_gate": "top2_fused",
+  "topk_method": "noaux_tc",
   "moe_gate_scale": false,
   "moe_gate_detach": 1.0,
   "moe_k": 8,

--- a/examples/experiments/ernie_pretrain/models/ernie/configuration.py
+++ b/examples/experiments/ernie_pretrain/models/ernie/configuration.py
@@ -161,7 +161,7 @@ class ErnieMoEConfig(PretrainedConfig):
         moe_fuse_experts: bool = False,
         moe_all_to_all_dropout: float = 0.0,
         moe_k=2,
-        moe_use_aux_free: bool = False,
+        topk_method: str = "greedy",
         moe_group_experts: bool = False,
         enable_delay_scale_loss: bool = True,
         num_acc_steps: Optional[int] = None,
@@ -365,7 +365,7 @@ class ErnieMoEConfig(PretrainedConfig):
         self.moe_layer_end_index = self.num_hidden_layers - 1 if moe_layer_end_index == -1 else moe_layer_end_index
         self.scoring_func = scoring_func
         self.moe_norm_gate_logits = moe_norm_gate_logits
-        self.moe_use_aux_free = moe_use_aux_free
+        self.topk_method = topk_method
         self.fuse_gate_detach_matmul = fuse_gate_detach_matmul
         if insert_empty_layer is not None:
             assert isinstance(insert_empty_layer, list), "insert_empty_layer should be a list"

--- a/examples/experiments/ernie_pretrain/models/ernie/modeling_moe.py
+++ b/examples/experiments/ernie_pretrain/models/ernie/modeling_moe.py
@@ -1097,7 +1097,7 @@ class ErnieDecoderLayer(nn.Layer):
         else:
             fc = [(cfg.moe_num_experts, fc_cls(cfg))]
         gate, experts, lm_gate, lm_experts = get_gate(self.config, fc, layer_idx)
-        if cfg.moe_use_aux_free:
+        if cfg.topk_method == "noaux_tc":
             moe_statics = MoEStatics(cfg, layer_idx)
         else:
             moe_statics = None

--- a/examples/experiments/ernie_pretrain/models/moe/moe_layer.py
+++ b/examples/experiments/ernie_pretrain/models/moe/moe_layer.py
@@ -462,7 +462,7 @@ class MOELayer(nn.Layer):
         self.moe_statics = moe_statics
         if self.use_correction_bias:
             logger.info(f"using correction bias, aux-coef:{self.gate.config.router_aux_loss_coef}")
-            assert self.gate.config.moe_use_aux_free
+            assert self.gate.config.topk_method == "noaux_tc"
 
         self.is_mp_moe = (
             hasattr(fleet.fleet, "_hcg") and group is fleet.get_hybrid_communicate_group().get_model_parallel_group()

--- a/examples/experiments/ernie_pretrain/models/moe/top2_gate.py
+++ b/examples/experiments/ernie_pretrain/models/moe/top2_gate.py
@@ -216,7 +216,7 @@ class Top2Gate(nn.Layer):
         if self.global_aux_loss:
             self.rank = dist.get_rank(self.group)
 
-        self.use_correction_bias = config.moe_use_aux_free
+        self.use_correction_bias = config.topk_method == "noaux_tc"
 
         if config.scoring_func == "softmax":
             self.act = partial(F.softmax, axis=-1)

--- a/examples/experiments/ernie_pretrain/yamls/ERNIE-4p5-300B-A47B/ci_ce/pretrain_4_nodes_ce.yaml
+++ b/examples/experiments/ernie_pretrain/yamls/ERNIE-4p5-300B-A47B/ci_ce/pretrain_4_nodes_ce.yaml
@@ -29,7 +29,6 @@ model_args:
         use_rms_qkv_recompute: true
 
         moe_logging: True
-        moe_use_aux_free: true
         use_recompute: false
         use_fp8_mlp: true
         use_fp8_fuse_node: true

--- a/examples/experiments/ernie_pretrain/yamls/ERNIE-4p5-300B-A47B/ci_ce/pretrain_8_gpus_ci.yaml
+++ b/examples/experiments/ernie_pretrain/yamls/ERNIE-4p5-300B-A47B/ci_ce/pretrain_8_gpus_ci.yaml
@@ -31,7 +31,6 @@ model_args:
         use_rms_qkv_recompute: true
 
         moe_logging: True
-        moe_use_aux_free: true
         use_recompute: false
         use_fp8_mlp: true
         use_fp8_fuse_node: true

--- a/examples/experiments/ernie_pretrain/yamls/ERNIE-4p5-300B-A47B/pretrain_2016_gpus.yaml
+++ b/examples/experiments/ernie_pretrain/yamls/ERNIE-4p5-300B-A47B/pretrain_2016_gpus.yaml
@@ -24,7 +24,6 @@ model_args:
         use_rms_qkv_recompute: true
 
         moe_logging: True
-        moe_use_aux_free: true
         use_recompute: false
         use_fp8_mlp: true
         use_fp8_fuse_node: true

--- a/examples/experiments/ernie_pretrain/yamls/ERNIE-4p5-300B-A47B/pretrain_96_gpus.yaml
+++ b/examples/experiments/ernie_pretrain/yamls/ERNIE-4p5-300B-A47B/pretrain_96_gpus.yaml
@@ -24,7 +24,6 @@ model_args:
         use_rms_qkv_recompute: true
 
         moe_logging: True
-        moe_use_aux_free: true
         use_recompute: false
         use_fp8_mlp: true
         use_fp8_fuse_node: true

--- a/examples/experiments/ernie_pretrain/yamls/ERNIE-4p5-300B-A47B/pretrain_96_gpus_small_acc.yaml
+++ b/examples/experiments/ernie_pretrain/yamls/ERNIE-4p5-300B-A47B/pretrain_96_gpus_small_acc.yaml
@@ -26,7 +26,6 @@ model_args:
         use_rms_qkv_recompute: true
 
         moe_logging: True
-        moe_use_aux_free: true
         use_recompute: false
         use_fp8_mlp: true
         use_fp8_fuse_node: true

--- a/paddleformers/cli/hparams/model_args.py
+++ b/paddleformers/cli/hparams/model_args.py
@@ -71,7 +71,10 @@ class ErniePretrainArgument:
     moe_num_experts: Union[int, list] = 0
     moe_k: int = field(default=2, metadata={"help": "Number of keys per experts"})
     moe_capacity = ()
-    moe_use_aux_free: bool = field(default=False, metadata={"help": "Whether to use aux free"})
+    topk_method: Optional[str] = field(
+        default=None,
+        metadata={"help": "MoE top-k method; noaux_tc enables aux-free routing"},
+    )
     moe_gate: str = field(default="top2_fused", metadata={"help": "MoE gate type"})
     transpose_split_quant: bool = field(default=False, metadata={"help": "Whether to use transpose split quant"})
 
@@ -178,12 +181,11 @@ class ModelArguments:
             "routing strategy is used instead of a learned gating network."
         },
     )
-    moe_use_aux_free: Optional[bool] = field(
+    topk_method: Optional[str] = field(
         default=None,
         metadata={
-            "help": "Whether to use auxiliary‑loss‑free routing. If True, "
-            "load balancing (using expert bias adjustments) is used instead "
-            "of traditional auxiliary loss for MoE."
+            "help": "MoE top-k routing method. Set to noaux_tc to enable "
+            "load balancing with expert bias adjustments instead of traditional auxiliary loss."
         },
     )
 

--- a/paddleformers/cli/train/ernie_pretrain/models/ernie/configuration.py
+++ b/paddleformers/cli/train/ernie_pretrain/models/ernie/configuration.py
@@ -161,7 +161,7 @@ class ErnieMoEConfig(PretrainedConfig):
         moe_fuse_experts: bool = False,
         moe_all_to_all_dropout: float = 0.0,
         moe_k=2,
-        moe_use_aux_free: bool = False,
+        topk_method: str = "greedy",
         moe_group_experts: bool = False,
         enable_delay_scale_loss: bool = True,
         num_acc_steps: Optional[int] = None,
@@ -364,7 +364,7 @@ class ErnieMoEConfig(PretrainedConfig):
         self.moe_layer_end_index = self.num_hidden_layers - 1 if moe_layer_end_index == -1 else moe_layer_end_index
         self.scoring_func = scoring_func
         self.moe_norm_gate_logits = moe_norm_gate_logits
-        self.moe_use_aux_free = moe_use_aux_free
+        self.topk_method = topk_method
         self.fuse_gate_detach_matmul = fuse_gate_detach_matmul
         if insert_empty_layer is not None:
             assert isinstance(insert_empty_layer, list), "insert_empty_layer should be a list"

--- a/paddleformers/cli/train/ernie_pretrain/models/ernie/modeling_moe.py
+++ b/paddleformers/cli/train/ernie_pretrain/models/ernie/modeling_moe.py
@@ -1110,7 +1110,7 @@ class ErnieDecoderLayer(nn.Layer):
         else:
             fc = [(cfg.moe_num_experts, fc_cls(cfg))]
         gate, experts, lm_gate, lm_experts = get_gate(self.config, fc, layer_idx)
-        if cfg.moe_use_aux_free:
+        if cfg.topk_method == "noaux_tc":
             moe_statics = MoEStatics(cfg, layer_idx)
         else:
             moe_statics = None

--- a/paddleformers/cli/train/ernie_pretrain/models/moe/moe_layer.py
+++ b/paddleformers/cli/train/ernie_pretrain/models/moe/moe_layer.py
@@ -470,7 +470,7 @@ class MOELayer(nn.Layer):
         self.moe_statics = moe_statics
         if self.use_correction_bias:
             logger.info(f"using correction bias, aux-coef:{self.gate.config.router_aux_loss_coef}")
-            assert self.gate.config.moe_use_aux_free
+            assert self.gate.config.topk_method == "noaux_tc"
 
         self.is_mp_moe = (
             hasattr(fleet.fleet, "_hcg") and group is fleet.get_hybrid_communicate_group().get_model_parallel_group()

--- a/paddleformers/cli/train/ernie_pretrain/models/moe/top2_gate.py
+++ b/paddleformers/cli/train/ernie_pretrain/models/moe/top2_gate.py
@@ -218,7 +218,7 @@ class Top2Gate(nn.Layer):
         if self.global_aux_loss:
             self.rank = dist.get_rank(self.group)
 
-        self.use_correction_bias = config.moe_use_aux_free
+        self.use_correction_bias = config.topk_method == "noaux_tc"
 
         if config.scoring_func == "softmax":
             self.act = partial(F.softmax, axis=-1)

--- a/paddleformers/cli/train/ernie_pretrain/src/trainers/pretraining_trainer.py
+++ b/paddleformers/cli/train/ernie_pretrain/src/trainers/pretraining_trainer.py
@@ -247,7 +247,7 @@ class PreTrainingArguments(TrainingArguments):
     )
     moe_router_bias_update_rate: float = field(
         default=1.0e-3,
-        metadata={"help": "moe aux free update coef,"},
+        metadata={"help": "moe aux-free update coef, only effective when model_config.topk_method=noaux_tc"},
     )
     use_fp8: bool = field(
         default=False,

--- a/paddleformers/cli/train/ernie_pretrain/workflow.py
+++ b/paddleformers/cli/train/ernie_pretrain/workflow.py
@@ -677,7 +677,7 @@ def run_ernie_pretrain(model_args, data_args, generating_args, training_args):
     callbacks += [GlobalRNGCallback()]
     callbacks += [OrthogonalCallback(ortho_loss_lambda)] if args.use_ortho_loss_callback else []
 
-    if getattr(cfg, "moe_use_aux_free", 0.0) > 0.0:
+    if cfg.topk_method == "noaux_tc":
         logger.info("adding aux free callback")
         callbacks += [MoECorrectionBiasAdjustCallback(args.moe_router_bias_update_rate, args.sequence_parallel)]
 

--- a/paddleformers/nn/moe/moe_alltoall_layer.py
+++ b/paddleformers/nn/moe/moe_alltoall_layer.py
@@ -163,7 +163,7 @@ class MOEAlltoAllLayer(MOELayerBase):
         self.moe_statics = moe_statics
         if self.use_correction_bias:
             logger.info(f"using correction bias, aux-coef:{self.gate.config.router_aux_loss_coef}")
-            assert self.gate.config.moe_use_aux_free
+            assert self.gate.config.topk_method == "noaux_tc"
 
         self.is_mp_moe = (
             hasattr(fleet.fleet, "_hcg") and group is fleet.get_hybrid_communicate_group().get_model_parallel_group()

--- a/paddleformers/nn/moe/topk_gate.py
+++ b/paddleformers/nn/moe/topk_gate.py
@@ -199,7 +199,7 @@ class TopKGate(nn.Layer):
 
         self.sinkhorn_2gate = config.sinkhorn_2gate
         self.sinkhorn_temp = config.sinkhorn_temp
-        self.use_correction_bias = config.moe_use_aux_free  # true
+        self.use_correction_bias = config.topk_method == "noaux_tc"
         self.use_token_type_bias = config.get("moe_use_token_type_bias", False)
 
         if config.scoring_func == "softmax":

--- a/paddleformers/transformers/ernie4_5_moe/configuration.py
+++ b/paddleformers/transformers/ernie4_5_moe/configuration.py
@@ -78,7 +78,7 @@ class Ernie4_5_MoeConfig(PretrainedConfig):
         moe_norm_gate_logits=True,
         moe_all_to_all_dropout: float = 0.0,
         moe_k=2,
-        moe_use_aux_free: bool = True,
+        topk_method: str = "noaux_tc",
         moe_group_experts: bool = False,
         moe_group_orthogonal_loss: bool = True,
         enable_delay_scale_loss: bool = True,
@@ -147,7 +147,7 @@ class Ernie4_5_MoeConfig(PretrainedConfig):
             moe_norm_gate_logits: Whether to normalize gate logits
             moe_all_to_all_dropout: Dropout for all-to-all communication
             moe_k: Number of experts to route to
-            moe_use_aux_free: Whether to use auxiliary-free routing
+            topk_method: Top-k routing method. ``noaux_tc`` enables auxiliary-free routing
             moe_group_experts: Whether to group experts (requires hard gating)
             moe_group_orthogonal_loss: Whether to use group orthogonal loss
             enable_delay_scale_loss: Whether to enable delayed loss scaling
@@ -217,7 +217,7 @@ class Ernie4_5_MoeConfig(PretrainedConfig):
         self.moe_layer_end_index = self.num_hidden_layers - 1 if moe_layer_end_index == -1 else moe_layer_end_index
         self.scoring_func = scoring_func
         self.moe_norm_gate_logits = moe_norm_gate_logits
-        self.moe_use_aux_free = moe_use_aux_free
+        self.topk_method = topk_method
         self.fuse_gate_detach_matmul = fuse_gate_detach_matmul
         self.moe_use_hard_gate = moe_use_hard_gate
         self.moe_multimodal_dispatch_use_allgather = moe_multimodal_dispatch_use_allgather
@@ -252,7 +252,6 @@ class Ernie4_5_MoeConfig(PretrainedConfig):
                 "enable_delay_scale_loss",
                 "enable_mtp_magic_send",
                 "moe_dropout_prob",
-                "moe_use_aux_free",
                 "router_aux_loss_coef",
                 "scoring_func",
                 "moe_group_experts",

--- a/paddleformers/transformers/ernie4_5_moe/modeling.py
+++ b/paddleformers/transformers/ernie4_5_moe/modeling.py
@@ -275,7 +275,10 @@ class Ernie4_5_MoeSparseMoeBlock(MOEAllGatherLayerV2):
             f"using moe-world-size: {config.moe_world_size} expert-per-device:{moe_num_experts_per_device}, moe_group={config.moe_group}"
         )
 
-        moe_statics = MoEStatics(config, layer_idx) if config.moe_use_aux_free else None
+        if config.topk_method == "noaux_tc":
+            moe_statics = MoEStatics(config, layer_idx)
+        else:
+            moe_statics = None
         experts = nn.LayerList([])
         moe_rank = paddle.distributed.get_rank(config.moe_group)
 

--- a/paddleformers/transformers/ernie4_5_moe_vl/model/configuration.py
+++ b/paddleformers/transformers/ernie4_5_moe_vl/model/configuration.py
@@ -269,7 +269,7 @@ class Ernie4_5_MoeConfig(Ernie4_5_Config):
         moe_norm_gate_logits=True,
         moe_all_to_all_dropout: float = 0.0,
         moe_k=2,
-        moe_use_aux_free: bool = False,
+        topk_method: str = "greedy",
         # `moe_group_experts` must be used with `moe_use_hard_gate=True`
         moe_group_experts: bool = False,
         moe_group_orthogonal_loss: bool = True,
@@ -317,7 +317,7 @@ class Ernie4_5_MoeConfig(Ernie4_5_Config):
             moe_norm_gate_logits: Whether to normalize gate logits
             moe_all_to_all_dropout: Dropout for all-to-all communication
             moe_k: Number of experts to route to
-            moe_use_aux_free: Whether to use auxiliary-free routing
+            topk_method: Top-k routing method. ``noaux_tc`` enables auxiliary-free routing
             moe_group_experts: Whether to group experts (requires hard gating)
             moe_group_orthogonal_loss: Whether to use group orthogonal loss
             enable_delay_scale_loss: Whether to enable delayed loss scaling
@@ -354,7 +354,7 @@ class Ernie4_5_MoeConfig(Ernie4_5_Config):
         self.moe_layer_end_index = self.num_hidden_layers - 1 if moe_layer_end_index == -1 else moe_layer_end_index
         self.scoring_func = scoring_func
         self.moe_norm_gate_logits = moe_norm_gate_logits
-        self.moe_use_aux_free = moe_use_aux_free
+        self.topk_method = topk_method
         self.fuse_gate_detach_matmul = fuse_gate_detach_matmul
         self.dpo_config = dpo_config
         self.moe_multimodal_dispatch_use_allgather = moe_multimodal_dispatch_use_allgather

--- a/paddleformers/transformers/ernie4_5_moe_vl/model/modeling_moe.py
+++ b/paddleformers/transformers/ernie4_5_moe_vl/model/modeling_moe.py
@@ -613,7 +613,7 @@ class Ernie4_5_DecoderLayer(nn.Layer):
             lm_gate, lm_experts = None, None
 
         # for AuxLoss Free Router:
-        if cfg.moe_use_aux_free:
+        if cfg.topk_method == "noaux_tc":
             moe_statics = MoEStatics(cfg, layer_idx)
         else:
             moe_statics = None

--- a/paddleformers/transformers/ernie4_5_moe_vl/model/moe/moe_layer.py
+++ b/paddleformers/transformers/ernie4_5_moe_vl/model/moe/moe_layer.py
@@ -432,7 +432,7 @@ class MOELayer(nn.Layer):
         self.moe_statics = moe_statics
         if self.use_correction_bias:
             logger.info(f"using correction bias, aux-coef:{self.gate.config.router_aux_loss_coef}")
-            assert self.gate.config.moe_use_aux_free
+            assert self.gate.config.topk_method == "noaux_tc"
 
         self.is_mp_moe = (
             hasattr(fleet.fleet, "_hcg") and group is fleet.get_hybrid_communicate_group().get_model_parallel_group()

--- a/paddleformers/transformers/ernie4_5_moe_vl/model/moe/topk_gate.py
+++ b/paddleformers/transformers/ernie4_5_moe_vl/model/moe/topk_gate.py
@@ -193,7 +193,7 @@ class TopKGate(nn.Layer):
 
         self.sinkhorn_2gate = config.sinkhorn_2gate
         self.sinkhorn_temp = config.sinkhorn_temp
-        self.use_correction_bias = config.moe_use_aux_free  # true
+        self.use_correction_bias = config.topk_method == "noaux_tc"
         self.use_token_type_bias = config.get("moe_use_token_type_bias", False)
 
         if config.scoring_func == "softmax":

--- a/tests/ai_edited_test/cli/test_ai_model_args.py
+++ b/tests/ai_edited_test/cli/test_ai_model_args.py
@@ -147,7 +147,7 @@ class TestModelArguments(unittest.TestCase):
         self.assertFalse(args.moe_group_experts)
         self.assertEqual(args.moe_orthogonal_loss_lambda, 0.0)
         self.assertFalse(args.moe_use_hard_gate)
-        self.assertIsNone(args.moe_use_aux_free)
+        self.assertIsNone(args.topk_method)
 
     def test_pp_seg_method(self):
         args = ModelArguments()

--- a/tests/ai_edited_test/nn/test_ai_moe_allgather_layer.py
+++ b/tests/ai_edited_test/nn/test_ai_moe_allgather_layer.py
@@ -178,7 +178,7 @@ class TestMOEAllGatherLayerV2Init(unittest.TestCase):
         mock_gate = MagicMock()
         mock_gate.config = MagicMock()
         mock_gate.config.router_aux_loss_coef = 0.0
-        mock_gate.config.moe_use_aux_free = True
+        mock_gate.config.topk_method = "noaux_tc"
         mock_gate.config.moe_use_hard_gate = False
         mock_gate.config.norm_gate_logits = False
         mock_gate.config.moe_orthogonal_loss_lambda = 0.0
@@ -217,7 +217,7 @@ class TestMOEAllGatherLayerV2Init(unittest.TestCase):
         mock_gate = MagicMock()
         mock_gate.config = MagicMock()
         mock_gate.config.router_aux_loss_coef = 0.0
-        mock_gate.config.moe_use_aux_free = True
+        mock_gate.config.topk_method = "noaux_tc"
         mock_gate.config.moe_use_hard_gate = False
         mock_gate.config.norm_gate_logits = False
         mock_gate.config.moe_orthogonal_loss_lambda = 0.0
@@ -257,7 +257,7 @@ class TestMOEAllGatherLayerV2Init(unittest.TestCase):
         mock_gate = MagicMock()
         mock_gate.config = MagicMock()
         mock_gate.config.router_aux_loss_coef = 0.0
-        mock_gate.config.moe_use_aux_free = True
+        mock_gate.config.topk_method = "noaux_tc"
         mock_gate.config.moe_use_hard_gate = False
         mock_gate.config.norm_gate_logits = False
         mock_gate.config.moe_orthogonal_loss_lambda = 0.0
@@ -291,7 +291,7 @@ class TestMOEAllGatherLayerV2Init(unittest.TestCase):
         mock_gate = MagicMock()
         mock_gate.config = MagicMock()
         mock_gate.config.router_aux_loss_coef = 0.0
-        mock_gate.config.moe_use_aux_free = True
+        mock_gate.config.topk_method = "noaux_tc"
         mock_gate.config.moe_use_hard_gate = False
         mock_gate.config.norm_gate_logits = False
         mock_gate.config.moe_orthogonal_loss_lambda = 0.0
@@ -325,7 +325,7 @@ class TestMOEAllGatherLayerV2Init(unittest.TestCase):
         mock_gate = MagicMock()
         mock_gate.config = MagicMock()
         mock_gate.config.router_aux_loss_coef = 0.0
-        mock_gate.config.moe_use_aux_free = True
+        mock_gate.config.topk_method = "noaux_tc"
         mock_gate.config.moe_use_hard_gate = False
         mock_gate.config.norm_gate_logits = False
         mock_gate.config.moe_orthogonal_loss_lambda = 0.0
@@ -387,7 +387,7 @@ class TestMOEAllGatherLayerV2ForwardExperts(unittest.TestCase):
         mock_gate = MagicMock()
         mock_gate.config = MagicMock()
         mock_gate.config.router_aux_loss_coef = 0.0
-        mock_gate.config.moe_use_aux_free = True
+        mock_gate.config.topk_method = "noaux_tc"
         mock_gate.config.moe_use_hard_gate = False
         mock_gate.config.norm_gate_logits = False
         mock_gate.config.moe_orthogonal_loss_lambda = 0.0
@@ -466,7 +466,7 @@ class TestMOEAllGatherLayerV2CalcRouterLoss(unittest.TestCase):
         mock_gate = MagicMock()
         mock_gate.config = MagicMock()
         mock_gate.config.router_aux_loss_coef = 0.0
-        mock_gate.config.moe_use_aux_free = True
+        mock_gate.config.topk_method = "noaux_tc"
         mock_gate.config.moe_use_hard_gate = False
         mock_gate.config.norm_gate_logits = False
         mock_gate.config.moe_orthogonal_loss_lambda = 0.0
@@ -519,7 +519,7 @@ class TestMOEAllGatherLayerV2FusedGateLogitsProcessFused(unittest.TestCase):
         mock_gate = MagicMock()
         mock_gate.config = MagicMock()
         mock_gate.config.router_aux_loss_coef = 0.0
-        mock_gate.config.moe_use_aux_free = True
+        mock_gate.config.topk_method = "noaux_tc"
         mock_gate.config.moe_use_hard_gate = False
         mock_gate.config.norm_gate_logits = False
         mock_gate.config.moe_orthogonal_loss_lambda = 0.0

--- a/tests/ai_edited_test/nn/test_ai_moe_alltoall_layer.py
+++ b/tests/ai_edited_test/nn/test_ai_moe_alltoall_layer.py
@@ -142,7 +142,7 @@ class TestMOEAlltoAllLayerInit(unittest.TestCase):
         mock_gate = MagicMock()
         mock_gate.config = MagicMock()
         mock_gate.config.router_aux_loss_coef = 0.01
-        mock_gate.config.moe_use_aux_free = True
+        mock_gate.config.topk_method = "noaux_tc"
         mock_gate.config.moe_use_hard_gate = False
         mock_gate.config.moe_orthogonal_loss_lambda = 0.0
         mock_gate.config.router_z_loss_coef = 0.0
@@ -184,7 +184,7 @@ class TestMOEAlltoAllLayerInit(unittest.TestCase):
         mock_gate = MagicMock()
         mock_gate.config = MagicMock()
         mock_gate.config.router_aux_loss_coef = 0.01
-        mock_gate.config.moe_use_aux_free = True
+        mock_gate.config.topk_method = "noaux_tc"
         mock_gate.parameters.return_value = []
 
         experts = nn.LayerList([nn.Linear(4, 4), nn.Linear(4, 4)])
@@ -213,7 +213,7 @@ class TestMOEAlltoAllLayerInit(unittest.TestCase):
         mock_gate = MagicMock()
         mock_gate.config = MagicMock()
         mock_gate.config.router_aux_loss_coef = 0.0
-        mock_gate.config.moe_use_aux_free = True
+        mock_gate.config.topk_method = "noaux_tc"
         mock_gate.parameters.return_value = []
 
         experts = nn.LayerList([nn.Linear(4, 4), nn.Linear(4, 4), nn.Linear(4, 4), nn.Linear(4, 4)])
@@ -240,7 +240,7 @@ class TestMOEAlltoAllLayerInit(unittest.TestCase):
         gate = nn.Linear(8, 4)
         gate.config = MagicMock()
         gate.config.router_aux_loss_coef = 0.0
-        gate.config.moe_use_aux_free = True
+        gate.config.topk_method = "noaux_tc"
 
         experts = nn.LayerList([nn.Linear(4, 4), nn.Linear(4, 4)])
         for p in experts.parameters():
@@ -261,7 +261,7 @@ class TestMOEAlltoAllLayerInit(unittest.TestCase):
         mock_gate = MagicMock()
         mock_gate.config = MagicMock()
         mock_gate.config.router_aux_loss_coef = 0.0
-        mock_gate.config.moe_use_aux_free = True
+        mock_gate.config.topk_method = "noaux_tc"
         mock_gate.parameters.return_value = []
 
         experts = nn.LayerList([nn.Linear(4, 4)])
@@ -283,7 +283,7 @@ class TestMOEAlltoAllLayerInit(unittest.TestCase):
         mock_gate = MagicMock()
         mock_gate.config = MagicMock()
         mock_gate.config.router_aux_loss_coef = 0.0
-        mock_gate.config.moe_use_aux_free = True
+        mock_gate.config.topk_method = "noaux_tc"
         mock_gate.parameters.return_value = []
 
         experts = nn.LayerList([nn.Linear(4, 4)])
@@ -304,7 +304,7 @@ class TestMOEAlltoAllLayerInit(unittest.TestCase):
         mock_gate = MagicMock()
         mock_gate.config = MagicMock()
         mock_gate.config.router_aux_loss_coef = 0.0
-        mock_gate.config.moe_use_aux_free = True
+        mock_gate.config.topk_method = "noaux_tc"
         mock_gate.parameters.return_value = []
 
         experts = nn.LayerList([nn.Linear(4, 4)])
@@ -326,7 +326,7 @@ class TestMOEAlltoAllLayerInit(unittest.TestCase):
         mock_gate = MagicMock()
         mock_gate.config = MagicMock()
         mock_gate.config.router_aux_loss_coef = 0.0
-        mock_gate.config.moe_use_aux_free = True
+        mock_gate.config.topk_method = "noaux_tc"
         mock_gate.parameters.return_value = []
 
         experts = nn.LayerList([nn.Linear(4, 4), nn.Linear(4, 4)])
@@ -352,7 +352,7 @@ class TestMOEAlltoAllLayerCalcRouterLoss(unittest.TestCase):
         mock_gate = MagicMock()
         mock_gate.config = MagicMock()
         mock_gate.config.router_aux_loss_coef = aux_loss_coef
-        mock_gate.config.moe_use_aux_free = True
+        mock_gate.config.topk_method = "noaux_tc"
         mock_gate.config.moe_orthogonal_loss_lambda = 0.0
         mock_gate.config.router_z_loss_coef = 0.0
         mock_gate.config.moe_use_hard_gate = False
@@ -434,7 +434,7 @@ class TestMOEAlltoAllLayerCombineExpertOutput(unittest.TestCase):
         mock_gate = MagicMock()
         mock_gate.config = MagicMock()
         mock_gate.config.router_aux_loss_coef = 0.0
-        mock_gate.config.moe_use_aux_free = True
+        mock_gate.config.topk_method = "noaux_tc"
         mock_gate.config.moe_use_hard_gate = False
         mock_gate.config.norm_gate_logits = False
         mock_gate.parameters.return_value = []
@@ -466,7 +466,7 @@ class TestMOEAlltoAllLayerCombineExpertOutput(unittest.TestCase):
         mock_gate = MagicMock()
         mock_gate.config = MagicMock()
         mock_gate.config.router_aux_loss_coef = 0.0
-        mock_gate.config.moe_use_aux_free = True
+        mock_gate.config.topk_method = "noaux_tc"
         mock_gate.config.moe_use_hard_gate = False
         mock_gate.config.norm_gate_logits = False
         mock_gate.parameters.return_value = []
@@ -502,7 +502,7 @@ class TestMOEAlltoAllLayerForwardExperts(unittest.TestCase):
         mock_gate = MagicMock()
         mock_gate.config = MagicMock()
         mock_gate.config.router_aux_loss_coef = 0.0
-        mock_gate.config.moe_use_aux_free = True
+        mock_gate.config.topk_method = "noaux_tc"
         mock_gate.parameters.return_value = []
 
         expert1 = nn.Linear(8, 8)
@@ -532,7 +532,7 @@ class TestMOEAlltoAllLayerForwardExperts(unittest.TestCase):
         mock_gate = MagicMock()
         mock_gate.config = MagicMock()
         mock_gate.config.router_aux_loss_coef = 0.0
-        mock_gate.config.moe_use_aux_free = True
+        mock_gate.config.topk_method = "noaux_tc"
         mock_gate.parameters.return_value = []
 
         # Fused experts must support len(), subscripting, and be callable
@@ -576,7 +576,7 @@ class TestMOEAlltoAllLayerFusedGateLogitsProcess(unittest.TestCase):
         mock_gate = MagicMock()
         mock_gate.config = MagicMock()
         mock_gate.config.router_aux_loss_coef = 0.0
-        mock_gate.config.moe_use_aux_free = True
+        mock_gate.config.topk_method = "noaux_tc"
         mock_gate.config.moe_use_hard_gate = False
         mock_gate.config.norm_gate_logits = False
         mock_gate.act = paddle.nn.functional.softmax
@@ -639,7 +639,7 @@ class TestMOEAlltoAllLayerForwardSingleStage(unittest.TestCase):
         mock_gate = MagicMock()
         mock_gate.config = MagicMock()
         mock_gate.config.router_aux_loss_coef = 0.0
-        mock_gate.config.moe_use_aux_free = True
+        mock_gate.config.topk_method = "noaux_tc"
         mock_gate.parameters.return_value = []
 
         experts = nn.LayerList([nn.Linear(4, 4), nn.Linear(4, 4)])

--- a/tests/ai_edited_test/nn/test_ai_topk_gate.py
+++ b/tests/ai_edited_test/nn/test_ai_topk_gate.py
@@ -45,7 +45,7 @@ class FakeGateConfig:
         self.global_aux_loss = False
         self.sinkhorn_2gate = False
         self.sinkhorn_temp = 1.0
-        self.moe_use_aux_free = False
+        self.topk_method = "greedy"
         self.router_aux_loss_coef = 0.01
         self.router_z_loss_coef = 0.0
         self.moe_orthogonal_loss_lambda = 0.0
@@ -419,7 +419,7 @@ class TestTopKGateCalAuxLoss(unittest.TestCase):
     @patch("paddleformers.nn.moe.topk_gate.dist.get_rank", return_value=0)
     def test_aux_loss_with_correction_bias_no_tokens_mask(self, mock_rank):
         """Test aux loss with correction_bias but no tokens_mask."""
-        config = FakeGateConfig(moe_use_aux_free=True, moe_k=2)
+        config = FakeGateConfig(topk_method="noaux_tc", moe_k=2)
         gate = self.TopKGate(config, layer_idx=0, group=_make_fake_group())
         gate_prob = F.softmax(_randn([8, 8]))
         dispatch_mask = paddle.randint(0, 8, [8])

--- a/tests/transformers/ernie4_5_moe/test_modeling.py
+++ b/tests/transformers/ernie4_5_moe/test_modeling.py
@@ -85,7 +85,7 @@
 #         moe_norm_gate_logits=True,
 #         moe_all_to_all_dropout=0.0,
 #         moe_k=2,
-#         moe_use_aux_free=True,
+#         topk_method="noaux_tc",
 #         moe_group_experts=False,
 #         moe_group_orthogonal_loss=True,
 #         enable_delay_scale_loss=True,
@@ -160,7 +160,7 @@
 #         self.moe_layer_end_index = self.num_hidden_layers - 1 if moe_layer_end_index == -1 else moe_layer_end_index
 #         self.moe_gate_act = moe_gate_act
 #         self.moe_norm_gate_logits = moe_norm_gate_logits
-#         self.moe_use_aux_free = moe_use_aux_free
+#         self.topk_method = topk_method
 #         self.fuse_gate_detach_matmul = fuse_gate_detach_matmul
 #         self.moe_use_hard_gate = moe_use_hard_gate
 #         self.num_nextn_predict_layers = num_nextn_predict_layers
@@ -249,7 +249,7 @@
 #             num_acc_steps=self.num_acc_steps,
 #             moe_gate_act=self.moe_gate_act,
 #             moe_norm_gate_logits=self.moe_norm_gate_logits,
-#             moe_use_aux_free=self.moe_use_aux_free,
+#             topk_method=self.topk_method,
 #             fuse_gate_detach_matmul=self.fuse_gate_detach_matmul,
 #             moe_use_hard_gate=self.moe_use_hard_gate,
 #             num_nextn_predict_layers=self.num_nextn_predict_layers,

--- a/tests/transformers/ernie4_5_moe_vl/test_modeling.py
+++ b/tests/transformers/ernie4_5_moe_vl/test_modeling.py
@@ -68,7 +68,7 @@ class Ernie4_5_VLModelTester:
         moe_multimodal_dispatch_use_allgather="v2-alltoall-unpad-text",
         moe_num_experts=[4, 4],
         moe_num_shared_experts=1,
-        moe_use_aux_free=True,
+        topk_method="noaux_tc",
         pixel_hidden_size=32,
         rms_norm_eps=1e-5,
         rope_3d=True,
@@ -129,7 +129,7 @@ class Ernie4_5_VLModelTester:
         self.moe_multimodal_dispatch_use_allgather = moe_multimodal_dispatch_use_allgather
         self.moe_num_experts = moe_num_experts
         self.moe_num_shared_experts = moe_num_shared_experts
-        self.moe_use_aux_free = moe_use_aux_free
+        self.topk_method = topk_method
         self.pixel_hidden_size = pixel_hidden_size
         self.rms_norm_eps = rms_norm_eps
         self.rope_3d = rope_3d
@@ -259,7 +259,7 @@ class Ernie4_5_VLModelTester:
             moe_multimodal_dispatch_use_allgather=self.moe_multimodal_dispatch_use_allgather,
             moe_num_experts=self.moe_num_experts,
             moe_num_shared_experts=self.moe_num_shared_experts,
-            moe_use_aux_free=self.moe_use_aux_free,
+            topk_method=self.topk_method,
             pixel_hidden_size=self.pixel_hidden_size,
             rms_norm_eps=self.rms_norm_eps,
             rope_3d=self.rope_3d,


### PR DESCRIPTION
- PaddleFormers 直接用 `topk_method == "noaux_tc"` 表示 aux-free MoE 路由。
- 移除 `moe_use_aux_free` 配置和判断，迁移相关 YAML/model_config 与测试。
