### PR TITLE
[eb4-1] Remove expert_mlp_use_bias usage

### DIFF
--- a/examples/experiments/ernie_pretrain/models/ernie/configuration.py
+++ b/examples/experiments/ernie_pretrain/models/ernie/configuration.py
@@ -96,7 +96,7 @@ class ErnieMoEConfig(PretrainedConfig):
         fuse_attn_ffn=False,
         fuse_swiglu=False,
         use_bias=False,
-        expert_mlp_use_bias=None,
+        moe_routed_expert_use_bias=None,
         rope_reorder=True,
         rope_theta=10000,
         apply_rope_fusion=False,
@@ -307,7 +307,7 @@ class ErnieMoEConfig(PretrainedConfig):
         update_nested_dict(default_fp8_configs, fp8_configs)
         self.fp8_configs = default_fp8_configs
         self.use_fp8 = use_fp8
-        self.expert_mlp_use_bias = expert_mlp_use_bias
+        self.moe_routed_expert_use_bias = moe_routed_expert_use_bias
         self.use_fp8_mlp = use_fp8_mlp
         self.use_fp8_fuse_node = use_fp8_fuse_node
         default_fp8_mem_configs = {

--- a/examples/experiments/ernie_pretrain/models/ernie/modeling_moe.py
+++ b/examples/experiments/ernie_pretrain/models/ernie/modeling_moe.py
@@ -1055,8 +1055,8 @@ class ErnieDecoderLayer(nn.Layer):
     def _init_gate_and_experts(self, layer_idx):
         cfg = deepcopy(self.config)
         fc_cls = ErnieMoeMLPFused if cfg.moe_fuse_experts and not cfg.use_fp8_mlp else ErnieMoeMLP
-        if self.config.expert_mlp_use_bias is not None:
-            cfg.use_bias = self.config.expert_mlp_use_bias
+        if self.config.moe_routed_expert_use_bias is not None:
+            cfg.use_bias = self.config.moe_routed_expert_use_bias
 
         if cfg.moe_intermediate_size:
             if isinstance(cfg.moe_intermediate_size, (tuple, list)):

--- a/paddleformers/cli/train/ernie_pretrain/models/ernie/configuration.py
+++ b/paddleformers/cli/train/ernie_pretrain/models/ernie/configuration.py
@@ -96,7 +96,7 @@ class ErnieMoEConfig(PretrainedConfig):
         fuse_attn_ffn=False,
         fuse_swiglu=False,
         use_bias=False,
-        expert_mlp_use_bias=None,
+        moe_routed_expert_use_bias=None,
         rope_reorder=True,
         rope_theta=10000,
         apply_rope_fusion=False,
@@ -306,7 +306,7 @@ class ErnieMoEConfig(PretrainedConfig):
         update_nested_dict(default_fp8_configs, fp8_configs)
         self.fp8_configs = default_fp8_configs
         self.use_fp8 = use_fp8
-        self.expert_mlp_use_bias = expert_mlp_use_bias
+        self.moe_routed_expert_use_bias = moe_routed_expert_use_bias
         self.use_fp8_mlp = use_fp8_mlp
         self.use_fp8_fuse_node = use_fp8_fuse_node
         default_fp8_mem_configs = {

--- a/paddleformers/cli/train/ernie_pretrain/models/ernie/modeling_moe.py
+++ b/paddleformers/cli/train/ernie_pretrain/models/ernie/modeling_moe.py
@@ -1068,8 +1068,8 @@ class ErnieDecoderLayer(nn.Layer):
     def _init_gate_and_experts(self, layer_idx):
         cfg = deepcopy(self.config)
         fc_cls = ErnieMoeMLPFused if cfg.moe_fuse_experts and not cfg.use_fp8_mlp else ErnieMoeMLP
-        if self.config.expert_mlp_use_bias is not None:
-            cfg.use_bias = self.config.expert_mlp_use_bias
+        if self.config.moe_routed_expert_use_bias is not None:
+            cfg.use_bias = self.config.moe_routed_expert_use_bias
 
         if cfg.moe_intermediate_size:
             if isinstance(cfg.moe_intermediate_size, (tuple, list)):


### PR DESCRIPTION
## Summary
- replace expert_mlp_use_bias with moe_routed_expert_use_bias in Ernie MoE configs
- route MoE expert bias override through moe_routed_expert_use_bias only

## Validation
- python -m py_compile targeted ernie-core and PaddleFormers files
- PYTHONPATH=third_party/ernie-core/src:third_party/ernie-core python -m pytest third_party/ernie-core/test/test_single/test_config.py -q