### PR TITLE
[BugFix] Fix Muon slice_config head_num for GQA kv_b_proj

### DIFF
--- a/paddleformers/transformers/minimax_m2/modeling.py
+++ b/paddleformers/transformers/minimax_m2/modeling.py
@@ -288,7 +288,8 @@ class MiniMaxM2PreTrainedModel(PretrainedModel):
                 slice_config[f"{prefix}.self_attn.kv_b_proj.weight"] = (
                     mla_slice_fn,
                     {
-                        "head_num": num_attention_head,
+                        # For GQA, kv_b_proj has num_key_value_heads, not num_attention_heads.
+                        "head_num": num_key_value_heads,
                         "axis": 1,
                         "head_split_sizes": [config.qk_nope_head_dim, config.v_head_dim],
                     },


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->
For GQA models with MLA, `kv_b_proj` has `num_key_value_heads` (e.g., 8) heads, not `num_attention_heads` (e.g., 32). The Muon `slice_config` was incorrectly using `num_attention_head` for `kv_b_proj`, causing `paddle.split` to receive a 64-section list that exceeded Paddle's dimension limit (max 9), triggering:

```
OSError: Invalid dimension to be accessed. received dimension is 64.
```

This bug was exposed by PaddleFleet PR #904 which correctly changed `kv_b_proj` to use `num_key_value_heads`.

### Changes
`paddleformers/transformers/minimax_m2/modeling.py:288-294`
- `kv_b_proj` slice_config `head_num`: `num_attention_head` → `num_key_value_heads`

### Test
- EB5 GQA MLA model training runs successfully after this fix
