### PR TITLE
fix(mtp): correct gen_mtp_layer_mask argument and implementation

### DIFF
--- a/paddleformers/datasets/collate.py
+++ b/paddleformers/datasets/collate.py
@@ -553,10 +553,9 @@ def collate_fn(
 
             return_list[-1].append(
                 gen_mtp_layer_mask(
-                    token_ids,
+                    position_ids,
                     max_seq_len,
                     training_args.num_nextn_predict_layers,
-                    tokenizer.eos_token_id,
                 )
             )
 
@@ -975,35 +974,32 @@ def gen_mtp_attn_mask_startend_row_indices(
 
 
 def gen_mtp_layer_mask(
-    batch_token_ids: List[List[int]],
+    batch_position_ids: List[List[int]],
     max_seq_len: int,
     mtp_depth: int,
-    eos_token_id: int = None,
 ) -> np.ndarray:
     """Generate MTP per-layer hidden inputs mask.
 
-    For each MTP layer, constructs the shifted input_ids (aligned with model's
-    MTPmmLayerPipe.forward) and zeros out positions where EOS appears, so that
-    hidden states at EOS boundaries are masked.
-
     Args:
-        batch_token_ids: List of token ID sequences (already concatenated as
-            a single-element list, e.g. [[id0, id1, ...]]).
+        batch_position_ids: List of position ID sequences,
+            e.g. [[0,1,2,...,N], [0,1,2,...,M]].
         max_seq_len: Padded sequence length, already extended by mtp_depth.
-        mtp_depth: Number of MTP prediction layers D.
-        eos_token_id: If provided, zero out positions where EOS appears in shifted input.
+        mtp_depth: Number of MTP prediction layers.
 
     Returns:
         np.ndarray, shape [mtp_depth, max_seq_len], dtype=int32.
     """
-    if eos_token_id is None:
-        return np.ones((mtp_depth, max_seq_len), dtype=np.int32)
-
-    all_token_ids = np.concatenate([np.array(ids, dtype=np.int32) for ids in batch_token_ids])
+    all_position_ids = np.concatenate([np.array(ids, dtype=np.int32) for ids in batch_position_ids])
+    if len(all_position_ids) < max_seq_len:
+        all_position_ids = np.pad(all_position_ids, (0, max_seq_len - len(all_position_ids)), constant_values=0)
+    detect = np.append(all_position_ids, 0)
+    boundaries = np.where(detect[:-1] > detect[1:])[0]
+    mask = np.ones(max_seq_len, dtype=np.int32)
+    mask[boundaries] = 0
     result = []
-    for mtp_idx in range(mtp_depth):
-        mask = np.ones(max_seq_len, dtype=np.int32)
-        shifted = all_token_ids[mtp_idx + 1 :]
-        mask[np.where(shifted == eos_token_id)[0]] = 0
+    for _ in range(mtp_depth):
+        new_mask = np.ones(max_seq_len, dtype=np.int32)
+        new_mask[:-1] = mask[1:]
+        mask = new_mask
         result.append(mask)
     return np.stack(result, axis=0)

--- a/paddleformers/datasets/collate.py
+++ b/paddleformers/datasets/collate.py
@@ -1000,20 +1000,10 @@ def gen_mtp_layer_mask(
         return np.ones((mtp_depth, max_seq_len), dtype=np.int32)
 
     all_token_ids = np.concatenate([np.array(ids, dtype=np.int32) for ids in batch_token_ids])
-    ids_input = all_token_ids[:-1]
-    seq_len = len(ids_input)
-    ids_mtp = ids_input[-mtp_depth:]
-    ids_ori = ids_input[:-mtp_depth]
-
-    mtp_hidden_inputs_mask_all = []
+    result = []
     for mtp_idx in range(mtp_depth):
-        mtp_ids_input_ids = np.concatenate([ids_ori[(mtp_idx + 1):], ids_mtp[:(mtp_idx + 1)]])
-        mask = np.ones((1, seq_len), dtype=np.int32)
-        eos_positions = np.where(mtp_ids_input_ids[:seq_len] == eos_token_id)[0]
-        mask[0, eos_positions] = 0
-        if seq_len < max_seq_len:
-            padding = np.ones((1, max_seq_len - seq_len), dtype=np.int32)
-            mask = np.concatenate([mask, padding], axis=1)
-        mtp_hidden_inputs_mask_all.append(mask)
-
-    return np.concatenate(mtp_hidden_inputs_mask_all, axis=0)
+        mask = np.ones(max_seq_len, dtype=np.int32)
+        shifted = all_token_ids[mtp_idx + 1 :]
+        mask[np.where(shifted == eos_token_id)[0]] = 0
+        result.append(mask)
+    return np.stack(result, axis=0)

--- a/paddleformers/datasets/collate.py
+++ b/paddleformers/datasets/collate.py
@@ -553,7 +553,7 @@ def collate_fn(
 
             return_list[-1].append(
                 gen_mtp_layer_mask(
-                    position_ids,
+                    original_position_ids,
                     max_seq_len,
                     training_args.num_nextn_predict_layers,
                 )

--- a/paddleformers/datasets/collate.py
+++ b/paddleformers/datasets/collate.py
@@ -553,7 +553,7 @@ def collate_fn(
 
             return_list[-1].append(
                 gen_mtp_layer_mask(
-                    original_position_ids,
+                    token_ids,
                     max_seq_len,
                     training_args.num_nextn_predict_layers,
                     tokenizer.eos_token_id,
@@ -982,8 +982,13 @@ def gen_mtp_layer_mask(
 ) -> np.ndarray:
     """Generate MTP per-layer hidden inputs mask.
 
+    For each MTP layer, constructs the shifted input_ids (aligned with model's
+    MTPmmLayerPipe.forward) and zeros out positions where EOS appears, so that
+    hidden states at EOS boundaries are masked.
+
     Args:
-        batch_token_ids: List of token ID sequences.
+        batch_token_ids: List of token ID sequences (already concatenated as
+            a single-element list, e.g. [[id0, id1, ...]]).
         max_seq_len: Padded sequence length, already extended by mtp_depth.
         mtp_depth: Number of MTP prediction layers D.
         eos_token_id: If provided, zero out positions where EOS appears in shifted input.
@@ -993,11 +998,22 @@ def gen_mtp_layer_mask(
     """
     if eos_token_id is None:
         return np.ones((mtp_depth, max_seq_len), dtype=np.int32)
+
     all_token_ids = np.concatenate([np.array(ids, dtype=np.int32) for ids in batch_token_ids])
-    result = []
+    ids_input = all_token_ids[:-1]
+    seq_len = len(ids_input)
+    ids_mtp = ids_input[-mtp_depth:]
+    ids_ori = ids_input[:-mtp_depth]
+
+    mtp_hidden_inputs_mask_all = []
     for mtp_idx in range(mtp_depth):
-        mask = np.ones(max_seq_len, dtype=np.int32)
-        shifted = all_token_ids[mtp_idx + 1 :]
-        mask[np.where(shifted == eos_token_id)[0]] = 0
-        result.append(mask)
-    return np.stack(result, axis=0)
+        mtp_ids_input_ids = np.concatenate([ids_ori[(mtp_idx + 1):], ids_mtp[:(mtp_idx + 1)]])
+        mask = np.ones((1, seq_len), dtype=np.int32)
+        eos_positions = np.where(mtp_ids_input_ids[:seq_len] == eos_token_id)[0]
+        mask[0, eos_positions] = 0
+        if seq_len < max_seq_len:
+            padding = np.ones((1, max_seq_len - seq_len), dtype=np.int32)
+            mask = np.concatenate([mask, padding], axis=1)
+        mtp_hidden_inputs_mask_all.append(mask)
+
+    return np.concatenate(mtp_hidden_inputs_mask_all, axis=0)

--- a/tests/dataset/test_collate.py
+++ b/tests/dataset/test_collate.py
@@ -26,10 +26,6 @@ from paddleformers.datasets.collate import (
     pad_batch_data,
 )
 
-# ---------------------------------------------------------------------------
-# Minimal stubs
-# ---------------------------------------------------------------------------
-
 
 class _TrainingArgs:
     """Minimal stub for training_args used by calc_padding_size."""
@@ -39,11 +35,6 @@ class _TrainingArgs:
         self.tensor_model_parallel_size = tp_size
         self.sequence_parallel = sequence_parallel
         self.fp8 = fp8
-
-
-# ---------------------------------------------------------------------------
-# calc_padding_size
-# ---------------------------------------------------------------------------
 
 
 class TestCalcPaddingSize(unittest.TestCase):
@@ -61,11 +52,6 @@ class TestCalcPaddingSize(unittest.TestCase):
         self.assertEqual(calc_padding_size(5, args), 8)
 
 
-# ---------------------------------------------------------------------------
-# pad_batch_data
-# ---------------------------------------------------------------------------
-
-
 class TestPadBatchData(unittest.TestCase):
     def test_pads_to_max_length(self):
         result = pad_batch_data([[1, 2, 3], [4, 5]], pad_idx=0)
@@ -75,11 +61,6 @@ class TestPadBatchData(unittest.TestCase):
     def test_pads_to_explicit_max_seq_len(self):
         result = pad_batch_data([[1, 2], [3]], pad_idx=-1, max_seq_len=5)
         np.testing.assert_array_equal(result[0], [1, 2, -1, -1, -1])
-
-
-# ---------------------------------------------------------------------------
-# gen_self_attn_mask
-# ---------------------------------------------------------------------------
 
 
 class TestGenSelfAttnMask(unittest.TestCase):
@@ -96,11 +77,6 @@ class TestGenSelfAttnMask(unittest.TestCase):
         np.testing.assert_array_equal(mask[0, 0, :4, :4], np.tril(np.ones((4, 4))))
 
 
-# ---------------------------------------------------------------------------
-# gen_attn_mask_startend_row_indices
-# ---------------------------------------------------------------------------
-
-
 class TestGenAttnMaskStartendRowIndices(unittest.TestCase):
     def test_output_shape_and_dtype(self):
         result = gen_attn_mask_startend_row_indices([[1, 2, 3]], max_seq_len=3, use_global_causal_attn=False)
@@ -108,7 +84,6 @@ class TestGenAttnMaskStartendRowIndices(unittest.TestCase):
         self.assertEqual(result.dtype, np.int32)
 
     def test_each_token_points_to_segment_end(self):
-        # Segment A: tokens 0-2 → end=3; Segment B: tokens 3-4 → end=5
         result = gen_attn_mask_startend_row_indices([[0, 0, 0], [0, 0]], max_seq_len=5, use_global_causal_attn=False)
         indices = result[0, 0, :, 0].tolist()
         self.assertEqual(indices[:3], [3, 3, 3])
@@ -120,15 +95,15 @@ class TestGenAttnMaskStartendRowIndices(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# Shared fixture
+# Shared fixture for MTP attn mask tests (token_ids based)
 #
 # BATCH = [[1, 2, EOS], [4, 5, 6]]
 # total_len=6, mtp_depth=2, max_seq_len=8
 # internal_boundaries=[3]
 #
 # Boundary shift rule (layer k): shifted = original - (k+1)
-#   Layer 0: 3-1=2 → blocks [0:2], [2:6]
-#   Layer 1: 3-2=1 → blocks [0:1], [1:6]
+#   Layer 0: 3-1=2 -> blocks [0:2], [2:6]
+#   Layer 1: 3-2=1 -> blocks [0:1], [1:6]
 # ---------------------------------------------------------------------------
 
 EOS = 3
@@ -136,11 +111,6 @@ BATCH = [[1, 2, EOS], [4, 5, 6]]
 MTP_DEPTH = 2
 TOTAL_LEN = 6
 MAX_SEQ_LEN = TOTAL_LEN + MTP_DEPTH  # 8
-
-
-# ---------------------------------------------------------------------------
-# gen_mtp_attn_mask
-# ---------------------------------------------------------------------------
 
 
 class TestGenMtpAttnMask(unittest.TestCase):
@@ -176,11 +146,6 @@ class TestGenMtpAttnMask(unittest.TestCase):
             np.testing.assert_array_equal(mask[k, 0, TOTAL_LEN:, :], 0.0)
 
 
-# ---------------------------------------------------------------------------
-# gen_mtp_attn_mask_startend_row_indices
-# ---------------------------------------------------------------------------
-
-
 class TestGenMtpAttnMaskStartendRowIndices(unittest.TestCase):
     def _call(self, use_global_causal_attn):
         return gen_mtp_attn_mask_startend_row_indices(BATCH, MAX_SEQ_LEN, MTP_DEPTH, use_global_causal_attn)
@@ -191,13 +156,13 @@ class TestGenMtpAttnMaskStartendRowIndices(unittest.TestCase):
         self.assertEqual(result.dtype, np.int32)
 
     def test_layer0_end_row_values(self):
-        """Layer 0: positions 0-1 → end=2, positions 2-5 → end=6."""
+        """Layer 0: positions 0-1 -> end=2, positions 2-5 -> end=6."""
         indices = self._call(False)[0, 0, :TOTAL_LEN, 0].tolist()
         self.assertEqual(indices[:2], [2, 2])
         self.assertEqual(indices[2:], [6, 6, 6, 6])
 
     def test_layer1_end_row_values(self):
-        """Layer 1: position 0 → end=1, positions 1-5 → end=6."""
+        """Layer 1: position 0 -> end=1, positions 1-5 -> end=6."""
         indices = self._call(False)[1, 0, :TOTAL_LEN, 0].tolist()
         self.assertEqual(indices[0], 1)
         self.assertEqual(indices[1:], [6, 6, 6, 6, 6])
@@ -222,88 +187,110 @@ class TestGenMtpAttnMaskStartendRowIndices(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# gen_mtp_layer_mask
-# ---------------------------------------------------------------------------
+# gen_mtp_layer_mask — uses position_ids for boundary detection
 #
-# all_token_ids=[1,2,EOS,4,5,6], ids_input=all[:-1]=[1,2,EOS,4,5]
-# ids_ori=ids_input[:-2]=[1,2,EOS], ids_mtp=ids_input[-2:]=[4,5]
-# Layer 0: mtp_ids=concat(ids_ori[1:], ids_mtp[:1])=[2,EOS,4] → EOS@1 → mask[1]=0
-# Layer 1: mtp_ids=concat(ids_ori[2:], ids_mtp[:2])=[EOS,4,5] → EOS@0 → mask[0]=0
-# padding area (seq_len=5 to max_seq_len=8) is all ones
+# Input: position_ids for 2 sequences of length 3 each.
+# position_ids = [[0,1,2], [0,1,2]] -> concatenated = [0,1,2,0,1,2]
+# Padded to max_seq_len=8: [0,1,2,0,1,2,0,0]
+#
+# Layer 0: shifted = all_pos[1:] = [1,2,0,1,2,0,0]
+#   boundary: shifted[i]>shifted[i+1] -> i=1(2>0), i=4(2>0) -> mask[1]=0, mask[4]=0
+# Layer 1: shifted = all_pos[2:] = [2,0,1,2,0,0]
+#   boundary: shifted[i]>shifted[i+1] -> i=0(2>0), i=3(2>0) -> mask[0]=0, mask[3]=0
 # ---------------------------------------------------------------------------
 
 
 class TestGenMtpLayerMask(unittest.TestCase):
-    def _call(self, eos_token_id=None):
-        return gen_mtp_layer_mask(BATCH, MAX_SEQ_LEN, MTP_DEPTH, eos_token_id)
+    POSITION_IDS = [[0, 1, 2], [0, 1, 2]]
+    MTP_DEPTH = 2
+    MAX_SEQ_LEN = 8
+
+    EXPECTED = np.array(
+        [
+            [1, 0, 1, 1, 0, 1, 1, 1],
+            [0, 1, 1, 0, 1, 1, 1, 1],
+        ],
+        dtype=np.int32,
+    )
 
     def test_output_shape_and_dtype(self):
-        result = self._call()
-        self.assertEqual(result.shape, (MTP_DEPTH, MAX_SEQ_LEN))
+        result = gen_mtp_layer_mask(self.POSITION_IDS, self.MAX_SEQ_LEN, self.MTP_DEPTH)
+        self.assertEqual(result.shape, (self.MTP_DEPTH, self.MAX_SEQ_LEN))
         self.assertEqual(result.dtype, np.int32)
 
-    def test_no_eos_all_ones(self):
-        np.testing.assert_array_equal(self._call(None), np.ones((MTP_DEPTH, MAX_SEQ_LEN), dtype=np.int32))
+    def test_full_output(self):
+        result = gen_mtp_layer_mask(self.POSITION_IDS, self.MAX_SEQ_LEN, self.MTP_DEPTH)
+        np.testing.assert_array_equal(result, self.EXPECTED)
 
-    def test_layer0_eos_zeroed_at_shifted_position(self):
-        """Layer 0: EOS at shifted position 1 → mask[0,1]=0, rest=1."""
-        result = self._call(EOS)
+    def test_layer0_boundaries(self):
+        """Layer 0: boundaries at positions 1 and 4."""
+        result = gen_mtp_layer_mask(self.POSITION_IDS, self.MAX_SEQ_LEN, self.MTP_DEPTH)
         self.assertEqual(result[0, 1], 0)
-        np.testing.assert_array_equal(np.delete(result[0], 1), 1)
+        self.assertEqual(result[0, 4], 0)
 
-    def test_layer1_eos_zeroed_at_shifted_position(self):
-        """Layer 1: EOS at shifted position 0 → mask[1,0]=0, rest=1."""
-        result = self._call(EOS)
+    def test_layer1_boundaries(self):
+        """Layer 1: boundaries at positions 0 and 3."""
+        result = gen_mtp_layer_mask(self.POSITION_IDS, self.MAX_SEQ_LEN, self.MTP_DEPTH)
         self.assertEqual(result[1, 0], 0)
-        np.testing.assert_array_equal(result[1, 1:], 1)
+        self.assertEqual(result[1, 3], 0)
 
     def test_padding_area_is_one(self):
-        result = self._call(EOS)
-        for k in range(MTP_DEPTH):
-            np.testing.assert_array_equal(result[k, TOTAL_LEN:], 1)
+        result = gen_mtp_layer_mask(self.POSITION_IDS, self.MAX_SEQ_LEN, self.MTP_DEPTH)
+        for k in range(self.MTP_DEPTH):
+            np.testing.assert_array_equal(result[k, 6:], 1)
+
+    def test_single_sequence_no_boundary(self):
+        """Single sequence: only boundary is at the end (before padding)."""
+        pos_ids = [[0, 1, 2, 3, 4]]
+        result = gen_mtp_layer_mask(pos_ids, 8, 2)
+        # Padded: [0,1,2,3,4,0,0,0]
+        # Layer 0: shifted=[1,2,3,4,0,0,0], boundary at i=3(4>0) -> mask[3]=0
+        # Layer 1: shifted=[2,3,4,0,0,0], boundary at i=2(4>0) -> mask[2]=0
+        self.assertEqual(result[0, 3], 0)
+        self.assertEqual(result[1, 2], 0)
+        self.assertEqual(result[0].sum(), 7)
+        self.assertEqual(result[1].sum(), 7)
 
 
 # ---------------------------------------------------------------------------
 # gen_mtp_layer_mask — 3 sequences, depth=3
-# ---------------------------------------------------------------------------
 #
-# seq1=[1,2,EOS], seq2=[4,EOS], seq3=[6,7,8]  (EOS=99)
-# all_token_ids=[1,2,99,4,99,6,7,8], ids_input=all[:-1]=[1,2,99,4,99,6,7]
-# ids_ori=ids_input[:-3]=[1,2,99,4], ids_mtp=ids_input[-3:]=[99,6,7]
-# Layer 0: mtp_ids=concat(ids_ori[1:], ids_mtp[:1])=[2,99,4,99] → EOS@[1,3]
-# Layer 1: mtp_ids=concat(ids_ori[2:], ids_mtp[:2])=[99,4,99,6] → EOS@[0,2]
-# Layer 2: mtp_ids=concat(ids_ori[3:], ids_mtp[:3])=[4,99,6,7]  → EOS@[1]
+# position_ids = [[0,1,2], [0,1], [0,1,2]] -> concat = [0,1,2,0,1,0,1,2]
+# total_len=8, max_seq_len=11 (8+3)
+# Padded to 11: [0,1,2,0,1,0,1,2,0,0,0]
+#
+# Layer 0: shifted = all_pos[1:] = [1,2,0,1,0,1,2,0,0,0]
+#   boundary: i=1(2>0), i=3(1>0), i=6(2>0) -> mask[1]=0, mask[3]=0, mask[6]=0
+# Layer 1: shifted = all_pos[2:] = [2,0,1,0,1,2,0,0,0]
+#   boundary: i=0(2>0), i=2(1>0), i=5(2>0) -> mask[0]=0, mask[2]=0, mask[5]=0
+# Layer 2: shifted = all_pos[3:] = [0,1,0,1,2,0,0,0]
+#   boundary: i=1(1>0), i=4(2>0) -> mask[1]=0, mask[4]=0
 # ---------------------------------------------------------------------------
 
 
 class TestGenMtpLayerMaskDepth3(unittest.TestCase):
     """Test with 3 packed sequences and mtp_depth=3."""
 
-    BATCH_3SEQ = [[1, 2, 99], [4, 99], [6, 7, 8]]
-    EOS_3SEQ = 99
-    MTP_DEPTH_3 = 3
-    MAX_SEQ_LEN_3 = 10
+    POSITION_IDS = [[0, 1, 2], [0, 1], [0, 1, 2]]
+    MTP_DEPTH = 3
+    MAX_SEQ_LEN = 11
 
     EXPECTED = np.array(
         [
-            [1, 0, 1, 0, 1, 1, 1, 1, 1, 1],
-            [0, 1, 0, 1, 1, 1, 1, 1, 1, 1],
-            [1, 0, 1, 1, 1, 1, 1, 1, 1, 1],
+            [1, 0, 1, 0, 1, 1, 0, 1, 1, 1, 1],
+            [0, 1, 0, 1, 1, 0, 1, 1, 1, 1, 1],
+            [1, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1],
         ],
         dtype=np.int32,
     )
 
     def test_full_output(self):
-        result = gen_mtp_layer_mask(
-            self.BATCH_3SEQ, self.MAX_SEQ_LEN_3, self.MTP_DEPTH_3, self.EOS_3SEQ
-        )
+        result = gen_mtp_layer_mask(self.POSITION_IDS, self.MAX_SEQ_LEN, self.MTP_DEPTH)
         np.testing.assert_array_equal(result, self.EXPECTED)
 
     def test_shape_and_dtype(self):
-        result = gen_mtp_layer_mask(
-            self.BATCH_3SEQ, self.MAX_SEQ_LEN_3, self.MTP_DEPTH_3, self.EOS_3SEQ
-        )
-        self.assertEqual(result.shape, (3, 10))
+        result = gen_mtp_layer_mask(self.POSITION_IDS, self.MAX_SEQ_LEN, self.MTP_DEPTH)
+        self.assertEqual(result.shape, (3, 11))
         self.assertEqual(result.dtype, np.int32)
 
 

--- a/tests/dataset/test_collate.py
+++ b/tests/dataset/test_collate.py
@@ -225,9 +225,11 @@ class TestGenMtpAttnMaskStartendRowIndices(unittest.TestCase):
 # gen_mtp_layer_mask
 # ---------------------------------------------------------------------------
 #
-# all_token_ids=[1,2,EOS,4,5,6], ids_mtp=[5,6], ids_ori=[1,2,3,4]
-# Layer 0: mtp_ids=[2,3,4,5] → EOS@1 → mask[1]=0
-# Layer 1: mtp_ids=[3,4,5,6] → EOS@0 → mask[0]=0
+# all_token_ids=[1,2,EOS,4,5,6], ids_input=all[:-1]=[1,2,EOS,4,5]
+# ids_ori=ids_input[:-2]=[1,2,EOS], ids_mtp=ids_input[-2:]=[4,5]
+# Layer 0: mtp_ids=concat(ids_ori[1:], ids_mtp[:1])=[2,EOS,4] → EOS@1 → mask[1]=0
+# Layer 1: mtp_ids=concat(ids_ori[2:], ids_mtp[:2])=[EOS,4,5] → EOS@0 → mask[0]=0
+# padding area (seq_len=5 to max_seq_len=8) is all ones
 # ---------------------------------------------------------------------------
 
 
@@ -259,6 +261,50 @@ class TestGenMtpLayerMask(unittest.TestCase):
         result = self._call(EOS)
         for k in range(MTP_DEPTH):
             np.testing.assert_array_equal(result[k, TOTAL_LEN:], 1)
+
+
+# ---------------------------------------------------------------------------
+# gen_mtp_layer_mask — 3 sequences, depth=3
+# ---------------------------------------------------------------------------
+#
+# seq1=[1,2,EOS], seq2=[4,EOS], seq3=[6,7,8]  (EOS=99)
+# all_token_ids=[1,2,99,4,99,6,7,8], ids_input=all[:-1]=[1,2,99,4,99,6,7]
+# ids_ori=ids_input[:-3]=[1,2,99,4], ids_mtp=ids_input[-3:]=[99,6,7]
+# Layer 0: mtp_ids=concat(ids_ori[1:], ids_mtp[:1])=[2,99,4,99] → EOS@[1,3]
+# Layer 1: mtp_ids=concat(ids_ori[2:], ids_mtp[:2])=[99,4,99,6] → EOS@[0,2]
+# Layer 2: mtp_ids=concat(ids_ori[3:], ids_mtp[:3])=[4,99,6,7]  → EOS@[1]
+# ---------------------------------------------------------------------------
+
+
+class TestGenMtpLayerMaskDepth3(unittest.TestCase):
+    """Test with 3 packed sequences and mtp_depth=3."""
+
+    BATCH_3SEQ = [[1, 2, 99], [4, 99], [6, 7, 8]]
+    EOS_3SEQ = 99
+    MTP_DEPTH_3 = 3
+    MAX_SEQ_LEN_3 = 10
+
+    EXPECTED = np.array(
+        [
+            [1, 0, 1, 0, 1, 1, 1, 1, 1, 1],
+            [0, 1, 0, 1, 1, 1, 1, 1, 1, 1],
+            [1, 0, 1, 1, 1, 1, 1, 1, 1, 1],
+        ],
+        dtype=np.int32,
+    )
+
+    def test_full_output(self):
+        result = gen_mtp_layer_mask(
+            self.BATCH_3SEQ, self.MAX_SEQ_LEN_3, self.MTP_DEPTH_3, self.EOS_3SEQ
+        )
+        np.testing.assert_array_equal(result, self.EXPECTED)
+
+    def test_shape_and_dtype(self):
+        result = gen_mtp_layer_mask(
+            self.BATCH_3SEQ, self.MAX_SEQ_LEN_3, self.MTP_DEPTH_3, self.EOS_3SEQ
+        )
+        self.assertEqual(result.shape, (3, 10))
+        self.assertEqual(result.dtype, np.int32)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
1. Fix call site: pass token_ids instead of original_position_ids
2. Rewrite gen_mtp_layer_mask to align with reference get_mtp_inputs_info:
   - ids_input = all_token_ids[:-1]
   - Split into ids_ori and ids_mtp
   - Construct shifted input per MTP layer
   - Zero out EOS positions in shifted input
   - Pad to max_seq_len with ones
3. Add depth=3 test case with 3 packed sequences

<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
