### PR TITLE
[Benchmark] Add GLM-4.5-Air 128K PT config

### DIFF
--- a/tests/config/benchmark/config/pt/GLM4.5-Air_128k.yaml
+++ b/tests/config/benchmark/config/pt/GLM4.5-Air_128k.yaml
@@ -33,11 +33,11 @@ save_steps: 200
 save_strategy: steps
 logging_steps: 1
 global_batch_size: 256
-gradient_accumulation_steps: 16
+gradient_accumulation_steps: 32
 logging_dir: ./vdl_log
 output_dir: ./checkpoints/glm45-air-pt-128k
 disable_tqdm: true
-eval_accumulation_steps: 16
+eval_accumulation_steps: 1
 
 
 # parallel: 8 nodes x 8 GPU = 64 cards
@@ -57,6 +57,7 @@ router_aux_loss_coef: 1.0e-4
 # performance
 recompute_granularity: full
 recompute_method: uniform
+recompute_num_layers: 1
 
 learning_rate: 5.0e-5
 warmup_steps: 50
@@ -99,4 +100,3 @@ tensorwise_offload_optimizer: true
 skip_profile_timer: false
 load_via_cpu: false
 fp32_residual_connection: false
-

--- a/tests/config/benchmark/config/pt/GLM4.5-Air_128k.yaml
+++ b/tests/config/benchmark/config/pt/GLM4.5-Air_128k.yaml
@@ -100,4 +100,3 @@ skip_profile_timer: false
 load_via_cpu: false
 fp32_residual_connection: false
 
-pre_alloc_memory: 200

--- a/tests/config/benchmark/config/pt/GLM4.5-Air_128k.yaml
+++ b/tests/config/benchmark/config/pt/GLM4.5-Air_128k.yaml
@@ -32,21 +32,23 @@ evaluation_strategy: steps
 save_steps: 200
 save_strategy: steps
 logging_steps: 1
-gradient_accumulation_steps: 128
+global_batch_size: 256
+gradient_accumulation_steps: 16
 logging_dir: ./vdl_log
 output_dir: ./checkpoints/glm45-air-pt-128k
 disable_tqdm: true
 eval_accumulation_steps: 16
 
 
-# parallel
-tensor_model_parallel_size: 8
+# parallel: 8 nodes x 8 GPU = 64 cards
+# world = TP * PP * sharding_parallel_size = 1 * 1 * 64
+# EP=8 / CP=4 嵌在 sharding 维度内（参考 baseline 已验证拓扑）
+tensor_model_parallel_size: 1
 sequence_parallel: true
+context_parallel_size: 4
 use_expert_parallel: true
 expert_model_parallel_size: 8
-pipeline_model_parallel_size: 4
-num_empty_layers_add_in_head: 2 # [10, 12, 12, 12]
-num_empty_layers_add_in_tail: 0
+pipeline_model_parallel_size: 1
 
 weight_decay: 0.1
 adam_beta2: 0.95
@@ -55,7 +57,6 @@ router_aux_loss_coef: 1.0e-4
 # performance
 recompute_granularity: full
 recompute_method: uniform
-recompute_num_layers: 1
 
 learning_rate: 5.0e-5
 warmup_steps: 50
@@ -63,8 +64,16 @@ min_lr: 1.0e-5
 lr_scheduler_type: cosine
 
 moe_deep_gemm: true
+moe_shared_expert_overlap: true
+apply_rope_fusion: true
 moe_router_force_load_balancing: false
 
+
+# sharding
+sharding: stage1
+split_param: true
+stage1_overlap: false
+sd_release_grads: true
 
 # pp
 pp_delay_scale_loss: true
@@ -86,7 +95,9 @@ continue_training: true
 dataloader_num_workers: 32
 prefetch_factor: 24
 
-tensorwise_offload_optimizer: false
+tensorwise_offload_optimizer: true
 skip_profile_timer: false
 load_via_cpu: false
 fp32_residual_connection: false
+
+pre_alloc_memory: 200

--- a/tests/config/benchmark/config/pt/GLM4.5-Air_128k.yaml
+++ b/tests/config/benchmark/config/pt/GLM4.5-Air_128k.yaml
@@ -1,0 +1,92 @@
+train_dataset_type: messages
+eval_dataset_type: messages
+train_dataset_path: /root/efficient_benchmark/dataset/data_60to64k/LVEval_60to64k_messages.jsonl
+train_dataset_prob: "1.0"
+eval_dataset_path: /root/efficient_benchmark/dataset/data_60to64k/LVEval_60to64k_messages.jsonl
+eval_dataset_prob: "1.0"
+
+packing: true
+truncate_packing: false
+max_seq_len: 131072
+mix_strategy: concat
+
+random_shuffle: true
+dataloader_shuffle: false
+use_template: false
+
+model_name_or_path: /root/efficient_benchmark/huggingface/GLM-4.5-Air
+
+# base
+stage: PT
+fine_tuning: full
+seed: 23
+do_train: true
+do_eval: false
+per_device_eval_batch_size: 1
+per_device_train_batch_size: 1
+num_train_epochs: 1
+max_steps: 50
+eval_iters: 10000
+eval_steps: 10000
+evaluation_strategy: steps
+save_steps: 200
+save_strategy: steps
+logging_steps: 1
+gradient_accumulation_steps: 128
+logging_dir: ./vdl_log
+output_dir: ./checkpoints/glm45-air-pt-128k
+disable_tqdm: true
+eval_accumulation_steps: 16
+
+
+# parallel
+tensor_model_parallel_size: 8
+sequence_parallel: true
+use_expert_parallel: true
+expert_model_parallel_size: 8
+pipeline_model_parallel_size: 4
+num_empty_layers_add_in_head: 2 # [10, 12, 12, 12]
+num_empty_layers_add_in_tail: 0
+
+weight_decay: 0.1
+adam_beta2: 0.95
+router_aux_loss_coef: 1.0e-4
+
+# performance
+recompute_granularity: full
+recompute_method: uniform
+recompute_num_layers: 1
+
+learning_rate: 5.0e-5
+warmup_steps: 50
+min_lr: 1.0e-5
+lr_scheduler_type: cosine
+
+moe_deep_gemm: true
+moe_router_force_load_balancing: false
+
+
+# pp
+pp_delay_scale_loss: true
+overlap_p2p_comm: true
+variable_seq_lengths: true
+best_unbalanced_scheduler: true
+pp_release_grads: true
+
+amp_master_grad: true
+bf16: true
+fp16_opt_level: O2
+fa_version: 3
+
+save_checkpoint_format: flex_checkpoint
+load_checkpoint_format: flex_checkpoint
+save_to_hf: true
+continue_training: true
+
+dataloader_num_workers: 32
+prefetch_factor: 24
+
+tensorwise_offload_optimizer: false
+skip_profile_timer: false
+load_via_cpu: false
+fp32_residual_connection: false


### PR DESCRIPTION
Add benchmark config for GLM-4.5-Air (106B-A12B MoE, 46 layers) at 128K context length under PaddleFleet PT stage.

Parallelism: TP=8, PP=4, EP=8, DP=1 (32 cards)
PP layer distribution: [10, 12, 12, 12]
  (num_empty_layers_add_in_head=2, num_empty_layers_add_in_tail=0)
Sequence length: 131072
Global batch size: 128
Learning rate: 5.0e-5 with cosine decay
Router aux loss: 1.0e-4
Checkpoint format: flex_checkpoint

<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
