### PR TITLE
Add CI approval check for trainer config changes

### DIFF
--- a/.github/workflows/trainer-approval.yml
+++ b/.github/workflows/trainer-approval.yml
@@ -1,0 +1,63 @@
+name: Check Trainer Config Need Approval
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'paddleformers/trainer/training_args.py'
+      - 'paddleformers/cli/hparams/**'
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  check-review:
+    runs-on: 'ernie-cpu'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if target files changed
+        id: check_diff
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          if git diff origin/${{ github.base_ref }} --name-only | grep -qE '^paddleformers/trainer/training_args\.py$|^paddleformers/cli/hparams/'; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Skip if target files not changed
+        if: steps.check_diff.outputs.changed == 'false'
+        run: |
+          echo "Target files not changed, skip approval check"
+
+      - name: Check required reviewer approval
+        if: steps.check_diff.outputs.changed == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const required = ["From00"];
+
+            const { data: reviews } = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+
+            const approved = new Set();
+            for (const r of reviews) {
+              if (required.includes(r.user.login) && r.state === "APPROVED") {
+                approved.add(r.user.login);
+              }
+            }
+
+            if (approved.size === 0) {
+              core.setFailed(
+                `paddleformers/trainer/training_args.py or paddleformers/cli/hparams/** changed: need approval from From00`
+              );
+            } else {
+              core.info(`Approved by: ${Array.from(approved).join(", ")}`);
+            }


### PR DESCRIPTION
## Changes

Add CI workflow requiring **From00** to review and approve PRs that modify:
- `paddleformers/trainer/training_args.py`
- `paddleformers/cli/hparams/**`

If From00 has not approved, the CI check will fail and block the PR merge.

Pattern follows existing `requirements-review.yml` workflow.