### PR TITLE
Add approval CI pipeline for paddleformers

### DIFF
--- a/.github/workflows/Approval.yml
+++ b/.github/workflows/Approval.yml
@@ -16,8 +16,12 @@ jobs:
     runs-on:
       group: APPROVAL
     steps:
+      - name: Cleanup
+        run: |
+          rm -rf * .[^.]*
+
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 200
 

--- a/.github/workflows/Approval.yml
+++ b/.github/workflows/Approval.yml
@@ -13,7 +13,8 @@ env:
 jobs:
   check-approvers:
     name: Check approval
-    runs-on: 'ernie-cpu'
+    runs-on:
+      group: APPROVAL
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/Approval.yml
+++ b/.github/workflows/Approval.yml
@@ -1,0 +1,32 @@
+name: Approval
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+env:
+  BRANCH: ${{ github.base_ref }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  PR_ID: ${{ github.event.pull_request.number }}
+  COMMIT_ID: ${{ github.event.pull_request.head.sha }}
+
+jobs:
+  check-approvers:
+    name: Check approval
+    runs-on: 'ernie-cpu'
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 200
+
+      - name: Merge PR to test branch
+        run: |
+          git fetch origin pull/${PR_ID}/merge
+          git checkout -b test FETCH_HEAD
+
+      - name: Display Required Approvers
+        run: |
+          git remote add upstream https://github.com/PaddlePaddle/PaddleFormers.git
+          git fetch upstream $BRANCH
+          bash ci/check_approval.sh

--- a/ci/check_approval.sh
+++ b/ci/check_approval.sh
@@ -1,0 +1,70 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ -z "${BRANCH:-}" ]; then
+    BRANCH="develop"
+fi
+
+PADDLE_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}")/../" && pwd )"
+
+UPSTREAM_BRANCH="upstream/${BRANCH}"
+if ! DIFF_BASE=$(git merge-base HEAD "${UPSTREAM_BRANCH}"); then
+    echo "Unable to find merge base between HEAD and ${UPSTREAM_BRANCH}." >&2
+    exit 1
+fi
+
+approval_line=$(curl -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/PaddlePaddle/PaddleFormers/pulls/${PR_ID}/reviews?per_page=10000")
+failed_num=1
+echo_list=()
+
+
+function check_approval(){
+    APPROVALS=$(echo "${approval_line}" | python "${PADDLE_ROOT}/ci/check_pr_approval.py" "$@")
+    if [[ "${APPROVALS}" == "FALSE" && "${echo_line}" != "" ]]; then
+        add_failed "${failed_num}. ${echo_line}"
+    fi
+}
+
+
+function add_failed(){
+    failed_num=`expr $failed_num + 1`
+    echo_list="${echo_list[@]}$1"
+}
+
+
+PADDLEFORMERS_TRAINER_APPROVERS="From00"
+PADDLEFORMERS_TRAINER_FILES=(
+    "paddleformers/trainer/training_args.py"
+    "paddleformers/cli/hparams/"
+)
+for FILE in "${PADDLEFORMERS_TRAINER_FILES[@]}"; do
+    HAS_MODIFIED=$(git diff --name-only "${DIFF_BASE}" HEAD -- | grep "^${FILE}" || true)
+    if [ "${HAS_MODIFIED}" != "" ] && [ "${PR_ID}" != "" ]; then
+        echo_line="You must be approved by From00 for changes in ${FILE}.\n"
+        APPROVER_LIST=(${PADDLEFORMERS_TRAINER_APPROVERS})
+        check_approval 1 "${APPROVER_LIST[@]}"
+    fi
+done
+
+
+if [ -n "${echo_list}" ];then
+  echo "****************"
+  echo -e "${echo_list[@]}"
+  echo "There are `expr $failed_num - 1` approved errors."
+  echo "****************"
+fi
+
+if [ -n "${echo_list}" ]; then
+  exit 6
+fi

--- a/ci/check_pr_approval.py
+++ b/ci/check_pr_approval.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import sys
+
+
+def check_approval(count, required_reviewers):
+    json_buff = ""
+    for line in sys.stdin:
+        json_buff = "".join([json_buff, line])
+    json_resp = json.loads(json_buff)
+    approves = 0
+    approved_user_ids = []
+    approved_user_logins = set()
+    for review in json_resp:
+        if review["state"] == "APPROVED":
+            approves += 1
+            approved_user_ids.append(review["user"]["id"])
+            approved_user_logins.add(review["user"]["login"])
+
+    # convert to int
+    required_reviewers_int = set()
+    required_reviewers_login = set()
+    for rr in required_reviewers:
+        if rr.isdigit():
+            required_reviewers_int.add(int(rr))
+        else:
+            required_reviewers_login.add(rr)
+
+    if (
+        len(set(approved_user_ids) & required_reviewers_int) + len(approved_user_logins & required_reviewers_login)
+        >= count
+    ):
+        print("TRUE")
+    else:
+        print("FALSE")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1].isdigit():
+        check_approval(int(sys.argv[1]), sys.argv[2:])
+    else:
+        print("Usage: python check_pr_approval.py [count] [required reviewer id] ...")

--- a/paddleformers/trainer/training_args.py
+++ b/paddleformers/trainer/training_args.py
@@ -15,7 +15,6 @@
 
 # This file is modified from
 #  https://github.com/huggingface/transformers/blob/main/src/transformers/training_args.py
-# test approval ci
 
 import contextlib
 import json

--- a/paddleformers/trainer/training_args.py
+++ b/paddleformers/trainer/training_args.py
@@ -15,6 +15,7 @@
 
 # This file is modified from
 #  https://github.com/huggingface/transformers/blob/main/src/transformers/training_args.py
+# test approval ci
 
 import contextlib
 import json


### PR DESCRIPTION
## Changes

Replicate PaddleFleet's approval check infrastructure to PaddleFormers:

- `ci/check_pr_approval.py`: Parse PR reviews and check if required approvers have approved
- `ci/check_approval.sh`: Approval check logic, currently requires **From00** approval for changes to:
  - `paddleformers/trainer/training_args.py`
  - `paddleformers/cli/hparams/**`
- `.github/workflows/Approval.yml`: Workflow trigger on PR events

## How it works

1. When a PR is opened/updated, the workflow checks which files are modified
2. If the modified files match protected paths, it verifies that the required reviewer has approved
3. If not approved, CI fails with a clear message indicating who needs to approve