### PR TITLE
test: verify approval CI for training_args

### DIFF
--- a/paddleformers/trainer/training_args.py
+++ b/paddleformers/trainer/training_args.py
@@ -15,6 +15,7 @@
 
 # This file is modified from
 #  https://github.com/huggingface/transformers/blob/main/src/transformers/training_args.py
+# test approval ci check
 
 import contextlib
 import json


### PR DESCRIPTION
Test PR to verify the approval CI pipeline blocks when modifying `paddleformers/trainer/training_args.py` without From00 approval.