### PR TITLE
test: verify approval CI passes for non-protected files

### DIFF
--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -15,6 +15,7 @@
 
 # This file is modified from
 #  https://github.com/huggingface/transformers/blob/main/src/transformers/trainer.py
+# test approval ci - this file is not protected
 from __future__ import annotations
 
 import collections


### PR DESCRIPTION
Test PR modifying `paddleformers/trainer/trainer.py` (not a protected file). Approval CI should pass without From00 approval.