### PR TITLE
Add MiMo-VL conversion validation utilities

### DIFF
--- a/tests/integration_test/convert_mimo_vl_to_paddle.py
+++ b/tests/integration_test/convert_mimo_vl_to_paddle.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Convert MiMo-VL (HF/PyTorch checkpoint) into Paddle checkpoint.
+
+Example:
+  python tests/integration_test/convert_mimo_vl_to_paddle.py \
+    --source-dir /path/to/MiMo-VL-7B-SFT \
+    --output-dir /path/to/MiMo-VL-7B-SFT-paddle
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import shutil
+import sys
+import time
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Convert HF MiMo-VL/Qwen2.5-VL weights to Paddle format.")
+    parser.add_argument("--source-dir", required=True, help="HF checkpoint directory (contains config.json + *.safetensors)")
+    parser.add_argument("--output-dir", default=None, help="Output Paddle checkpoint directory")
+    parser.add_argument(
+        "--paddleformers-root",
+        default=None,
+        help="Path to local PaddleFormers repo. Defaults to this repository root.",
+    )
+    parser.add_argument(
+        "--dtype",
+        default="bfloat16",
+        choices=["auto", "float16", "bfloat16", "float32"],
+        help="Load dtype for conversion",
+    )
+    parser.add_argument("--max-shard-size", default="5GB", help="Max shard size for saving safetensors")
+    parser.add_argument("--low-cpu-mem-usage", action="store_true", help="Enable low CPU memory loading")
+    parser.add_argument(
+        "--load-checkpoint-format",
+        default="legacy",
+        choices=["legacy", "flex_checkpoint"],
+        help="Checkpoint loading backend in PaddleFormers. Use legacy to avoid FlexCheckpoint OOM in conversion.",
+    )
+    parser.add_argument(
+        "--load-via-cpu",
+        action="store_true",
+        help="Offload checkpoint loading to CPU when backend supports it (effective for flex_checkpoint).",
+    )
+    parser.add_argument(
+        "--device",
+        default="gpu",
+        choices=["cpu", "gpu"],
+        help="Device to initialize/load model on during conversion.",
+    )
+    parser.add_argument("--no-safe-serialization", action="store_true", help="Save as .pdparams instead of safetensors")
+    parser.add_argument(
+        "--save-to-hf-format",
+        action="store_true",
+        help="Save checkpoint in HF-compatible tensor orientation (transpose-selected). Default saves Paddle-native orientation.",
+    )
+    parser.add_argument("--no-copy-aux-files", action="store_true", help="Do not copy tokenizer/processor files")
+    parser.add_argument("--verify-paddle-load", action="store_true", help="Load converted model once for smoke check")
+    parser.add_argument("--overwrite", action="store_true", help="Overwrite output directory if it already exists")
+    return parser.parse_args()
+
+
+def add_local_paddleformers(paddleformers_root: Path) -> None:
+    if paddleformers_root.exists() and str(paddleformers_root) not in sys.path:
+        sys.path.insert(0, str(paddleformers_root))
+
+
+def default_repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def resolve_output_dir(source_dir: Path, output_dir: str | None) -> Path:
+    if output_dir is not None:
+        return Path(output_dir).resolve()
+    return source_dir.parent / f"{source_dir.name}-paddle"
+
+
+def prepare_output_dir(output_dir: Path, overwrite: bool) -> None:
+    if output_dir.exists():
+        if not overwrite:
+            raise FileExistsError(f"Output directory already exists: {output_dir}. Use --overwrite to replace it.")
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+
+def copy_auxiliary_files(source_dir: Path, output_dir: Path) -> list[str]:
+    """Copy tokenizer/processor metadata files that model.save_pretrained does not always include."""
+    candidates = [
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "vocab.json",
+        "merges.txt",
+        "added_tokens.json",
+        "special_tokens_map.json",
+        "chat_template.json",
+        "preprocessor_config.json",
+        "generation_config.json",
+        "README.md",
+    ]
+    copied = []
+    for name in candidates:
+        src = source_dir / name
+        dst = output_dir / name
+        if src.exists() and not dst.exists():
+            shutil.copy2(src, dst)
+            copied.append(name)
+    return copied
+
+
+def write_paddle_configuration_json(output_dir: Path) -> None:
+    meta_path = output_dir / "configuration.json"
+    meta = {
+        "framework": "paddle",
+        "task": "text-generation",
+        "allow_remote": True,
+    }
+    with meta_path.open("w", encoding="utf-8") as f:
+        json.dump(meta, f, ensure_ascii=False)
+
+
+def detect_output_checkpoint_style(output_dir: Path) -> str:
+    """
+    Detect key style of saved checkpoint.
+    Returns:
+        "hf_keys"      -> keys like model.layers.*, visual.blocks.*
+        "paddle_keys"  -> keys like model.language_model.*, model.visual.*
+        "unknown"      -> cannot decide
+    """
+    index_path = output_dir / "model.safetensors.index.json"
+    if not index_path.exists():
+        return "unknown"
+    try:
+        with index_path.open("r", encoding="utf-8") as f:
+            index_data = json.load(f)
+        weight_map = index_data.get("weight_map", {})
+        keys = list(weight_map.keys())
+        if not keys:
+            return "unknown"
+        sample_keys = keys[: min(200, len(keys))]
+        has_hf_keys = any(k.startswith("model.layers.") or k.startswith("visual.blocks.") for k in sample_keys)
+        has_paddle_keys = any(k.startswith("model.language_model.") or k.startswith("model.visual.") for k in sample_keys)
+        if has_hf_keys and not has_paddle_keys:
+            return "hf_keys"
+        if has_paddle_keys and not has_hf_keys:
+            return "paddle_keys"
+    except Exception:
+        return "unknown"
+    return "unknown"
+
+
+def convert_model(args: argparse.Namespace) -> None:
+    source_dir = Path(args.source_dir).resolve()
+    if not source_dir.exists():
+        raise FileNotFoundError(f"Source directory does not exist: {source_dir}")
+    if not (source_dir / "config.json").exists():
+        raise FileNotFoundError(f"Missing config.json in source directory: {source_dir}")
+
+    output_dir = resolve_output_dir(source_dir, args.output_dir)
+    prepare_output_dir(output_dir, args.overwrite)
+
+    paddleformers_root = Path(args.paddleformers_root).resolve() if args.paddleformers_root else default_repo_root()
+    add_local_paddleformers(paddleformers_root)
+
+    import paddle
+    from paddleformers.transformers import Qwen2_5_VLForConditionalGeneration
+
+    if args.device == "cpu":
+        paddle.set_device("cpu")
+    else:
+        paddle.set_device("gpu")
+
+    load_kwargs = {
+        "convert_from_hf": True,
+        "use_safetensors": True,
+        "low_cpu_mem_usage": bool(args.low_cpu_mem_usage),
+        "load_checkpoint_format": args.load_checkpoint_format,
+        "load_via_cpu": bool(args.load_via_cpu),
+    }
+    if args.dtype != "auto":
+        load_kwargs["dtype"] = args.dtype
+
+    print("[1/4] Loading HF checkpoint and converting to Paddle tensors ...")
+    print(f"       source={source_dir}")
+    t0 = time.time()
+    model = Qwen2_5_VLForConditionalGeneration.from_pretrained(str(source_dir), **load_kwargs)
+    t1 = time.time()
+    print(f"       done in {t1 - t0:.1f}s")
+
+    print("[2/4] Saving Paddle checkpoint ...")
+    save_kwargs = {
+        "safe_serialization": not args.no_safe_serialization,
+        "max_shard_size": args.max_shard_size,
+        "save_to_hf": bool(args.save_to_hf_format),
+    }
+    model.save_pretrained(str(output_dir), **save_kwargs)
+    t2 = time.time()
+    print(f"       saved to {output_dir}")
+    print(f"       done in {t2 - t1:.1f}s")
+
+    print("[3/4] Writing Paddle metadata and copying auxiliary files ...")
+    write_paddle_configuration_json(output_dir)
+    copied = []
+    if not args.no_copy_aux_files:
+        copied = copy_auxiliary_files(source_dir, output_dir)
+    print(f"       copied_aux_files={copied if copied else '[]'}")
+
+    if args.verify_paddle_load:
+        # Release memory from the first loaded model before verify load.
+        del model
+        gc.collect()
+        if paddle.device.is_compiled_with_cuda():
+            paddle.device.cuda.empty_cache()
+
+        print("[4/4] Verifying converted Paddle checkpoint can be loaded ...")
+        ckpt_style = detect_output_checkpoint_style(output_dir)
+        # VLM save_pretrained in PaddleFormers commonly writes HF-style keys.
+        if ckpt_style == "hf_keys":
+            verify_convert_from_hf = True
+        elif ckpt_style == "paddle_keys":
+            verify_convert_from_hf = False
+        else:
+            verify_convert_from_hf = bool(args.save_to_hf_format)
+        print(f"       detected_checkpoint_style={ckpt_style}, verify_convert_from_hf={verify_convert_from_hf}")
+
+        verify_kwargs = {
+            "convert_from_hf": verify_convert_from_hf,
+            "use_safetensors": not args.no_safe_serialization,
+            "low_cpu_mem_usage": bool(args.low_cpu_mem_usage),
+            "load_checkpoint_format": args.load_checkpoint_format,
+            "load_via_cpu": bool(args.load_via_cpu),
+        }
+        if args.dtype != "auto":
+            verify_kwargs["dtype"] = args.dtype
+        _ = Qwen2_5_VLForConditionalGeneration.from_pretrained(str(output_dir), **verify_kwargs)
+        print("       verify_load=PASS")
+    else:
+        print("[4/4] Skipped verify load (use --verify-paddle-load to enable)")
+
+    print("\nConversion finished successfully.")
+    print(f"Output: {output_dir}")
+
+
+def main() -> None:
+    args = parse_args()
+    convert_model(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration_test/mimo_vl_conversion_report.md
+++ b/tests/integration_test/mimo_vl_conversion_report.md
@@ -1,0 +1,105 @@
+# MiMo-VL-7B-SFT Conversion Report
+
+## 1. Purpose
+
+This report records the MiMo-VL-7B-SFT checkpoint migration from HuggingFace safetensors to a Paddle-compatible checkpoint.
+
+MiMo-VL-7B-SFT does not introduce a new PaddleFormers model implementation. The checkpoint follows the Qwen2.5-VL architecture and can be loaded by the existing `Qwen2_5_VLForConditionalGeneration` implementation.
+
+Therefore, this migration focuses on checkpoint conversion and validation instead of adding a new `paddleformers/transformers/mimo_vl` modeling directory.
+
+## 2. Conversion Command
+
+```bash
+python tests/integration_test/convert_mimo_vl_to_paddle.py \
+  --source-dir /path/to/MiMo-VL-7B-SFT \
+  --output-dir /path/to/MiMo-VL-7B-SFT-paddle \
+  --dtype bfloat16 \
+  --load-checkpoint-format legacy \
+  --device cpu \
+  --verify-paddle-load \
+  --overwrite
+```
+
+Notes:
+
+- `convert_from_hf=True` is used internally when loading the original HuggingFace checkpoint.
+- `load_checkpoint_format="legacy"` is used for stable local loading.
+- Tokenizer, processor, generation config, and auxiliary metadata files are copied to the output directory.
+
+## 3. Converted Checkpoint Loading
+
+The converted checkpoint is loaded with:
+
+```python
+from paddleformers.transformers import Qwen2_5_VLForConditionalGeneration
+
+model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
+    "/path/to/MiMo-VL-7B-SFT-paddle",
+    convert_from_hf=True,
+    use_safetensors=True,
+    load_checkpoint_format="legacy",
+    low_cpu_mem_usage=True,
+    dtype="bfloat16",
+)
+```
+
+`convert_from_hf=True` is required because the saved safetensors checkpoint uses HF-style key names.
+
+## 4. Load Validation
+
+Result:
+
+```text
+All model checkpoint weights were used when initializing Qwen2_5_VLForConditionalGeneration.
+verify_load_pass
+```
+
+## 5. Text-Only Smoke Inference
+
+Result:
+
+```text
+smoke_pass=True
+gen_time_sec=1.682
+```
+
+## 6. HF vs Paddle Logits Consistency
+
+The same text input was tokenized once and fed to both the original HuggingFace checkpoint and the converted Paddle checkpoint.
+
+Command:
+
+```bash
+CUDA_VISIBLE_DEVICES=7 LOAD_STATE_DICT_THREAD_NUM=8 \
+python tests/integration_test/verify_mimo_vl_hf_vs_paddle.py \
+  --hf-dir /path/to/MiMo-VL-7B-SFT \
+  --paddle-dir /path/to/MiMo-VL-7B-SFT-paddle \
+  --device gpu \
+  --hf-dtype bfloat16 \
+  --paddle-dtype bfloat16 \
+  --paddle-load-checkpoint-format legacy \
+  --low-cpu-mem-usage \
+  --strict
+```
+
+Result:
+
+```json
+{
+  "shape": [1, 8, 151680],
+  "max_abs_diff": 0.0005908012390136719,
+  "mean_abs_diff": 2.8572936571436003e-05,
+  "p99_abs_diff": 0.000240325927734375,
+  "allclose": true,
+  "atol": 0.001,
+  "rtol": 0.001,
+  "hf_top1_token_id": 56177,
+  "paddle_top1_token_id": 56177,
+  "top1_match": true
+}
+```
+
+## 7. Conclusion
+
+MiMo-VL-7B-SFT is supported as a Qwen2.5-VL checkpoint variant. The converted Paddle checkpoint can be loaded by the existing `Qwen2_5_VLForConditionalGeneration` implementation, passes text-only smoke inference, and is numerically aligned with the original HuggingFace checkpoint under `atol=1e-3, rtol=1e-3`.

--- a/tests/integration_test/verify_mimo_vl_hf_vs_paddle.py
+++ b/tests/integration_test/verify_mimo_vl_hf_vs_paddle.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Compare HF and Paddle forward logits for MiMo-VL/Qwen2.5-VL (text-only).
+
+This script uses the same tokenized text input for both models and compares logits.
+
+Example:
+  python tests/integration_test/verify_mimo_vl_hf_vs_paddle.py \
+    --hf-dir /path/to/MiMo-VL-7B-SFT \
+    --paddle-dir /path/to/MiMo-VL-7B-SFT-paddle
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Verify HF vs Paddle logits consistency (text-only).")
+    parser.add_argument("--hf-dir", required=True, help="HF checkpoint directory")
+    parser.add_argument("--paddle-dir", required=True, help="Converted Paddle checkpoint directory")
+    parser.add_argument(
+        "--paddleformers-root",
+        default=None,
+        help="Path to local PaddleFormers repo. Defaults to this repository root.",
+    )
+    parser.add_argument("--prompt", default="Please briefly introduce yourself in one sentence.", help="Input prompt")
+    parser.add_argument("--max-length", type=int, default=64, help="Max token length for verification input")
+    parser.add_argument(
+        "--hf-dtype",
+        default="float32",
+        choices=["float16", "bfloat16", "float32"],
+        help="HF model load dtype",
+    )
+    parser.add_argument(
+        "--paddle-dtype",
+        default="float32",
+        choices=["auto", "float16", "bfloat16", "float32"],
+        help="Paddle model load dtype",
+    )
+    parser.add_argument(
+        "--paddle-convert-from-hf",
+        default="auto",
+        choices=["auto", "true", "false"],
+        help="Whether Paddle from_pretrained should treat checkpoint as HF-style keys",
+    )
+    parser.add_argument(
+        "--paddle-load-checkpoint-format",
+        default="legacy",
+        choices=["legacy", "flex_checkpoint"],
+        help="Paddle checkpoint loader backend",
+    )
+    parser.add_argument(
+        "--device",
+        default="gpu",
+        choices=["cpu", "gpu"],
+        help="Run forward on cpu or gpu",
+    )
+    parser.add_argument("--atol", type=float, default=1e-3, help="Absolute tolerance for np.allclose")
+    parser.add_argument("--rtol", type=float, default=1e-3, help="Relative tolerance for np.allclose")
+    parser.add_argument("--low-cpu-mem-usage", action="store_true", help="Enable low CPU memory loading for Paddle")
+    parser.add_argument("--strict", action="store_true", help="Exit with non-zero code if allclose is False")
+    return parser.parse_args()
+
+
+def add_local_paddleformers(paddleformers_root: Path) -> None:
+    if paddleformers_root.exists() and str(paddleformers_root) not in sys.path:
+        sys.path.insert(0, str(paddleformers_root))
+
+
+def default_repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def detect_output_checkpoint_style(model_dir: Path) -> str:
+    """
+    Returns:
+        hf_keys: keys like model.layers.*, visual.blocks.*
+        paddle_keys: keys like model.language_model.*, model.visual.*
+        unknown: cannot determine
+    """
+    index_path = model_dir / "model.safetensors.index.json"
+    if not index_path.exists():
+        return "unknown"
+    try:
+        with index_path.open("r", encoding="utf-8") as f:
+            index_data = json.load(f)
+        keys = list(index_data.get("weight_map", {}).keys())
+        if not keys:
+            return "unknown"
+        sample = keys[: min(200, len(keys))]
+        has_hf = any(k.startswith("model.layers.") or k.startswith("visual.blocks.") for k in sample)
+        has_pd = any(k.startswith("model.language_model.") or k.startswith("model.visual.") for k in sample)
+        if has_hf and not has_pd:
+            return "hf_keys"
+        if has_pd and not has_hf:
+            return "paddle_keys"
+    except Exception:
+        return "unknown"
+    return "unknown"
+
+
+def load_hf_logits(args: argparse.Namespace, input_ids_np: np.ndarray, attention_mask_np: np.ndarray) -> np.ndarray:
+    import torch
+    import importlib.metadata as importlib_metadata
+
+    # Some transformers versions unconditionally query torchcodec metadata when importing model classes.
+    # If torchcodec is absent, patch version lookup to avoid import failure for text-only verification.
+    _orig_version = importlib_metadata.version
+
+    def _safe_version(name: str) -> str:
+        if name == "torchcodec":
+            try:
+                return _orig_version(name)
+            except importlib_metadata.PackageNotFoundError:
+                return "0.0.0"
+        return _orig_version(name)
+
+    importlib_metadata.version = _safe_version
+    from transformers import Qwen2_5_VLForConditionalGeneration
+
+    hf_dtype_map = {
+        "float16": torch.float16,
+        "bfloat16": torch.bfloat16,
+        "float32": torch.float32,
+    }
+    hf_dtype = hf_dtype_map[args.hf_dtype]
+
+    print("[HF] Loading model ...")
+    t0 = time.time()
+    model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
+        str(args.hf_dir),
+        torch_dtype=hf_dtype,
+    )
+    model.eval()
+    if args.device == "gpu" and torch.cuda.is_available():
+        model = model.to("cuda:0")
+        device = "cuda:0"
+    else:
+        device = "cpu"
+    t1 = time.time()
+    print(f"[HF] Loaded in {t1 - t0:.1f}s")
+
+    input_ids_t = torch.from_numpy(input_ids_np).to(device)
+    attention_mask_t = torch.from_numpy(attention_mask_np).to(device)
+
+    with torch.no_grad():
+        outputs = model(input_ids=input_ids_t, attention_mask=attention_mask_t, return_dict=True)
+        logits = outputs.logits.float().cpu().numpy()
+    return logits
+
+
+def load_paddle_logits(args: argparse.Namespace, input_ids_np: np.ndarray, attention_mask_np: np.ndarray) -> np.ndarray:
+    import paddle
+    from paddleformers.transformers import Qwen2_5_VLForConditionalGeneration
+
+    if args.device == "gpu":
+        paddle.set_device("gpu:0")
+    else:
+        paddle.set_device("cpu")
+
+    if args.paddle_convert_from_hf == "auto":
+        style = detect_output_checkpoint_style(Path(args.paddle_dir))
+        convert_from_hf = style == "hf_keys"
+        print(f"[Paddle] detected_checkpoint_style={style}, convert_from_hf={convert_from_hf}")
+    else:
+        convert_from_hf = args.paddle_convert_from_hf == "true"
+
+    load_kwargs = {
+        "convert_from_hf": convert_from_hf,
+        "use_safetensors": True,
+        "low_cpu_mem_usage": bool(args.low_cpu_mem_usage),
+        "load_checkpoint_format": args.paddle_load_checkpoint_format,
+    }
+    if args.paddle_dtype != "auto":
+        load_kwargs["dtype"] = args.paddle_dtype
+
+    print("[Paddle] Loading model ...")
+    t0 = time.time()
+    model = Qwen2_5_VLForConditionalGeneration.from_pretrained(str(args.paddle_dir), **load_kwargs)
+    model.eval()
+    t1 = time.time()
+    print(f"[Paddle] Loaded in {t1 - t0:.1f}s")
+
+    input_ids_t = paddle.to_tensor(input_ids_np, dtype="int64")
+    attention_mask_t = paddle.to_tensor(attention_mask_np, dtype="int64")
+
+    with paddle.no_grad():
+        outputs = model(input_ids=input_ids_t, attention_mask=attention_mask_t, return_dict=True)
+        logits = outputs.logits.astype("float32").numpy()
+    return logits
+
+
+def summarize_diff(hf_logits: np.ndarray, pd_logits: np.ndarray, attention_mask_np: np.ndarray, atol: float, rtol: float) -> dict:
+    if hf_logits.shape != pd_logits.shape:
+        raise ValueError(f"Shape mismatch: hf={hf_logits.shape}, paddle={pd_logits.shape}")
+
+    diff = np.abs(hf_logits - pd_logits)
+    max_abs_diff = float(diff.max())
+    mean_abs_diff = float(diff.mean())
+    p99_abs_diff = float(np.quantile(diff, 0.99))
+    allclose = bool(np.allclose(hf_logits, pd_logits, atol=atol, rtol=rtol))
+
+    last_idx = int(attention_mask_np[0].sum() - 1)
+    hf_top1 = int(np.argmax(hf_logits[0, last_idx]))
+    pd_top1 = int(np.argmax(pd_logits[0, last_idx]))
+
+    return {
+        "shape": list(hf_logits.shape),
+        "max_abs_diff": max_abs_diff,
+        "mean_abs_diff": mean_abs_diff,
+        "p99_abs_diff": p99_abs_diff,
+        "allclose": allclose,
+        "atol": atol,
+        "rtol": rtol,
+        "last_token_index": last_idx,
+        "hf_top1_token_id": hf_top1,
+        "paddle_top1_token_id": pd_top1,
+        "top1_match": hf_top1 == pd_top1,
+    }
+
+
+def main() -> None:
+    args = parse_args()
+    hf_dir = Path(args.hf_dir).resolve()
+    paddle_dir = Path(args.paddle_dir).resolve()
+    paddleformers_root = Path(args.paddleformers_root).resolve() if args.paddleformers_root else default_repo_root()
+    add_local_paddleformers(paddleformers_root)
+
+    if not hf_dir.exists():
+        raise FileNotFoundError(f"HF directory not found: {hf_dir}")
+    if not paddle_dir.exists():
+        raise FileNotFoundError(f"Paddle directory not found: {paddle_dir}")
+
+    print("[Tokenizer] Loading HF tokenizer ...")
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(str(hf_dir), use_fast=False)
+    batch = tokenizer(
+        args.prompt,
+        return_tensors="np",
+        max_length=args.max_length,
+        truncation=True,
+    )
+
+    input_ids_np = batch["input_ids"].astype("int64")
+    attention_mask_np = batch["attention_mask"].astype("int64")
+
+    hf_logits = load_hf_logits(args, input_ids_np, attention_mask_np)
+    pd_logits = load_paddle_logits(args, input_ids_np, attention_mask_np)
+
+    summary = summarize_diff(
+        hf_logits=hf_logits,
+        pd_logits=pd_logits,
+        attention_mask_np=attention_mask_np,
+        atol=args.atol,
+        rtol=args.rtol,
+    )
+
+    print("\n===== Verification Summary =====")
+    print(json.dumps(summary, indent=2, ensure_ascii=False))
+
+    if args.strict and not summary["allclose"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

## PR Type

Model checkpoint adaptation / conversion support.

## Description

This PR adds conversion and validation utilities for `MiMo-VL-7B-SFT`.

`MiMo-VL-7B-SFT` does not introduce a new model architecture in PaddleFormers. Its checkpoint follows the Qwen2.5-VL architecture and can be loaded by the existing `Qwen2_5_VLForConditionalGeneration` implementation. Therefore this PR does not add a new `paddleformers/transformers/mimo_vl` modeling directory.

Instead, this PR focuses on:

- Converting the HuggingFace safetensors checkpoint to a Paddle-compatible checkpoint.
- Verifying that the converted Paddle checkpoint can be loaded by `Qwen2_5_VLForConditionalGeneration`.
- Comparing text-only logits between the original HF checkpoint and the converted Paddle checkpoint.
- Providing usage notes for publishing the converted checkpoint to the Paddle model hub.

## Why No New Model Files Are Added

MiMo-VL reuses the Qwen2.5-VL model structure. Duplicating the Qwen2.5-VL implementation under a separate `mimo_vl` module would add maintenance cost without introducing new model behavior.

The converted checkpoint should be loaded through:

```python
from paddleformers.transformers import Qwen2_5_VLForConditionalGeneration

model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
    "<mimo-vl-paddle-checkpoint>",
    convert_from_hf=True,
    use_safetensors=True,
    load_checkpoint_format="legacy",
    dtype="bfloat16",
)
```

## Validation

### 1. Paddle Checkpoint Load

Command:

```bash
CUDA_VISIBLE_DEVICES=7 LOAD_STATE_DICT_THREAD_NUM=8 python - <<'PY'
import sys, paddle
paddle.set_device("gpu:0")
sys.path.insert(0, "/path/to/PaddleFormers")
from paddleformers.transformers import Qwen2_5_VLForConditionalGeneration

Qwen2_5_VLForConditionalGeneration.from_pretrained(
    "<mimo-vl-paddle-checkpoint>",
    convert_from_hf=True,
    use_safetensors=True,
    load_checkpoint_format="legacy",
    low_cpu_mem_usage=True,
    dtype="bfloat16",
)
print("verify_load_pass")
PY
```

Result:

```text
All model checkpoint weights were used when initializing Qwen2_5_VLForConditionalGeneration.
verify_load_pass
```

### 2. Text-Only Smoke Inference

Result:

```text
smoke_pass=True
gen_time_sec=1.682
```

### 3. HF vs Paddle Logits Consistency

The same text input was tokenized once and fed to both the original HF checkpoint and the converted Paddle checkpoint.

Result:

```json
{
  "shape": [1, 8, 151680],
  "max_abs_diff": 0.0005908012390136719,
  "mean_abs_diff": 2.8572936571436003e-05,
  "p99_abs_diff": 0.000240325927734375,
  "allclose": true,
  "atol": 0.001,
  "rtol": 0.001,
  "hf_top1_token_id": 56177,
  "paddle_top1_token_id": 56177,
  "top1_match": true
}
```

Conclusion:

The converted Paddle checkpoint is numerically aligned with the original HF checkpoint for text-only forward logits under `atol=1e-3, rtol=1e-3`.

## Notes

- The converted checkpoint is saved as safetensors.
- `load_checkpoint_format="legacy"` is used for stable local loading. The flex checkpoint path may trigger memory pressure or AOA-related loading issues for this checkpoint.
- The checkpoint keys are HF-style after saving, so `convert_from_hf=True` is required when loading the converted Paddle checkpoint.

## Checklist

- Add MiMo-VL conversion utility.
- Add HF vs Paddle logits verification utility.
- Verify converted Paddle checkpoint can be loaded.
- Run text-only smoke inference.
- Run HF vs Paddle logits consistency check.
- Upload converted checkpoint to Paddle model hub.


