### PR TITLE
Fix swanlab

### DIFF
--- a/paddleformers/trainer/integrations.py
+++ b/paddleformers/trainer/integrations.py
@@ -415,6 +415,7 @@ class SwanLabCallback(TrainerCallback):
 
         self._swanlab = swanlab
         self._initialized = False
+        self._disabled = False
         self._log_model = os.getenv("SWANLAB_LOG_MODEL", None)
 
     def setup(self, args, state, model, **kwargs):
@@ -449,7 +450,14 @@ class SwanLabCallback(TrainerCallback):
         - **SWANLAB_API_HOST** (`str`, *optional*, defaults to `None`):
             API address for the SwanLab cloud environment for private version (its free)
         """
+        # Check if SwanLab is disabled via environment variable
+        if os.getenv("SWANLAB_MODE", "").lower() == "disabled":
+            self._initialized = True
+            self._disabled = True
+            return
+
         self._initialized = True
+        self._disabled = False
 
         if state.is_world_process_zero:
             logger.info('Automatic SwanLab logging enabled, to disable set os.environ["SWANLAB_MODE"] = "disabled"')
@@ -510,6 +518,8 @@ class SwanLabCallback(TrainerCallback):
 
         if not self._initialized:
             self.setup(args, state, model)
+        if self._disabled:
+            return
         if state.is_world_process_zero:
             for k, v in logs.items():
                 if k in single_value_scalars:
@@ -528,6 +538,8 @@ class SwanLabCallback(TrainerCallback):
     def on_predict(self, args, state, control, metrics, **kwargs):
         if not self._initialized:
             self.setup(args, state, **kwargs)
+        if self._disabled:
+            return
         if state.is_world_process_zero:
             metrics = rewrite_logs(metrics)
             self._swanlab.log(metrics)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -22,7 +22,7 @@ pytest-timeout
 paddleocr
 pre-commit
 wandb
-swanlab==0.7.19
+swanlab
 tensorboard
 tensorboardX
 triton >= 3.1

--- a/tests/trainer/test_trainer_visualization.py
+++ b/tests/trainer/test_trainer_visualization.py
@@ -94,7 +94,9 @@ class TestSwanlabCallback(unittest.TestCase):
                 log = {"loss": 100 - 0.4 * global_step, "learning_rate": 0.1, "global_step": global_step}
                 swanlabcallback.on_log(args, state, control, logs=log)
         swanlabcallback.on_train_end(args, state, control, model=model)
-        swanlabcallback._swanlab.finish()
+        # In disabled mode, finish() should not be called as there is no active run
+        if not swanlabcallback._disabled:
+            swanlabcallback._swanlab.finish()
         os.environ.pop("SWANLAB_MODE", None)
         shutil.rmtree(output_dir)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
新版本 swanlab 升级后，当 SWANLAB_MODE=disabled 时：
swanlab.init() 不会创建活跃的 run，后续调用 swanlab.log() 和 swanlab.finish() 会抛出 RuntimeError: No active Run
1. paddleformers/trainer/integrations.py
在 __init__ 中添加 self._disabled = False 标志
在 setup() 中检查 SWANLAB_MODE=disabled，如果是则设置 self._disabled = True 并提前返回
在 on_log() 和 on_predict() 中检查 _disabled 标志，如果为 True 则跳过 swanlab 操作
2. tests/trainer/test_trainer_visualization.py
在测试中检查 _disabled 标志，只在非 disabled 模式下调用 swanlab.finish()

