### PR TITLE
Fix DSA indexer loss PP logging reduce

### DIFF
--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -2668,15 +2668,32 @@ class Trainer:
                     DSAIndexerLossLoggingHelper,
                 )
 
-                if DSAIndexerLossLoggingHelper.tracker.get("values") is not None:
-                    loss_scale = 1.0 / self.args.gradient_accumulation_steps
-                    DSAIndexerLossLoggingHelper.reduce_loss_in_tracker()
-                    tracker = DSAIndexerLossLoggingHelper.tracker
-                    indexer_loss_values = tracker["values"] * loss_scale
-                    num_layers = indexer_loss_values.shape[0]
-                    avg_indexer_loss = indexer_loss_values.sum() / num_layers
-                    logs["indexer_loss"] = avg_indexer_loss.item()
-                    DSAIndexerLossLoggingHelper.clean_loss_in_tracker()
+                config = getattr(self.model, "config", None)
+                num_layers = None
+                csa_compress_ratios = None
+                if config is not None:
+                    num_layers = config.num_hidden_layers + (
+                        getattr(config, "mtp_num_layers", 0) or getattr(config, "num_nextn_predict_layers", 0)
+                    )
+                    csa_compress_ratios = getattr(config, "csa_compress_ratios", None)
+                loss_scale = 1.0 / self.args.gradient_accumulation_steps
+                try:
+                    DSAIndexerLossLoggingHelper.track_indexer_metrics(
+                        loss_scale=loss_scale,
+                        iteration=self.state.global_step,
+                        total_loss_dict=logs,
+                        num_layers=num_layers,
+                        csa_compress_ratios=csa_compress_ratios,
+                    )
+                except TypeError:
+                    if DSAIndexerLossLoggingHelper.tracker.get("values") is not None:
+                        DSAIndexerLossLoggingHelper.track_indexer_metrics(
+                            loss_scale=loss_scale,
+                            iteration=self.state.global_step,
+                            total_loss_dict=logs,
+                        )
+                if "indexer loss" in logs:
+                    logs["indexer_loss"] = logs.pop("indexer loss").item()
             except (ImportError, AttributeError):
                 pass
 


### PR DESCRIPTION


<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Ensure all pipeline ranks enter indexer loss metric reduction by passing layer metadata to the PaddleFleet logging helper. Ranks without local indexer layers can then initialize zero trackers and participate in the PP all-reduce, avoiding hangs in hybrid attention layouts.