### PR TITLE
[Feat] Add `cp_balance_mode`  for different CP scatter/gather behavior

### DIFF
--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -2068,7 +2068,10 @@ class Trainer:
                 and isinstance(self.model, FleetGPTModel)
                 and get_batch_on_this_cp_rank is not None
             ):
-                inputs = get_batch_on_this_cp_rank(inputs)
+                inputs = get_batch_on_this_cp_rank(
+                    inputs,
+                    cp_balance_mode=getattr(self.args, "cp_balance_mode", "dualchunk_allgather"),
+                )
 
             if self.args.ignore_data_skip:
                 self.timers and self.timers("read-data").stop()

--- a/paddleformers/trainer/training_args.py
+++ b/paddleformers/trainer/training_args.py
@@ -793,6 +793,10 @@ class TrainingArguments:
             )
         },
     )
+    cp_balance_mode: str = field(
+        default="dualchunk_allgather",
+        metadata={"help": "CP scatter/gather layout mode: 'dualchunk_allgather' or 'contiguous_allgather'."},
+    )
     expert_model_parallel_size: int = field(
         default=-1,
         metadata={"help": ("The paddle expert data parallel strategy.")},

--- a/paddleformers/transformers/configuration_utils.py
+++ b/paddleformers/transformers/configuration_utils.py
@@ -248,6 +248,7 @@ class LlmMetaConfig:
         ("expert_model_parallel_size", int, 1, "expert_model_parallel_size"),
         # context_parallel
         ("context_parallel_size", int, 1, "context_parallel_size"),
+        ("cp_balance_mode", str, "dualchunk_allgather", "CP scatter/gather layout mode"),
         # pp refine recompute
         ("no_recompute_layers", Optional[List[int]], None, "no_recompute_layers"),
         ("num_empty_layers_add_in_tail", int, 0, "Additional layers to append at the end"),

--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,7 @@ try:
         install_requires=REQUIRED_PACKAGES,
         entry_points={"console_scripts": get_console_scripts()},
         extras_require={
-            "paddlefleet": ["paddlefleet==0.3.0.dev20260529+30f17a82ef4"],
+            "paddlefleet": ["paddlefleet==0.3.0.dev20260608+d84d344d3bb"],
         },
         python_requires=">=3.8",
         classifiers=[

--- a/tests/trainer/test_cp_balance_mode.py
+++ b/tests/trainer/test_cp_balance_mode.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for cp_balance_mode propagation through PaddleFormers."""
+
+import dataclasses
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+from paddleformers.trainer import TrainingArguments
+from paddleformers.trainer.argparser import PdArgumentParser
+from paddleformers.transformers.configuration_utils import LlmMetaConfig
+
+
+class TestCpBalanceModeTrainingArgs(unittest.TestCase):
+    """Test cp_balance_mode field on TrainingArguments."""
+
+    def test_field_exists_with_default(self):
+        fields = {f.name: f for f in dataclasses.fields(TrainingArguments)}
+        self.assertIn("cp_balance_mode", fields)
+        self.assertEqual(fields["cp_balance_mode"].default, "dualchunk_allgather")
+
+    def test_parseable_from_cmdline(self):
+        parser = PdArgumentParser((TrainingArguments,))
+        ns = parser.parse_args(["--output_dir", "/tmp/test", "--cp_balance_mode", "contiguous_allgather"])
+        self.assertEqual(ns.cp_balance_mode, "contiguous_allgather")
+
+
+class TestCpBalanceModeLlmMetaConfig(unittest.TestCase):
+    """Test cp_balance_mode in LlmMetaConfig hybrid_parallel_attributes."""
+
+    def test_in_defaults(self):
+        defaults = LlmMetaConfig._get_defaults()
+        self.assertIn("cp_balance_mode", defaults)
+        self.assertEqual(defaults["cp_balance_mode"], "dualchunk_allgather")
+
+    def test_set_llm_config_propagates(self):
+        config = types.SimpleNamespace()
+        args = types.SimpleNamespace(cp_balance_mode="contiguous_allgather")
+        LlmMetaConfig.set_llm_config(config, args)
+        self.assertEqual(config.cp_balance_mode, "contiguous_allgather")
+
+    def test_set_llm_config_default_when_missing(self):
+        config = types.SimpleNamespace()
+        args = types.SimpleNamespace()  # no cp_balance_mode attr
+        LlmMetaConfig.set_llm_config(config, args)
+        self.assertEqual(config.cp_balance_mode, "dualchunk_allgather")
+
+
+class TestGetInputsListCpBalanceMode(unittest.TestCase):
+    """Test _get_inputs_list passes cp_balance_mode to get_batch_on_this_cp_rank."""
+
+    def test_passes_contiguous_mode(self):
+        mock_get_batch = MagicMock(side_effect=lambda inputs, **kw: inputs)
+
+        with patch("paddleformers.trainer.trainer.is_paddlefleet_available", return_value=True), patch(
+            "paddleformers.trainer.trainer.FleetGPTModel", str
+        ), patch("paddleformers.trainer.trainer.get_batch_on_this_cp_rank", mock_get_batch):
+
+            from paddleformers.trainer.trainer import Trainer
+
+            args = MagicMock()
+            args.enable_auto_parallel = False
+            args.use_hybrid_parallel = True
+            args.sep_parallel_size = 1
+            args.context_parallel_size = 4
+            args.split_inputs_sequence_dim = False
+            args.ignore_data_skip = False
+            args.cp_balance_mode = "contiguous_allgather"
+
+            trainer = object.__new__(Trainer)
+            trainer.args = args
+            trainer.model = "fake_model"  # isinstance("fake_model", str) == True
+            trainer.timers = None
+
+            trainer._get_inputs_list({"input_ids": [1, 2, 3]})
+
+        mock_get_batch.assert_called_once()
+        _, kwargs = mock_get_batch.call_args
+        self.assertEqual(kwargs["cp_balance_mode"], "contiguous_allgather")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
New features

### PR changes
APIs

### Description
增加了一个 trainer_arg 配置：`cp_balance_mode`，用于支持 DSV4：
- 正常 flashmask/flashattention 需要走 dualchunk CP 切分做负载均衡，所以一般用 `dualchunk_allgather`
- DSV4 稀疏 attention 目前需要连续 CP 切分，所以走 `contiguous_allgather`

后续在接入 flashmask overlap 功能后，`cp_balance_mode` 将会扩展后缀（用来判断是否需要开启计算通信 overlap）。本 PR 只考虑：{负载均衡方式}_{CP通信行为}
