### PR TITLE
[Cherry-Pick 1.2 | Trainer] Fix weight decay parameter filtering in trainer

### DIFF
--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -3333,11 +3333,9 @@ class Trainer:
         Trainer's init through `optimizers`, or subclass and override this method in a subclass.
         """
         if self.optimizer is None:
-            if self.optimizer_grouped_parameters is not None:
-                params = self.optimizer_grouped_parameters
-                apply_decay_param_fun = None
-            else:
-                params = [p for p in self.model.parameters() if not p.stop_gradient]
+
+            def _build_apply_decay_param_fun():
+                # Keep the default AdamW behavior: apply weight decay to all trainable parameters except bias and norm.
                 decay_parameters = [
                     p.name
                     for n, p in self.model.named_parameters()
@@ -3346,6 +3344,20 @@ class Trainer:
 
                 def apply_decay_param_fun(x):
                     return x in decay_parameters
+
+                return apply_decay_param_fun
+
+            if self.optimizer_grouped_parameters is not None:
+                params = self.optimizer_grouped_parameters
+                # A plain list only customizes the trainable set, so it should still use the default decay filter.
+                # But dict may define per-group weight_decay explicitly, so do not override.
+                is_param_group_dict = (
+                    isinstance(params, (list, tuple)) and len(params) > 0 and isinstance(params[0], dict)
+                )
+                apply_decay_param_fun = None if is_param_group_dict else _build_apply_decay_param_fun()
+            else:
+                params = [p for p in self.model.parameters() if not p.stop_gradient]
+                apply_decay_param_fun = _build_apply_decay_param_fun()
 
             optimizer_cls, optimizer_kwargs = Trainer.get_optimizer_cls_and_kwargs(self.args)
             if self.args.optim == OptimizerNames.ADAMW_CUSTOM:


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Models

### Description
#### 问题
SFT workflow 会把所有 trainable 参数作为普通 list 传进去：PaddleFormers/paddleformers/cli/train/sft/workflow.py:738，然后调用 `trainer.set_optimizer_grouped_parameters(trainable_parameters)`：workflow.py:741。

DPO workflow 同样如此：PaddleFormers/paddleformers/cli/train/dpo/workflow.py:445 和 workflow.py:448。

```
    trainable_parameters = [
        p for p in model.parameters() if not p.stop_gradient or ("quantization_linear" in p.name and "w_1" in p.name)
    ]
    trainer.set_optimizer_grouped_parameters(trainable_parameters)
```


这导致 Trainer.create_optimizer() 走 `optimizer_grouped_parameters is not None` 分支，完全跳过 bias / norm 的 decay 过滤，导致最后对 bias 和 norm 都做了 decay。

```
            if self.optimizer_grouped_parameters is not None:
                params = self.optimizer_grouped_parameters
                apply_decay_param_fun = None
            else:
                params = [p for p in self.model.parameters() if not p.stop_gradient]
                decay_parameters = [
                    p.name
                    for n, p in self.model.named_parameters()
                    if not p.stop_gradient and not any(nd in n for nd in ["bias", "norm"])
                ]

                def apply_decay_param_fun(x):
                    return x in decay_parameters

            self.optimizer = optimizer_cls(
                learning_rate=self.lr_scheduler if lr_scheduler is None else lr_scheduler,
                apply_decay_param_fun=apply_decay_param_fun,
                parameters=params,
                weight_decay=self.args.weight_decay,
                grad_clip=nn.ClipGradByGlobalNorm(self.args.max_grad_norm) if self.args.max_grad_norm > 0 else None,
                **optimizer_kwargs,
            )
```


#### 修复
修复 SFT/DPO 普通参数 list 路径，即保留现有默认 Trainer 行为：**bias/norm 不 decay**。

不破坏用户真正自定义 param group 的能力：如果用户传的是 dict group，说明可能已经显式设置了每组 weight_decay，Trainer 不应覆盖。


Merged in dev: https://github.com/PaddlePaddle/PaddleFormers/pull/4633