### PR TITLE
[DeepSeek-V4] Remove redundant mtp_num_layers filter condition

### DIFF
--- a/paddleformers/transformers/deepseek_v4/modeling.py
+++ b/paddleformers/transformers/deepseek_v4/modeling.py
@@ -836,12 +836,11 @@ class DeepseekV4PreTrainedModel(PretrainedModel):
                 ]
 
         # === 3. Top-level mHC head contraction (inverse) ===
-        if mtp_num_layers > 0:
-            stmts += [
-                "model.mhc_contract.hc_head_base -> hc_head_base, dtype='float32'",
-                "model.mhc_contract.hc_head_fn^T -> hc_head_fn, dtype='float32'",
-                "model.mhc_contract.hc_head_scale -> hc_head_scale, dtype='float32'",
-            ]
+        stmts += [
+            "model.mhc_contract.hc_head_base -> hc_head_base, dtype='float32'",
+            "model.mhc_contract.hc_head_fn^T -> hc_head_fn, dtype='float32'",
+            "model.mhc_contract.hc_head_scale -> hc_head_scale, dtype='float32'",
+        ]
 
         # === 4. Per-layer mappings (reversed to avoid intermediate tensor name collisions) ===
         for L in reversed(range(num_decoder_layers)):

--- a/paddleformers/transformers/deepseek_v4/modeling.py
+++ b/paddleformers/transformers/deepseek_v4/modeling.py
@@ -542,12 +542,11 @@ class DeepseekV4PreTrainedModel(PretrainedModel):
                 ]
 
         # === 3. Top-level mHC head contraction (output head HyperConnection) ===
-        if mtp_num_layers > 0:
-            stmts += [
-                "hc_head_base -> model.mhc_contract.hc_head_base, dtype='bfloat16'",
-                "hc_head_fn^T -> model.mhc_contract.hc_head_fn, dtype='bfloat16'",
-                "hc_head_scale -> model.mhc_contract.hc_head_scale, dtype='bfloat16'",
-            ]
+        stmts += [
+            "hc_head_base -> model.mhc_contract.hc_head_base, dtype='bfloat16'",
+            "hc_head_fn^T -> model.mhc_contract.hc_head_fn, dtype='bfloat16'",
+            "hc_head_scale -> model.mhc_contract.hc_head_scale, dtype='bfloat16'",
+        ]
 
         # === 4. MTP (Multi-Token Prediction) layers ===
         for i in range(mtp_num_layers):


### PR DESCRIPTION
## 变更说明

删除 `DeepseekV4PreTrainedModel` 中 mHC head contraction 权重加载语句外层冗余的 `if mtp_num_layers > 0` 条件判断。

该条件是多余的，因为 `mhc_contract` 模块无论 `mtp_num_layers` 是否大于 0 都存在，其权重应始终被加载。