### PR TITLE
[DSv4] Add accuracy compatible patch for PaddleFormers

### DIFF
--- a/paddleformers/datasets/collate.py
+++ b/paddleformers/datasets/collate.py
@@ -495,18 +495,17 @@ def collate_fn(
         batch = [sum(batch, [])]
         max_seq_len = sum(len(item.token_ids) for sequence in batch for item in sequence)
     fixed_tokens_path = os.environ.get("LOAD_FIXED_DATA_PATH")
+    fixed_data = None
     fixed_tokens = None
     if fixed_tokens_path:
-        rank = paddle.distributed.get_rank() if paddle.distributed.is_initialized() else 0
-        seq_len = training_args.max_seq_len
-        suffix = f"step0_rank{rank}_seq{seq_len}.npy"
-        tokens_file = os.path.join(fixed_tokens_path, f"tokens_{suffix}")
-        labels_file = os.path.join(fixed_tokens_path, f"labels_{suffix}")
-        fixed_input_ids = np.load(tokens_file).flatten().tolist()
-        fixed_labels = np.load(labels_file).flatten().tolist()
-        fixed_position_ids = list(range(len(fixed_input_ids)))
-        max_seq_len = calc_padding_size(len(fixed_input_ids), training_args)
-        fixed_tokens = True
+        from paddleformers.utils.accuracy_compatible_patch import (
+            load_fixed_training_data,
+        )
+
+        fixed_data = load_fixed_training_data(training_args, mtp_depth, calc_padding_size)
+        if fixed_data is not None:
+            max_seq_len = fixed_data.max_seq_len
+            fixed_tokens = True
     if not max_seq_len:
         max_seq_len = max(sum(len(item.token_ids) for item in sequence) for sequence in batch)
     max_seq_len = calc_padding_size(max_seq_len, training_args)
@@ -516,12 +515,19 @@ def collate_fn(
     # mask_seq_len: when mtp_attention_flexible is enabled, masks use (max_seq_len - mtp_depth)
     mask_seq_len = max_seq_len - mtp_depth if use_mtp_attention_flexible else max_seq_len
 
-    for batch_sequence in batch:
-        if fixed_tokens is not None:
-            original_position_ids = [fixed_position_ids]
-            token_ids = [fixed_input_ids]
-            labels = [fixed_labels]
-            position_ids = [fixed_position_ids]
+    if fixed_data is not None:
+        from paddleformers.utils.accuracy_compatible_patch import (
+            fixed_data_iter,
+            fixed_data_sample,
+        )
+
+        batch_iter = fixed_data_iter(fixed_data, batch)
+    else:
+        batch_iter = batch
+
+    for batch_sequence in batch_iter:
+        if fixed_data is not None:
+            original_position_ids, token_ids, labels, position_ids = fixed_data_sample(fixed_data, len(return_list))
         elif len(batch_sequence) == 1 and isinstance(batch_sequence[0].position_ids[0], List):
             original_position_ids = batch_sequence[0].position_ids
         else:
@@ -605,31 +611,6 @@ def collate_fn(
 
     return_list = [np.concatenate(tensor_list) for tensor_list in zip(*return_list)]
     input_dict = dict(zip(input_keys, return_list))
-    if fixed_tokens is not None and (
-        os.environ.get("LOG_DATA_MD5", "0") == "1" or os.environ.get("LOG_LAYER_MD5", "0") == "1"
-    ):
-        import hashlib
-
-        try:
-            rank = paddle.distributed.get_rank()
-        except Exception:
-            rank = 0
-        main_input = np.asarray([fixed_input_ids], dtype=np.int64)
-        main_labels = np.asarray([fixed_labels], dtype=np.int64)
-        print(
-            f"[LOAD_FIXED_DATA_PATH] loaded from {fixed_tokens_path}",
-            flush=True,
-        )
-        print(
-            f"[DATA_PATH_MD5] rank={rank} input_ids shape={list(main_input.shape)} "
-            f"md5={hashlib.md5(main_input.tobytes()).hexdigest()}",
-            flush=True,
-        )
-        print(
-            f"[DATA_PATH_MD5] rank={rank} labels shape={list(main_labels.shape)} "
-            f"md5={hashlib.md5(main_labels.tobytes()).hexdigest()}",
-            flush=True,
-        )
     return input_dict
 
 

--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import collections
 import contextlib
 import gc
+import hashlib
 import inspect
 import json
 import math
@@ -119,6 +120,10 @@ if TYPE_CHECKING:
         from transformers.tokenization_utils import PreTrainedTokenizer
 
 from paddle.framework.recall_error import LOSS_INF_ERROR, LOSS_NAN_ERROR
+
+from paddleformers.utils.accuracy_compatible_patch import (
+    apply_dsv4_accuracy_compatible_patch,
+)
 
 from ..transformers.context_parallel_utils import auto_split_sequence_dim_load_balance
 from ..transformers.image_processing_utils import ImageProcessingMixin
@@ -2366,6 +2371,16 @@ class Trainer:
                     else:
                         tr_loss += tr_loss_step
 
+                    should_flush_sequence_first_wgrad = (step_control + 1) % args.gradient_accumulation_steps == 0 or (
+                        steps_in_epoch <= args.gradient_accumulation_steps and (step + 1) == steps_in_epoch
+                    )
+                    if apply_dsv4_accuracy_compatible_patch() and should_flush_sequence_first_wgrad:
+                        from paddleformers.utils.accuracy_compatible_patch import (
+                            flush_sequence_first_wgrad,
+                        )
+
+                        flush_sequence_first_wgrad(model)
+
                     def fused_allreduce_gradients_no_sync(paramlist, hcg):
                         paramlist = list(paramlist)
                         nonmoe_list = [p for p in paramlist if not getattr(p, "no_sync", False)]
@@ -2459,7 +2474,11 @@ class Trainer:
                             self.timers and self.timers("all-reduce").stop()
                             self.timers and self.timers("optimizer-step").start()
 
-                        if not args.enable_auto_parallel and self.args.gradient_accumulation_steps > 1:
+                        if (
+                            not args.enable_auto_parallel
+                            and self.args.gradient_accumulation_steps > 1
+                            and not apply_dsv4_accuracy_compatible_patch()
+                        ):
                             paddle.device.synchronize()
                             parameters = (
                                 model._layers.parameters() if hasattr(model, "_layers") else model.parameters()
@@ -2747,12 +2766,21 @@ class Trainer:
             # all_gather + mean() to get average loss over all processes
             avg_loss = self._nested_gather(tr_loss).mean()
             tr_loss_scalar = self._get_item_from_loss(avg_loss)
+            raw_lm_loss_scalar = None
+            if apply_dsv4_accuracy_compatible_patch() and num_steps > 0:
+                from paddleformers.utils.accuracy_compatible_patch import (
+                    pop_raw_lm_loss,
+                )
+
+                raw_lm_loss_scalar = pop_raw_lm_loss()
 
             # reset tr_loss to zero
             tr_loss.subtract_(tr_loss)
             # set loss to zero if all steps are skipped since last log
             if num_steps == 0:
                 logs["loss"] = 0.0
+            elif raw_lm_loss_scalar is not None:
+                logs["loss"] = round(raw_lm_loss_scalar, 8)
             else:
                 logs["loss"] = round(tr_loss_scalar / num_steps, 8)
 
@@ -2765,10 +2793,12 @@ class Trainer:
             # Mirrors LOG_LOSS_MD5 hooks in PaddleFleet's loss path so it can be
             # diff'd against Megatron's [LOSS_PATH_MD5] output.
             if os.environ.get("LOG_LOSS_MD5", "0") == "1":
-                import hashlib
-
                 _md5_loss_t = avg_loss.detach().cast("float32").reshape([1])
                 logs["loss_md5"] = hashlib.md5(_md5_loss_t.numpy().tobytes()).hexdigest()
+
+            if os.environ.get("LOG_FINAL_LM_LOSS_MD5", "0") == "1" and raw_lm_loss_scalar is not None:
+                raw_lm_loss_arr = np.array([raw_lm_loss_scalar], dtype=np.float32)
+                logs["loss_md5"] = hashlib.md5(raw_lm_loss_arr.tobytes()).hexdigest()
 
             divisor = 2**30
             # TODO(@gexiao): replace these codes with unified APIs in Paddle
@@ -2904,6 +2934,7 @@ class Trainer:
             except (ImportError, AttributeError):
                 pass
 
+            tr_loss_scalar = raw_lm_loss_scalar * num_steps if raw_lm_loss_scalar is not None else tr_loss_scalar
             self._total_loss_scalar += tr_loss_scalar
             self._globalstep_last_logged = self.state.global_step
             self._globalstep_last_start_time = time.time()
@@ -4089,6 +4120,11 @@ class Trainer:
         Return:
             `paddle.Tensor`: The tensor with training loss on this batch.
         """
+        if apply_dsv4_accuracy_compatible_patch():
+            from paddleformers.utils.accuracy_compatible_patch import set_loss_acc_steps
+
+            set_loss_acc_steps(self.args.gradient_accumulation_steps)
+
         # accumulation data
         if data_buffer_prepared:
             if len(self._pp_data_buffer) < self.args.gradient_accumulation_steps:
@@ -4128,6 +4164,13 @@ class Trainer:
             inputs = _dataset_process_function()
         else:
             inputs = PipelineDatasetPreprocessor(_dataset_process_function)
+
+        if apply_dsv4_accuracy_compatible_patch():
+            from paddleformers.utils.accuracy_compatible_patch import (
+                set_pipeline_loss_scale,
+            )
+
+            set_pipeline_loss_scale(self.args.gradient_accumulation_steps)
 
         with self.autocast_smart_context_manager():
             loss = model.forward_backward_pipeline(inputs, self.scaler if self.do_grad_scaling else None)

--- a/paddleformers/trainer/trainer_utils.py
+++ b/paddleformers/trainer/trainer_utils.py
@@ -64,6 +64,11 @@ from paddle.io import IterableDataset
 from paddle.optimizer.lr import LambdaDecay
 from transformers.tokenization_utils_base import BatchEncoding
 
+from paddleformers.utils.accuracy_compatible_patch import (
+    apply_dsv4_accuracy_compatible_patch,
+    has_optimizer_state,
+)
+
 # from ..ops import Topology
 from ..trainer.argparser import strtobool
 from ..utils.import_utils import is_paddlefleet_available
@@ -687,6 +692,8 @@ def get_cosine_schedule_with_warmup(
     def lr_lambda(current_step):
         if current_step < num_warmup_steps:
             return float(current_step) / float(max(1, num_warmup_steps))
+        if apply_dsv4_accuracy_compatible_patch() and current_step >= num_training_steps:
+            return min_lr / learning_rate
         progress = float(current_step - num_warmup_steps) / float(max(1, num_training_steps - num_warmup_steps))
         ratio = max(0.0, 0.5 * (1.0 + math.cos(math.pi * float(num_cycles) * 2.0 * progress)))
         return ratio * (1 - min_lr / learning_rate) + min_lr / learning_rate
@@ -1519,11 +1526,8 @@ def init_optimizer(optimizer, model_sharded_state_dict, state_dict_metadata):
         for buffer in optimizer._comm_buffer_list:
             for param_name, grad_view in buffer._sharding_param_grad_view.items():
                 struct_name = static_to_struct_mapping[param_name]
-                if os.getenv("HACK_CONVERT_CKPT", "0").lower() not in ["true", "1"]:
-                    if not any(
-                        struct_name + state_name in state_dict_metadata for state_name in optimizer_state_names
-                    ):
-                        continue
+                if not has_optimizer_state(struct_name, state_dict_metadata, optimizer_state_names):
+                    continue
                 param_buffer = grad_view._param_buffer
                 param_begin = grad_view._param_begin
                 param_end = grad_view._param_end
@@ -1545,11 +1549,8 @@ def init_optimizer(optimizer, model_sharded_state_dict, state_dict_metadata):
                 if param_name not in static_to_struct_mapping:
                     continue
                 struct_name = static_to_struct_mapping[param_name]
-                if os.getenv("HACK_CONVERT_CKPT", "0").lower() not in ["true", "1"]:
-                    if not any(
-                        struct_name + state_name in state_dict_metadata for state_name in optimizer_state_names
-                    ):
-                        continue
+                if not has_optimizer_state(struct_name, state_dict_metadata, optimizer_state_names):
+                    continue
                 param_buffer = grad_view._param_buffer
                 param_begin = grad_view._param_begin
                 param_end = grad_view._param_end
@@ -1574,11 +1575,8 @@ def init_optimizer(optimizer, model_sharded_state_dict, state_dict_metadata):
                 if param_name not in static_to_struct_mapping:
                     continue
                 struct_name = static_to_struct_mapping[param_name]
-                if os.getenv("HACK_CONVERT_CKPT", "0").lower() not in ["true", "1"]:
-                    if not any(
-                        struct_name + state_name in state_dict_metadata for state_name in optimizer_state_names
-                    ):
-                        continue
+                if not has_optimizer_state(struct_name, state_dict_metadata, optimizer_state_names):
+                    continue
                 parameter_list.append(param)
 
         optimizer._create_accumulators(paddle.base.framework.default_main_program().global_block(), parameter_list)

--- a/paddleformers/transformers/aoa_config_base.py
+++ b/paddleformers/transformers/aoa_config_base.py
@@ -402,7 +402,14 @@ class MoEAOAConfigGenerator:
         statements.append(
             f"{prefix}.mlp.gate.e_score_correction_bias -> {prefix_offset}.mlp.gate.e_score_correction_bias"
         )
-        statements.append(f"{prefix}.mlp.gate.weight -> {prefix_offset}.mlp.gate.weight, dtype='float32'")
+        from paddleformers.utils.accuracy_compatible_patch import (
+            apply_dsv4_accuracy_compatible_patch,
+        )
+
+        gate_weight_stmt = f"{prefix}.mlp.gate.weight -> {prefix_offset}.mlp.gate.weight"
+        if not apply_dsv4_accuracy_compatible_patch():
+            gate_weight_stmt += ", dtype='float32'"
+        statements.append(gate_weight_stmt)
 
         # Shared experts (if model has them)
         if params.has_shared_experts:

--- a/paddleformers/transformers/deepseek_v4/modeling.py
+++ b/paddleformers/transformers/deepseek_v4/modeling.py
@@ -393,6 +393,10 @@ class DeepseekV4PreTrainedModel(PretrainedModel):
         HF naming convention: layers.{L}.attn.*, layers.{L}.ffn.*, embed.weight, etc.
         PF naming convention: model.layers.{L}.self_attn.*, model.layers.{L}.mlp.*, etc.
         """
+        from paddleformers.utils.accuracy_compatible_patch import (
+            apply_dsv4_accuracy_compatible_patch,
+        )
+
         num_hidden_layers = config.num_hidden_layers
         num_experts = config.n_routed_experts
         n_shared_experts = getattr(config, "n_shared_experts", 1)
@@ -408,6 +412,7 @@ class DeepseekV4PreTrainedModel(PretrainedModel):
         # Note: num_hidden_layers in PaddleFormers config is the decoder layer count (NOT bumped by MTP).
         # MTP layers are appended AFTER the decoder layers, so MTP layer i is at index num_hidden_layers + i.
         num_decoder_layers = num_hidden_layers
+        use_accuracy_patch = apply_dsv4_accuracy_compatible_patch()
 
         stmts = []
 
@@ -504,7 +509,10 @@ class DeepseekV4PreTrainedModel(PretrainedModel):
                 ]
 
             # --- MoE Gate ---
-            stmts += [f"{src}.ffn.gate.weight -> {tgt}.mlp.gate.weight, dtype='float32'"]
+            gate_weight_stmt = f"{src}.ffn.gate.weight -> {tgt}.mlp.gate.weight"
+            if not use_accuracy_patch:
+                gate_weight_stmt += ", dtype='float32'"
+            stmts += [gate_weight_stmt]
             # Non-hash layers have e_score_correction_bias; hash layers use tid2eid
             if L >= moe_n_hash_layers:
                 stmts += [f"{src}.ffn.gate.bias -> {tgt}.mlp.gate.e_score_correction_bias"]
@@ -636,8 +644,11 @@ class DeepseekV4PreTrainedModel(PretrainedModel):
                     ]
 
             # --- MoE Gate (MTP layers are always non-hash, so always have bias) ---
+            gate_weight_stmt = f"{mtp_src}.ffn.gate.weight -> {tl}.mlp.gate.weight"
+            if not use_accuracy_patch:
+                gate_weight_stmt += ", dtype='float32'"
             stmts += [
-                f"{mtp_src}.ffn.gate.weight -> {tl}.mlp.gate.weight, dtype='float32'",
+                gate_weight_stmt,
                 f"{mtp_src}.ffn.gate.bias -> {tl}.mlp.gate.e_score_correction_bias",
             ]
 

--- a/paddleformers/utils/accuracy_compatible_patch.py
+++ b/paddleformers/utils/accuracy_compatible_patch.py
@@ -1,0 +1,209 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Callable
+
+import numpy as np
+import paddle
+import paddle.distributed as dist
+
+_APPLY_DSV4_ACCURACY_COMPATIBLE_PATCH = os.environ.get("APPLY_DSV4_ACCURACY_COMPATIBLE_PATCH", "0") == "1"
+_LOAD_FIXED_DATA_CALL_COUNT = 0
+
+
+def apply_dsv4_accuracy_compatible_patch() -> bool:
+    return _APPLY_DSV4_ACCURACY_COMPATIBLE_PATCH
+
+
+@dataclass
+class FixedTrainingData:
+    input_ids: list
+    labels: list
+    position_ids: list
+    max_seq_len: int
+    batched: bool = False
+
+
+def load_fixed_training_data(
+    training_args,
+    mtp_depth: int,
+    calc_padding_size: Callable[[int, object], int],
+) -> FixedTrainingData | None:
+    fixed_tokens_path = os.environ.get("LOAD_FIXED_DATA_PATH")
+    if not fixed_tokens_path:
+        return None
+
+    global _LOAD_FIXED_DATA_CALL_COUNT
+
+    rank = paddle.distributed.get_rank() if paddle.distributed.is_initialized() else 0
+    seq_len = training_args.max_seq_len
+    accumulation_steps = max(1, int(getattr(training_args, "gradient_accumulation_steps", 1)))
+    call_index = _LOAD_FIXED_DATA_CALL_COUNT
+    _LOAD_FIXED_DATA_CALL_COUNT += 1
+    fixed_step = call_index // accumulation_steps
+    micro_step = call_index % accumulation_steps
+    suffix = f"step{fixed_step}_micro{micro_step}_rank{rank}_seq{seq_len}.npy"
+    tokens_file = os.path.join(fixed_tokens_path, f"tokens_{suffix}")
+    labels_file = os.path.join(fixed_tokens_path, f"labels_{suffix}")
+    if not os.path.exists(tokens_file):
+        suffix = f"step{fixed_step}_rank{rank}_seq{seq_len}.npy"
+        tokens_file = os.path.join(fixed_tokens_path, f"tokens_{suffix}")
+        labels_file = os.path.join(fixed_tokens_path, f"labels_{suffix}")
+
+    fixed_input_arr = np.load(tokens_file)
+    fixed_label_arr = np.load(labels_file)
+    if fixed_input_arr.ndim == 1:
+        input_ids = fixed_input_arr.tolist()
+        labels = fixed_label_arr.tolist()
+        return FixedTrainingData(
+            input_ids=input_ids,
+            labels=labels,
+            position_ids=list(range(len(input_ids))),
+            max_seq_len=calc_padding_size(len(input_ids), training_args),
+        )
+
+    if fixed_input_arr.ndim != 2:
+        raise ValueError("LOAD_FIXED_DATA_PATH expects 1D or 2D token arrays, " f"got shape {fixed_input_arr.shape}")
+    if fixed_label_arr.shape != fixed_input_arr.shape:
+        raise ValueError(
+            f"LOAD_FIXED_DATA_PATH labels shape {fixed_label_arr.shape} "
+            f"does not match tokens shape {fixed_input_arr.shape}"
+        )
+
+    input_ids = [row.tolist() for row in fixed_input_arr]
+    labels = [row.tolist() for row in fixed_label_arr]
+    position_ids = [list(range(len(row))) for row in input_ids]
+    return FixedTrainingData(
+        input_ids=input_ids,
+        labels=labels,
+        position_ids=position_ids,
+        max_seq_len=calc_padding_size(max(len(row) for row in input_ids), training_args),
+        batched=True,
+    )
+
+
+def fixed_data_iter(fixed_data: FixedTrainingData | None, batch: list):
+    if fixed_data is not None and fixed_data.batched:
+        return [None] * len(fixed_data.input_ids)
+    return batch
+
+
+def fixed_data_sample(fixed_data: FixedTrainingData, index: int):
+    if fixed_data.batched:
+        return (
+            [fixed_data.position_ids[index]],
+            [fixed_data.input_ids[index]],
+            [fixed_data.labels[index]],
+            [fixed_data.position_ids[index]],
+        )
+    return (
+        [fixed_data.position_ids],
+        [fixed_data.input_ids],
+        [fixed_data.labels],
+        [fixed_data.position_ids],
+    )
+
+
+def _get_param_grad(param):
+    grad = getattr(param, "main_grad", None)
+    if grad is not None:
+        return grad
+    grad_attr = getattr(param, "grad", None)
+    return grad_attr() if callable(grad_attr) else grad_attr
+
+
+def flush_sequence_first_wgrad(model) -> None:
+    attrs = (
+        "_dsv4_hc_mapping_seqfirst_wgrad",
+        "_dsv4_attn_o_group_seqfirst_wgrad",
+    )
+    with paddle.no_grad():
+        for _, param in model.named_parameters():
+            seqfirst_wgrad = None
+            matched_attr = None
+            for attr in attrs:
+                seqfirst_wgrad = getattr(param, attr, None)
+                if seqfirst_wgrad is not None:
+                    matched_attr = attr
+                    break
+            if matched_attr is None:
+                continue
+            grad = _get_param_grad(param)
+            if grad is None:
+                continue
+            grad.set_value(seqfirst_wgrad.cast(grad.dtype))
+            setattr(param, matched_attr, None)
+
+
+def set_loss_acc_steps(acc_steps: int) -> None:
+    try:
+        from paddlefleet.accuracy_compatible_patch import LossScaleBeforeBackward
+
+        LossScaleBeforeBackward.set_acc_steps(acc_steps)
+    except (ImportError, AttributeError):
+        pass
+
+
+def pop_raw_lm_loss():
+    try:
+        from paddlefleet.accuracy_compatible_patch import LossScaleBeforeBackward
+
+        raw_lm_loss = LossScaleBeforeBackward.pop()
+    except (ImportError, AttributeError):
+        raw_lm_loss = None
+
+    if raw_lm_loss is not None:
+        loss_sum, loss_count = raw_lm_loss
+    else:
+        loss_sum = paddle.zeros([1], dtype=paddle.float32)
+        loss_count = paddle.zeros([1], dtype=paddle.float32)
+
+    if dist.is_initialized():
+        dist.all_reduce(loss_sum, dist.ReduceOp.SUM)
+        dist.all_reduce(loss_count, dist.ReduceOp.SUM)
+
+    if loss_count.item() <= 0:
+        return None
+
+    return float((loss_sum / loss_count).cast("float32").numpy()[0])
+
+
+def set_pipeline_loss_scale(acc_steps: int) -> None:
+    if acc_steps <= 1:
+        return
+    acc_scale = paddle.to_tensor(1.0 / acc_steps, dtype=paddle.float32)
+    try:
+        from paddlefleet.transformer.multi_token_prediction import MTPLossAutoScaler
+
+        MTPLossAutoScaler.set_loss_scale(acc_scale)
+    except (ImportError, AttributeError):
+        pass
+    try:
+        from paddlefleet.transformer.dsa_attention import DSAIndexerLossAutoScaler
+
+        DSAIndexerLossAutoScaler.set_loss_scale(acc_scale)
+    except (ImportError, AttributeError):
+        pass
+
+
+def has_optimizer_state(struct_name, state_dict_metadata, optimizer_state_names):
+    if apply_dsv4_accuracy_compatible_patch():
+        return any(struct_name + state_name in state_dict_metadata for state_name in optimizer_state_names)
+    if os.getenv("HACK_CONVERT_CKPT", "0").lower() in ["true", "1"]:
+        return True
+    return any(struct_name + state_name in state_dict_metadata for state_name in optimizer_state_names)

--- a/paddleformers/utils/accuracy_compatible_patch.py
+++ b/paddleformers/utils/accuracy_compatible_patch.py
@@ -151,21 +151,15 @@ def flush_sequence_first_wgrad(model) -> None:
 
 
 def set_loss_acc_steps(acc_steps: int) -> None:
-    try:
-        from paddlefleet.accuracy_compatible_patch import LossScaleBeforeBackward
+    from paddlefleet.accuracy_compatible_patch import LossScaleBeforeBackward
 
-        LossScaleBeforeBackward.set_acc_steps(acc_steps)
-    except (ImportError, AttributeError):
-        pass
+    LossScaleBeforeBackward.set_acc_steps(acc_steps)
 
 
 def pop_raw_lm_loss():
-    try:
-        from paddlefleet.accuracy_compatible_patch import LossScaleBeforeBackward
+    from paddlefleet.accuracy_compatible_patch import LossScaleBeforeBackward
 
-        raw_lm_loss = LossScaleBeforeBackward.pop()
-    except (ImportError, AttributeError):
-        raw_lm_loss = None
+    raw_lm_loss = LossScaleBeforeBackward.pop()
 
     if raw_lm_loss is not None:
         loss_sum, loss_count = raw_lm_loss
@@ -187,18 +181,11 @@ def set_pipeline_loss_scale(acc_steps: int) -> None:
     if acc_steps <= 1:
         return
     acc_scale = paddle.to_tensor(1.0 / acc_steps, dtype=paddle.float32)
-    try:
-        from paddlefleet.transformer.multi_token_prediction import MTPLossAutoScaler
+    from paddlefleet.transformer.dsa_attention import DSAIndexerLossAutoScaler
+    from paddlefleet.transformer.multi_token_prediction import MTPLossAutoScaler
 
-        MTPLossAutoScaler.set_loss_scale(acc_scale)
-    except (ImportError, AttributeError):
-        pass
-    try:
-        from paddlefleet.transformer.dsa_attention import DSAIndexerLossAutoScaler
-
-        DSAIndexerLossAutoScaler.set_loss_scale(acc_scale)
-    except (ImportError, AttributeError):
-        pass
+    MTPLossAutoScaler.set_loss_scale(acc_scale)
+    DSAIndexerLossAutoScaler.set_loss_scale(acc_scale)
 
 
 def has_optimizer_state(struct_name, state_dict_metadata, optimizer_state_names):


### PR DESCRIPTION
## Summary

- 新增 PaddleFormers 侧的 DSv4 精度对齐兼容 helper，用于统一管理对齐开关、固定数据加载、raw LM loss 日志和 sequence-first 梯度刷新。
- 将 trainer、scheduler、optimizer state 加载和 fixed-data collate 路径收敛到该 helper 中。
- MoE gate AOA dtype 相关改动受 `APPLY_DSV4_ACCURACY_COMPATIBLE_PATCH` 控制，默认不开启时保持原始映射行为。

