### PR TITLE
Test PaddleFormers approval gate for switch path

### DIFF
--- a/paddleformers/trainer/training_args.py
+++ b/paddleformers/trainer/training_args.py
@@ -46,7 +46,7 @@ from .trainer_utils import (
     split_parallel_config,
 )
 
-# Conditionally import paddlefleet modules
+# Conditionally import paddlefleet modules for optional distributed training support.
 if is_paddlefleet_available():
     from paddlefleet.parallel_state import get_tensor_model_parallel_group
     from paddlefleet.training import initialize_fleet

--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -30,6 +30,12 @@ def get_container_type(container):
     return container_t
 
 
+class TestGetContainerType(unittest.TestCase):
+    def test_empty_container_type(self):
+        self.assertIs(get_container_type([]), list)
+        self.assertIs(get_container_type(()), tuple)
+
+
 class CommonTest(unittest.TestCase):
     def __init__(self, methodName="runTest"):
         super(CommonTest, self).__init__(methodName=methodName)


### PR DESCRIPTION
## Summary
- Touch a PaddleFormers approval-gated trainer path to verify the Approval workflow interception.
- Expected approval requirement: From00 for changes under paddleformers/trainer/training_args.py.

## Test plan
- pre-commit run --all-files (failed on existing unrelated flake8/trailing-whitespace/copyright/doc spacing issues)
- python -m pre_commit run --files paddleformers/trainer/training_args.py