### PR TITLE
Test PaddleFormers packages custom op trigger

### DIFF
--- a/packages/custom_ops/approval_trigger.cu
+++ b/packages/custom_ops/approval_trigger.cu
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This placeholder file intentionally lives under packages/custom_ops so
+// changed-file path rules can detect custom operator related changes.

--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -30,6 +30,12 @@ def get_container_type(container):
     return container_t
 
 
+class TestGetContainerType(unittest.TestCase):
+    def test_empty_container_type(self):
+        self.assertIs(get_container_type([]), list)
+        self.assertIs(get_container_type(()), tuple)
+
+
 class CommonTest(unittest.TestCase):
     def __init__(self, methodName="runTest"):
         super(CommonTest, self).__init__(methodName=methodName)


### PR DESCRIPTION
## Summary
- Add a minimal file under packages/custom_ops to trigger path-based custom operator detection.
- The changed file path contains a parent directory segment named packages.

## Test plan
- pre-commit run --all-files (failed on existing unrelated flake8/trailing-whitespace/copyright/doc spacing issues)
- python -m pre_commit run --files packages/custom_ops/approval_trigger.cu