### PR TITLE
Cherry-pick packages custom op trigger to release/1.2

### DIFF
--- a/packages/custom_ops/approval_trigger.cu
+++ b/packages/custom_ops/approval_trigger.cu
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This placeholder file intentionally lives under packages/custom_ops so
+// changed-file path rules can detect custom operator related changes.


### PR DESCRIPTION
## Summary
- Cherry-pick 29771f9f85f9551e50a956b1887bfcf43a801f4f to release/1.2.
- The changed file path contains a parent directory segment named packages.

## Test plan
- pre-commit run --all-files (failed on existing unrelated flake8/trailing-whitespace/copyright/doc spacing issues)
- python -m pre_commit run --files packages/custom_ops/approval_trigger.cu