### PR TITLE
[Bug fixes] Add on_step_begin to InternalMedicineCallback for pre-quant expert-norm collection

### DIFF
--- a/paddleformers/trainer/trainer_callback.py
+++ b/paddleformers/trainer/trainer_callback.py
@@ -972,6 +972,19 @@ class InternalMedicineCallback(TrainerCallback):
         except Exception:
             logger.error("[InternalMedicine/pfleet] Failed to setup monitors")
 
+    def on_step_begin(self, args, state, control, **kwargs):
+        # Collect expert weight norms before the FP8 quant callback clears the
+        # bf16 expert weights. Only monitors that expose collect_expert_norms()
+        # have step-begin work; others keep their metrics on forward hooks. This
+        # MUST run before FP8QuantWeightCallback.on_step_begin, which is ensured
+        # by registering this callback ahead of it in the callbacks list.
+        if not self._setup_done:
+            return
+        for monitor in self._monitor_dict.values():
+            collect = getattr(monitor, "collect_expert_norms", None)
+            if collect is not None:
+                collect()
+
     def on_step_end(self, args, state, control, **kwargs):
         if not self._setup_done:
             return


### PR DESCRIPTION
### PR types

Bug fixes

### PR changes

APIs

### Description

Adds an `on_step_begin` hook to `InternalMedicineCallback` (`paddleformers/trainer/trainer_callback.py`). For each registered monitor that exposes `collect_expert_norms()`, it invokes that method at step begin, before `FP8QuantWeightCallback` quantizes and clears the bf16 expert weights via `optimizer.clear_param_storage("moe_expert")`.

Why: when `offline_quant_expert_weight` is enabled, the FP8 quant callback frees the bf16 expert weights at step begin. The PaddleFleet `moe_health` monitor used to read those weights from a forward hook (which runs after quant), so it silently read cleared weights — `expert_norm_*` metrics were lost and the per-expert read also thrashed the allocator against EP a2a, regressing step time ~3.8x. Collecting at step begin (ahead of the quant callback) reads the true bf16 weights and keeps the forward hot path clean.

Wired via duck typing (`getattr(monitor, "collect_expert_norms", None)`), so monitors without that method are unaffected and behavior is unchanged when no internal-medicine monitor is active.

This is part of a 3-repo change; the other two must land together:
- `llm-internal-medicine`: moves expert-norm collection into `collect_expert_norms()` and vectorizes it.https://github.com/bo-ke/llm-internal-medicine/pull/8/changes
- `ernie5/pretrain.py`: drops the duplicate local `InternalMedicineCallback` registration so the Trainer-auto-registered one runs ahead of `FP8QuantWeightCallback`.