### PR TITLE
Wire internal_medicine_qk_row_stride through to qk_stats monitor

### DIFF
--- a/paddleformers/cli/hparams/finetuning_args.py
+++ b/paddleformers/cli/hparams/finetuning_args.py
@@ -81,6 +81,14 @@ class PreTrainingArguments(TrainingArguments):
         default=1,
         metadata={"help": "Step interval for internal medicine monitors."},
     )
+    internal_medicine_qk_row_stride: int = field(
+        default=1,
+        metadata={
+            "help": "qk_stats query-row subsampling stride. 1 = exact full pass. "
+            "Larger values (e.g. 16/32) subsample query rows to cut the O(S^2) cost "
+            "on long sequences; mean/entropy/sink stay unbiased, max is a lower bound."
+        },
+    )
     num_consecutive: int = field(
         default=1,
         metadata={"help": "H5 file consecutive num."},

--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -501,6 +501,7 @@ class Trainer:
                 InternalMedicineCallback(
                     monitors=self.args.internal_medicine_monitors,
                     monitor_interval=self.args.internal_medicine_monitor_interval,
+                    qk_row_stride=getattr(self.args, "internal_medicine_qk_row_stride", 1),
                 )
             )
         default_callbacks += get_reporting_integration_callbacks(self.args.report_to)

--- a/paddleformers/trainer/trainer_callback.py
+++ b/paddleformers/trainer/trainer_callback.py
@@ -935,11 +935,12 @@ class SPGradSyncCallback(TrainerCallback):
 
 
 class InternalMedicineCallback(TrainerCallback):
-    def __init__(self, monitors=None, monitor_interval: int = 1, verbose: bool = True):
+    def __init__(self, monitors=None, monitor_interval: int = 1, verbose: bool = True, qk_row_stride: int = 1):
         super().__init__()
         self.monitors = self._normalize_monitors(monitors)
         self.monitor_interval = monitor_interval
         self.verbose = verbose
+        self.qk_row_stride = qk_row_stride
         self._monitor_dict = {}
         self._training_logs = None
         self._setup_done = False
@@ -974,6 +975,7 @@ class InternalMedicineCallback(TrainerCallback):
                 monitor_dict=self._monitor_dict,
                 monitor_interval=self.monitor_interval,
                 verbose=self.verbose,
+                qk_stats={"row_stride": self.qk_row_stride},
             )
             self._training_logs = training_logs
             self._setup_done = True


### PR DESCRIPTION
### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.
- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types

Function optimization

### PR changes

APIs

### Description

Adds an `internal_medicine_qk_row_stride` training argument (default `1` = exact full pass) and threads it through `InternalMedicineCallback` into `setup_monitors` as `qk_stats={"row_stride": ...}`.

This lets long-sequence runs subsample qk_stats query rows from the yaml config to cut the O(S^2) hot-path cost of the qk_stats monitor, while keeping mean/entropy/sink statistics unbiased (max becomes a lower bound). Default `1` preserves exact prior behavior.

Depends on the matching `row_stride` support in the internal_medicine `setup_monitors` (`qk_stats` options channel).

No new tests: this is a pure config passthrough; the underlying row_stride behavior is covered by tests in the internal_medicine repo.