### PR TITLE
Add Fleet MoE logging bridge

### DIFF
--- a/paddleformers/cli/hparams/model_args.py
+++ b/paddleformers/cli/hparams/model_args.py
@@ -161,6 +161,10 @@ class ModelArguments:
         default="dummy",
         metadata={"help": "MoE communication group. Supported values: 'mp', 'dummy'."},
     )
+    moe_logging: Optional[bool] = field(
+        default=None,
+        metadata={"help": "Whether to enable Fleet MoE balance logging."},
+    )
     moe_multimodal_dispatch_use_allgather: Optional[str] = field(
         default="v2-alltoall-unpad",
         metadata={"help": "moe dispatch use unpad allgather strategy."},

--- a/paddleformers/cli/train/sft/workflow.py
+++ b/paddleformers/cli/train/sft/workflow.py
@@ -330,6 +330,7 @@ def run_sft(
     model_config.max_sequence_length = data_args.max_seq_len
     model_config._attn_implementation = model_args._attn_implementation
     model_config.is_lora = model_args.lora
+    model_config.moe_logging = model_args.moe_logging
 
     # Sync arguments to MLLM sub_config
     if getattr(model_config, "text_config", None) is not None:

--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -184,6 +184,7 @@ from .trainer_utils import (  # set_hyrbid_parallel_seed,
     EMAStateAssembler,
     EvalLoopOutput,
     EvalPrediction,
+    FleetTrainingLogs,
     IntervalStrategy,
     IterableDatasetShard,
     OptimizerNames,
@@ -629,6 +630,14 @@ class Trainer:
             self.trained_tokens = 0
 
         self.global_training_logs = {}
+        self._register_fleet_moe_training_logs()
+
+    def _register_fleet_moe_training_logs(self):
+        try:
+            from paddlefleet.training.global_vars import set_global_training_logs
+        except ImportError:
+            return
+        set_global_training_logs(FleetTrainingLogs(self))
 
     def _wrap_amp_model(self, args, model):
         logger.info("Using half precision")

--- a/paddleformers/trainer/trainer_utils.py
+++ b/paddleformers/trainer/trainer_utils.py
@@ -96,6 +96,7 @@ from .utils.reshard import SHARDING_STRATEGY_V1, split_opt_state
 from .utils.sharding_io import GroupGetter, to_device
 
 __all__ = [
+    "FleetTrainingLogs",
     "TrainOutput",
     "PredictionOutput",
     "EvalPrediction",
@@ -109,6 +110,25 @@ __all__ = [
     "set_hyrbid_parallel_seed",
     "log_trainer_start",
 ]
+
+
+class FleetTrainingLogs:
+    def __init__(self, trainer):
+        self.trainer = trainer
+
+    def update(self, **kwargs):
+        for key, value in kwargs.items():
+            if hasattr(value, "item"):
+                value = value.item()
+            self.trainer.global_training_logs[key] = value
+
+    def is_moe_balance_logs_enabled(self):
+        if not self.trainer.model.config.moe_logging:
+            return False
+
+        interval = self.trainer.args.global_logging_interval
+        remainder = (self.trainer.state.global_step + 1) % (interval * interval)
+        return 0 <= remainder < interval
 
 
 def mock_offload_optimizer():

--- a/paddleformers/trainer/trainer_utils.py
+++ b/paddleformers/trainer/trainer_utils.py
@@ -123,7 +123,8 @@ class FleetTrainingLogs:
             self.trainer.global_training_logs[key] = value
 
     def is_moe_balance_logs_enabled(self):
-        if not self.trainer.model.config.moe_logging:
+        config = getattr(self.trainer.model, "config", None)
+        if not getattr(config, "moe_logging", False):
             return False
 
         interval = self.trainer.args.global_logging_interval


### PR DESCRIPTION
## Summary
- add a top-level moe_logging model argument for Formers training configs
- copy model_args.moe_logging into model_config on the SFT/PT workflow path
- register a FleetTrainingLogs adapter so PaddleFleet global_training_logs can populate Trainer logs when MoE balance logging is enabled