### PR TITLE
Add training visualization support to trainer and callbacks

### DIFF
--- a/paddleformers/cli/hparams/finetuning_args.py
+++ b/paddleformers/cli/hparams/finetuning_args.py
@@ -77,9 +77,14 @@ class PreTrainingArguments(TrainingArguments):
             "help": "Comma-separated list of internal medicine monitors. Options: qk_stats,moe_health,massive_act,all"
         },
     )
-    internal_medicine_monitor_interval: int = field(
-        default=1,
-        metadata={"help": "Step interval for internal medicine monitors."},
+    internal_medicine_monitor_interval: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": "Step interval for internal medicine monitors. "
+            "0 disables monitoring (no collection, no viewer). "
+            "Positive integer is the sampling interval. "
+            "Omitted -> defaults to 1 with a warning."
+        },
     )
     internal_medicine_qk_row_stride: int = field(
         default=1,
@@ -87,6 +92,14 @@ class PreTrainingArguments(TrainingArguments):
             "help": "qk_stats query-row subsampling stride. 1 = exact full pass. "
             "Larger values (e.g. 16/32) subsample query rows to cut the O(S^2) cost "
             "on long sequences; mean/entropy/sink stay unbiased, max is a lower bound."
+        },
+    )
+    internal_medicine_log_dir: str = field(
+        default="",
+        metadata={
+            "help": "Directory for the per-step JSONL produced by the internal-medicine "
+            "callback (rank 0 only). File name is fixed to 'internal_medicine.jsonl'. "
+            "Empty -> use output_dir. Consumed by tools/internal_medicine/server.py."
         },
     )
     num_consecutive: int = field(
@@ -317,8 +330,12 @@ class FinetuningArguments(
     )
 
     def __post_init__(self):
-        if self.internal_medicine_monitors and self.internal_medicine_monitor_interval < 1:
-            raise ValueError("internal_medicine_monitor_interval must be greater than 0 when monitors are enabled")
+        if (
+            self.internal_medicine_monitors
+            and self.internal_medicine_monitor_interval is not None
+            and self.internal_medicine_monitor_interval < 0
+        ):
+            raise ValueError("internal_medicine_monitor_interval must be >= 0 (0 disables monitoring)")
 
         self.bf16 = True
         if self.compute_type == "bf16":

--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -497,12 +497,20 @@ class Trainer:
                 model, PipelineLayer
             ), f"Only support pipeline parallel mode when model is PipelineLayer or PipelineLayer!!! but get {type(model.model)}"
         default_callbacks = DEFAULT_CALLBACKS.copy()
-        if getattr(self.args, "internal_medicine_monitors", ""):
+
+        _im_monitors = getattr(self.args, "internal_medicine_monitors", "")
+        _im_interval = getattr(self.args, "internal_medicine_monitor_interval", None)
+        if _im_monitors and _im_interval != 0:
+            # Resolve the metrics log directory: explicit -> use as-is; empty -> output_dir.
+            _im_log_dir = (
+                getattr(self.args, "internal_medicine_log_dir", "") or getattr(self.args, "output_dir", "") or "."
+            )
             default_callbacks.append(
                 InternalMedicineCallback(
-                    monitors=self.args.internal_medicine_monitors,
-                    monitor_interval=self.args.internal_medicine_monitor_interval,
+                    monitors=_im_monitors,
+                    monitor_interval=_im_interval,  # None -> callback warns + uses 1
                     qk_row_stride=getattr(self.args, "internal_medicine_qk_row_stride", 1),
+                    log_dir=_im_log_dir,
                 )
             )
         default_callbacks += get_reporting_integration_callbacks(self.args.report_to)

--- a/paddleformers/trainer/trainer_callback.py
+++ b/paddleformers/trainer/trainer_callback.py
@@ -935,15 +935,34 @@ class SPGradSyncCallback(TrainerCallback):
 
 
 class InternalMedicineCallback(TrainerCallback):
-    def __init__(self, monitors=None, monitor_interval: int = 1, verbose: bool = True, qk_row_stride: int = 1):
+    def __init__(
+        self,
+        monitors=None,
+        monitor_interval=None,
+        verbose: bool = True,
+        qk_row_stride: int = 1,
+        log_dir: str = "",
+    ):
         super().__init__()
         self.monitors = self._normalize_monitors(monitors)
-        self.monitor_interval = monitor_interval
+        if monitor_interval is None:
+            logger.warning(
+                "[InternalMedicine] internal_medicine_monitor_interval not set; defaulting to 1. "
+                "Set it to 0 in your yaml to disable internal-medicine monitoring entirely."
+            )
+            monitor_interval = 1
+        self.monitor_interval = int(monitor_interval)
         self.verbose = verbose
         self.qk_row_stride = qk_row_stride
+        self.log_dir = log_dir or ""
+        self.log_path = os.path.join(self.log_dir, "internal_medicine.jsonl") if self.log_dir else ""
         self._monitor_dict = {}
         self._training_logs = None
         self._setup_done = False
+        # Lazy-resolved flags: only rank 0 writes; init on first on_log call so
+        # the distributed env is fully up by then.
+        self._is_writer = None
+        self._log_path_ready = False
 
     @staticmethod
     def _normalize_monitors(monitors) -> list:
@@ -1004,13 +1023,56 @@ class InternalMedicineCallback(TrainerCallback):
             monitor.step()
 
     def on_log(self, args, state, control, logs=None, **kwargs):
-        if not self._setup_done or logs is None or self._training_logs is None:
+        if not self._setup_done or self._training_logs is None:
             return
 
         aggregated = self._training_logs.gather_and_aggregate()
         if aggregated:
-            logs.update(aggregated)
             self._training_logs.reset()
+            self._maybe_write_jsonl(state, aggregated)
+
+    def _resolve_writer(self):
+        """Decide once whether this process should write the jsonl file.
+
+        Only the global rank-0 process writes. Resolved lazily because the
+        distributed env may not be ready at callback construction time.
+        """
+        if self._is_writer is not None:
+            return self._is_writer
+        rank = 0
+        try:
+            import paddle.distributed as dist  # type: ignore
+
+            if dist.is_initialized():
+                rank = dist.get_rank()
+        except Exception:
+            rank = 0
+        self._is_writer = (rank == 0) and bool(self.log_path)
+        return self._is_writer
+
+    def _maybe_write_jsonl(self, state, aggregated):
+        if not self._resolve_writer():
+            return
+        try:
+            if not self._log_path_ready:
+                d = os.path.dirname(self.log_path)
+                if d:
+                    os.makedirs(d, exist_ok=True)
+                self._log_path_ready = True
+            record = {"global_step": int(getattr(state, "global_step", 0))}
+            for k, v in aggregated.items():
+                # Only JSON-serializable scalars; cast tensors/numpy to float.
+                try:
+                    record[k] = float(v)
+                except (TypeError, ValueError):
+                    # Skip non-scalar entries silently — the viewer only
+                    # plots scalar series anyway.
+                    continue
+            with open(self.log_path, "a", encoding="utf-8") as f:
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        except Exception:
+            # Never let logging IO crash training.
+            logger.exception("[InternalMedicine] failed to append jsonl record")
 
 
 class EMAStateAssemblerCallback(TrainerCallback):


### PR DESCRIPTION
### PR types
New features

### PR changes
APIs

### Description
增强 InternalMedicine 监控的可控性与可观测性，便于配合 `tools/internal_medicine/server.py` 查看训练过程指标。

**主要改动**

1. `internal_medicine_monitor_interval` 语义调整（`paddleformers/cli/hparams/finetuning_args.py`）
   - 类型由 `int` 改为 `Optional[int]`，默认值 `None`。
   - `0`：彻底关闭 internal-medicine 监控（不注册 callback、不采集、不落盘）。
   - 正整数：按该间隔采样。
   - 未设置：默认 `1`，并在 callback 中打印 warning 提示。
   - 校验逻辑由 `< 1` 改为 `< 0`，允许 `0`。

2. 新增 `internal_medicine_log_dir` 参数
   - 指定 rank 0 写入的 per-step JSONL 目录，文件名固定为 `internal_medicine.jsonl`。
   - 为空时回退到 `output_dir`。

3. Trainer 接入逻辑（`paddleformers/trainer/trainer.py`）
   - 当 `internal_medicine_monitors` 启用且 `interval != 0` 时才注册 `InternalMedicineCallback`。
   - 解析并向下传递 `log_dir`。

4. `InternalMedicineCallback` 落盘能力（`paddleformers/trainer/trainer_callback.py`）
   - 新增 `log_dir` 构造参数，懒解析 writer：仅 global rank 0 写文件，避免多卡冲突。
   - `on_log` 不再把聚合指标塞回 `logs`，改为追加写入 `internal_medicine.jsonl`，每行一条带 `global_step` 的 JSON 记录。
   - 非标量字段安全跳过；IO 异常仅记录日志，不影响训练。

### Usage
```yaml
# 关闭监控
internal_medicine_monitor_interval: 0

# 启用并自定义日志目录
internal_medicine_monitors: "qk_stats,moe_health"
internal_medicine_monitor_interval: 10
internal_medicine_log_dir: "/path/to/logs"   # 留空则使用 output_dir