### PR TITLE
add swa_high_precision_norm

### DIFF
--- a/paddleformers/transformers/configuration_utils.py
+++ b/paddleformers/transformers/configuration_utils.py
@@ -503,6 +503,12 @@ class LlmMetaConfig:
             "Whether to use high precision ROPEs.",
         ),
         (
+            "swa_high_precision_norm",
+            bool,
+            False,
+            "Whether to use high precision NORMS in DSV4 SWA. ONLY support for dsv4_hybrid_attention.",
+        ),
+        (
             "gated_linear_unit",
             bool,
             True,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->

> 新增swa 中norm高精模式，支持qkv进行norm与rope的计算过程中以fp32进行，以支持训推一致。

**新增开关：**
+ swa_high_precision_norm：在QKV的Norm过程中，计算应用fp32，返回时重新cast回原有精度，如bf16。

**备注**
当swa_high_precision_norm开启，kv的rms_norm将在fp32下进行，并返回kv为fp32