### PR TITLE
[FC] Fix EMA save

### DIFF
--- a/paddleformers/trainer/utils/zero_cost_checkpoint.py
+++ b/paddleformers/trainer/utils/zero_cost_checkpoint.py
@@ -1529,7 +1529,8 @@ class EMABuffer(ABC):
                 del ema_tensor
 
             if self.offload:
-                v_pin = v.pin_memory()
+                src = v.detach() if isinstance(v, paddle.base.framework.EagerParamBase) else v
+                v_pin = src.pin_memory()
                 v_pin.name = v.name
                 v = v_pin
             ema_state_dict[k] = v


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
问题：开启 ZCC 保存 EMA 时报错 cannot pickle 'paddle.base.libpaddle.ProcessGroupNCCL' object。
分析：EMA 累加时对参数做 pin_memory()，会 deepcopy。但 EagerParamBase 含不可序列化的 ProcessGroupNCCL，故报错。
修复：pin_memory() 前先做一下 detach()，再做 pin。不影响 EMA 整体的保存逻辑。