### PR TITLE
[fix] internal_medicine_monitor_interval default to 0 (disabled)

### DIFF
--- a/paddleformers/cli/hparams/finetuning_args.py
+++ b/paddleformers/cli/hparams/finetuning_args.py
@@ -77,13 +77,12 @@ class PreTrainingArguments(TrainingArguments):
             "help": "Comma-separated list of internal medicine monitors. Options: qk_stats,moe_health,massive_act,all"
         },
     )
-    internal_medicine_monitor_interval: Optional[int] = field(
-        default=None,
+    internal_medicine_monitor_interval: int = field(
+        default=0,
         metadata={
             "help": "Step interval for internal medicine monitors. "
-            "0 disables monitoring (no collection, no viewer). "
-            "Positive integer is the sampling interval. "
-            "Omitted -> defaults to 1 with a warning."
+            "0 (default) disables monitoring (no collection, no viewer). "
+            "Positive integer is the sampling interval."
         },
     )
     internal_medicine_qk_row_stride: int = field(

--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -499,16 +499,15 @@ class Trainer:
         default_callbacks = DEFAULT_CALLBACKS.copy()
 
         _im_monitors = getattr(self.args, "internal_medicine_monitors", "")
-        _im_interval = getattr(self.args, "internal_medicine_monitor_interval", None)
-        if _im_monitors and _im_interval != 0:
-            # Resolve the metrics log directory: explicit -> use as-is; empty -> output_dir.
+        _im_interval = int(getattr(self.args, "internal_medicine_monitor_interval", 0) or 0)
+        if _im_monitors and _im_interval > 0:
             _im_log_dir = (
                 getattr(self.args, "internal_medicine_log_dir", "") or getattr(self.args, "output_dir", "") or "."
             )
             default_callbacks.append(
                 InternalMedicineCallback(
                     monitors=_im_monitors,
-                    monitor_interval=_im_interval,  # None -> callback warns + uses 1
+                    monitor_interval=_im_interval,
                     qk_row_stride=getattr(self.args, "internal_medicine_qk_row_stride", 1),
                     log_dir=_im_log_dir,
                 )

--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -499,7 +499,13 @@ class Trainer:
         default_callbacks = DEFAULT_CALLBACKS.copy()
 
         _im_monitors = getattr(self.args, "internal_medicine_monitors", "")
-        _im_interval = int(getattr(self.args, "internal_medicine_monitor_interval", 0) or 0)
+        _im_interval = getattr(self.args, "internal_medicine_monitor_interval", 0)
+        if _im_interval is None:
+            raise ValueError(
+                "internal_medicine_monitor_interval is None. Expected int "
+                "(0 to disable monitoring, positive int for sampling interval). "
+            )
+        _im_interval = int(_im_interval)
         if _im_monitors and _im_interval > 0:
             _im_log_dir = (
                 getattr(self.args, "internal_medicine_log_dir", "") or getattr(self.args, "output_dir", "") or "."

--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -500,12 +500,15 @@ class Trainer:
 
         _im_monitors = getattr(self.args, "internal_medicine_monitors", "")
         _im_interval = getattr(self.args, "internal_medicine_monitor_interval", 0)
-        if _im_interval is None:
-            raise ValueError(
-                "internal_medicine_monitor_interval is None. Expected int "
-                "(0 to disable monitoring, positive int for sampling interval). "
-            )
-        _im_interval = int(_im_interval)
+        if _im_monitors:
+            if _im_interval is None:
+                raise ValueError(
+                    "internal_medicine_monitor_interval is None. Expected int "
+                    "(0 to disable monitoring, positive int for sampling interval). "
+                )
+            _im_interval = int(_im_interval)
+        else:
+            _im_interval = 0
         if _im_monitors and _im_interval > 0:
             _im_log_dir = (
                 getattr(self.args, "internal_medicine_log_dir", "") or getattr(self.args, "output_dir", "") or "."

--- a/paddleformers/trainer/trainer_callback.py
+++ b/paddleformers/trainer/trainer_callback.py
@@ -938,20 +938,14 @@ class InternalMedicineCallback(TrainerCallback):
     def __init__(
         self,
         monitors=None,
-        monitor_interval=None,
+        monitor_interval=0,
         verbose: bool = True,
         qk_row_stride: int = 1,
         log_dir: str = "",
     ):
         super().__init__()
         self.monitors = self._normalize_monitors(monitors)
-        if monitor_interval is None:
-            logger.warning(
-                "[InternalMedicine] internal_medicine_monitor_interval not set; defaulting to 1. "
-                "Set it to 0 in your yaml to disable internal-medicine monitoring entirely."
-            )
-            monitor_interval = 1
-        self.monitor_interval = int(monitor_interval)
+        self.monitor_interval = int(monitor_interval) if monitor_interval else 0
         self.verbose = verbose
         self.qk_row_stride = qk_row_stride
         self.log_dir = log_dir or ""
@@ -974,6 +968,12 @@ class InternalMedicineCallback(TrainerCallback):
 
     def on_train_begin(self, args, state, control, model=None, **kwargs):
         if model is None or self._setup_done or not self.monitors:
+            return
+        if self.monitor_interval <= 0:
+            logger.warning(
+                "[InternalMedicine] monitor_interval=%s is non-positive; skipping monitor setup.",
+                self.monitor_interval,
+            )
             return
 
         self._maybe_truncate_on_resume(state)


### PR DESCRIPTION
## 背景

CI 报错：`TypeError: unsupported operand type(s) for %: 'int' and 'NoneType'` at `base_monitor.py:66` —— `internal_medicine_monitor_interval` 默认 None，泄漏到 `Probe.monitor_interval`，取模崩溃。

## 改动

`InternalMedicineCallback.__init__` 里 `monitor_interval` 默认值从 `None` 改为 `0`，去掉 None→1 的自动兜底。yaml 未显式设置 interval 时，语义从"默认每步监控"变为"默认关闭"，与 trainer.py 里 `_im_interval != 0` 的 gate 对齐。

## 行为变化

- 显式写 `internal_medicine_monitor_interval: N (N>0)`：不受影响
- 未写：之前 → 默认每步监控；现在 → 默认关闭（显式 opt-in）

## 配套 PR

llm-internal-medicine: [https://github.com/bo-ke/llm-internal-medicine/pull/13] — `_should_monitor` 加防御性检查，兜底 0/None。
