### PR TITLE
Propagate Kimi accuracy-compatible flag to PaddleFleet provider

### DIFF
--- a/paddleformers/transformers/kimi_k2/modeling.py
+++ b/paddleformers/transformers/kimi_k2/modeling.py
@@ -33,6 +33,12 @@ class KimiK2Provider(GPTModelProvider):
     def __post_init__(config):
         super().__post_init__()
         if getattr(config, "use_accuracy_compatible", False):
+            if getattr(config, "sequence_parallel", False) and getattr(config, "multi_latent_attention", False):
+                raise ValueError(
+                    "use_accuracy_compatible=True maps to PaddleFleet "
+                    "gpt_model_use_experimental_version, which does not "
+                    "support Kimi-K2 MLA with sequence_parallel=True."
+                )
             # PaddleFleet still uses this internal flag for several
             # precision-alignment branches. Keep the public PaddleFormers
             # knob as the single user-facing gate.

--- a/paddleformers/transformers/kimi_k2/modeling.py
+++ b/paddleformers/transformers/kimi_k2/modeling.py
@@ -32,6 +32,11 @@ class KimiK2Provider(GPTModelProvider):
 
     def __post_init__(config):
         super().__post_init__()
+        if getattr(config, "use_accuracy_compatible", False):
+            # PaddleFleet still uses this internal flag for several
+            # precision-alignment branches. Keep the public PaddleFormers
+            # knob as the single user-facing gate.
+            config.gpt_model_use_experimental_version = True
 
 
 class KimiK2PretrainedModel(PretrainedModel):


### PR DESCRIPTION
## Summary
- when KimiK2Provider receives use_accuracy_compatible=True, also set the PaddleFleet internal gpt_model_use_experimental_version flag
- keeps the public PaddleFormers knob as the single user-facing accuracy gate

## Validation
- python -m py_compile paddleformers/transformers/kimi_k2/modeling.py
- used in the Kimi reduced-checkpoint alignment workspace together with PaddleFleet accuracy-compatible paths