### PR TITLE
[fix] Rotate pre-existing internal_medicine.jsonl on fresh start

### DIFF
--- a/paddleformers/trainer/trainer_callback.py
+++ b/paddleformers/trainer/trainer_callback.py
@@ -1053,13 +1053,31 @@ class InternalMedicineCallback(TrainerCallback):
         return self._is_writer
 
     def _maybe_truncate_on_resume(self, state):
-        """Drop rows with global_step > resume_step from the jsonl on resume."""
+        """Handle a pre-existing jsonl at setup time.
+
+        - Fresh start (resume_step == 0) with a leftover jsonl from a previous
+          run: rotate it aside to <log_path>.bak.<YYYYMMDD_HHMMSS> so the new
+          run starts with a clean file and the viewer isn't confused by a
+          non-monotonic global_step axis.
+        - Real resume from checkpoint (resume_step > 0): keep rows with
+          global_step <= resume_step, drop the tail (any "future" rows past
+          the checkpoint), same behavior as before.
+        """
         if not self._resolve_writer():
+            return
+        if not self.log_path or not os.path.exists(self.log_path):
             return
         resume_step = int(getattr(state, "global_step", 0) or 0)
         if resume_step <= 0:
-            return
-        if not self.log_path or not os.path.exists(self.log_path):
+            try:
+                bak = f"{self.log_path}.bak.{time.strftime('%Y%m%d_%H%M%S')}"
+                os.replace(self.log_path, bak)
+                logger.info(
+                    "[InternalMedicine] rotated pre-existing jsonl to %s (fresh start)",
+                    bak,
+                )
+            except Exception:
+                logger.error("[InternalMedicine] failed to rotate pre-existing jsonl")
             return
         try:
             kept = []

--- a/paddleformers/trainer/trainer_callback.py
+++ b/paddleformers/trainer/trainer_callback.py
@@ -1070,7 +1070,12 @@ class InternalMedicineCallback(TrainerCallback):
         resume_step = int(getattr(state, "global_step", 0) or 0)
         if resume_step <= 0:
             try:
-                bak = f"{self.log_path}.bak.{time.strftime('%Y%m%d_%H%M%S')}"
+                ts = time.strftime("%Y%m%d_%H%M%S")
+                bak = f"{self.log_path}.bak.{ts}"
+                suffix = 1
+                while os.path.exists(bak):
+                    bak = f"{self.log_path}.bak.{ts}.{suffix}"
+                    suffix += 1
                 os.replace(self.log_path, bak)
                 logger.info(
                     "[InternalMedicine] rotated pre-existing jsonl to %s (fresh start)",


### PR DESCRIPTION
### PR types

Bug fixes

### PR changes

APIs

### Description

**问题**

`InternalMedicineCallback._maybe_truncate_on_resume` 目前只处理 `resume_from_checkpoint` 场景（`state.global_step > 0`）。当 fresh restart（`state.global_step == 0`）且已有前一次 crash / Ctrl+C 中断留下的老 jsonl 时，新 run 会直接在老 step-58 行之后 append 新 step-1 行，导致 `global_step` 轴出现非单调，viewer 画图时曲线错乱：

```
L1-58:  first run,  global_step 1 → 58   （Ctrl+C 中断）
L59+:   second run, global_step 1 → ...  （fresh 起，无 checkpoint）
```

**修复**

`resume_step == 0` 时，若已存在老 jsonl，则将其 rotate 为 `<log_path>.bak.<YYYYMMDD_HHMMSS>`，新 run 从空文件开始写；`resume_step > 0`（真正的 checkpoint resume）路径不变，仍然截尾保留 `global_step <= resume_step` 的行。

老数据**不删除**，只是改名备份到 `.bak.*` 文件；用户仍可从这些文件里查看历史数据。

**行为矩阵**

| resume_step | 老 jsonl 是否存在 | 新行为 |
|-------------|------------------|--------|
| 0（fresh）   | 否               | 无操作 |
| 0（fresh）   | 是               | rotate 老文件到 `.bak.<ts>`，新 run 从空文件开始 |
| > 0（ckpt）  | 否               | 无操作 |
| > 0（ckpt）  | 是               | 截尾保留 `global_step <= resume_step` 的行（原有逻辑） |