### PR TITLE
[DSV4] Respect padding_free for Fleet SFT max sequence length

### DIFF
--- a/paddleformers/cli/train/sft/workflow.py
+++ b/paddleformers/cli/train/sft/workflow.py
@@ -626,8 +626,11 @@ def run_sft(
             max_seq_len = data_args.max_seq_len
             logger.warning(f"Setting max_seq_len to {max_seq_len} for mbs > 1 using PaddleFleet model.")
         else:
-            max_seq_len = None
-            logger.warning("Setting max_seq_len to None for mbs = 1 using PaddleFleet Model.")
+            max_seq_len = None if data_args.padding_free else data_args.max_seq_len
+            logger.warning(
+                f"Setting max_seq_len to {max_seq_len} for mbs = 1 using PaddleFleet model "
+                f"with padding_free={data_args.padding_free}."
+            )
     else:
         max_seq_len = (
             data_args.max_seq_len


### PR DESCRIPTION
#### Before submitting

- [x] Python syntax checked with python -m py_compile
- [x] Diff whitespace checked with git diff --check

### PR types

Bug fixes

### PR changes

APIs

### Description

For PaddleFleet SFT with micro batch size 1, the workflow previously set the collator max sequence length to None unconditionally. As a result, padding_free=false could not make the collator honor the configured max_seq_len.

This change keeps max_seq_len=None when padding_free is enabled, and uses data_args.max_seq_len otherwise. The warning now reports both the selected length and padding_free value.

This preserves dynamic-length collation for padding-free training while allowing fixed-length workloads to pad to their configured sequence length.

Validation:
- python -m py_compile paddleformers/cli/train/sft/workflow.py
- git diff --check
