### PR TITLE
Expose DeepSeek V4 IndexCache training configuration

### DIFF
--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -1290,6 +1290,14 @@ class Trainer:
                 worker_groups=worker_groups,
             )
 
+            if self.args.tensorwise_offload_optimizer:
+                logger.info("Offloading master weights before loading optimizer state for FC...")
+                for v in master_weights.values():
+                    offload(v.local_tensor)
+                gc.collect()
+                if paddle.is_compiled_with_cuda():
+                    paddle.device.cuda.empty_cache()
+
             if not self.args.ignore_load_lr_and_optim:
                 dist.load_state_dict(
                     opt_states,

--- a/paddleformers/transformers/deepseek_v4/configuration.py
+++ b/paddleformers/transformers/deepseek_v4/configuration.py
@@ -111,6 +111,8 @@ class DeepseekV4Config(PretrainedConfig):
         "index_n_heads": "dsa_index_n_heads",
         "index_head_dim": "dsa_index_head_dim",
         "index_topk": "dsa_index_topk",
+        "index_topk_pattern": "index_topk_pattern",
+        "indexcache_multi_layer_distill": "indexcache_multi_layer_distill",
     }
 
     def __init__(
@@ -150,6 +152,8 @@ class DeepseekV4Config(PretrainedConfig):
         dsa_index_n_heads=64,
         dsa_index_head_dim=128,
         dsa_index_topk=512,
+        index_topk_pattern=None,
+        indexcache_multi_layer_distill=False,
         dsa_indexer_loss_coeff=0.01,
         dsa_indexer_use_sparse_loss=True,
         # === mHC (Hyper-Connection) ===
@@ -250,6 +254,8 @@ class DeepseekV4Config(PretrainedConfig):
         self.dsa_index_n_heads = dsa_index_n_heads
         self.dsa_index_head_dim = dsa_index_head_dim
         self.dsa_index_topk = dsa_index_topk
+        self.index_topk_pattern = index_topk_pattern
+        self.indexcache_multi_layer_distill = indexcache_multi_layer_distill
         self.dsa_indexer_loss_coeff = dsa_indexer_loss_coeff
         self.dsa_indexer_use_sparse_loss = dsa_indexer_use_sparse_loss
 

--- a/paddleformers/transformers/deepseek_v4/modeling.py
+++ b/paddleformers/transformers/deepseek_v4/modeling.py
@@ -72,6 +72,8 @@ class DeepseekV4ModelProvider(GPTModelProvider):
         "index_n_heads": "dsa_index_n_heads",
         "index_head_dim": "dsa_index_head_dim",
         "index_topk": "dsa_index_topk",
+        "index_topk_pattern": "index_topk_pattern",
+        "indexcache_multi_layer_distill": "indexcache_multi_layer_distill",
     }
 
 


### PR DESCRIPTION
## Summary

- expose `index_topk_pattern` and `indexcache_multi_layer_distill` through `DeepseekV4Config`
- forward both fields through `DeepseekV4ModelProvider` transform rules
- offload tensorwise optimizer master weights before loading optimizer state during full-state resume, reducing the temporary memory peak

## Baseline

- base: `PaddlePaddle/PaddleFormers:release/1.2`
- base commit: `f8320e0c25c257f786099002a07acfb7dbdb07ac`
- head commit: `0af50b5fe3333fe7f9247918ef908ab431fd1ebc`

## Scope

- 2 commits
- 3 files
- 16 insertions

The core IndexCache producer/reuse and multi-layer distillation implementation lives in PaddleFleet. This PR contains the PaddleFormers configuration bridge and the optimizer-resume safeguard used by the current training path.

## Validation

- `git diff --check origin/release/1.2...HEAD`
- syntax compilation of all 3 changed Python files
- instantiated `DeepseekV4Config(index_topk_pattern="FSS", indexcache_multi_layer_distill=True)` and verified both fields

Draft PR for reviewing the current integration shape before deciding whether and how to split the changes for upstream submission.