### PR TITLE
[TeleChat]: add TeleChat causal language model support

### DIFF
--- a/paddleformers/cli/utils/llm_utils.py
+++ b/paddleformers/cli/utils/llm_utils.py
@@ -423,6 +423,15 @@ def get_lora_target_modules(model):
             ".*mlp.fc1.*",
             ".*mlp.fc2.*",
         ]
+    elif model.config.model_type == "telechat":
+        target_modules = [
+            ".*query.*",
+            ".*key_value.*",
+            ".*dense.*",
+            ".*gate_proj.*",
+            ".*up_proj.*",
+            ".*down_proj.*",
+        ]
     elif model.config.model_type == "glm4v_moe":
         target_modules = [
             # language_model

--- a/paddleformers/datasets/template/template.py
+++ b/paddleformers/datasets/template/template.py
@@ -665,6 +665,15 @@ register_template(
 )
 
 
+register_template(
+    name="telechat",
+    format_user=StringFormatter(slots=["<_user>{{content}}<_bot>"]),
+    format_assistant=StringFormatter(slots=["{{content}}"]),
+    suffix=["<_end>"],
+    chat_sep="<_end>",
+)
+
+
 # copied from qwen template
 register_template(
     name="qwen3",

--- a/paddleformers/transformers/__init__.py
+++ b/paddleformers/transformers/__init__.py
@@ -173,6 +173,10 @@ import_structure = {
     "paddleocr_vl.processor": ["PaddleOCRVLProcessor"],
     "gpt_oss.configuration": ["GptOssConfig"],
     "gpt_oss.modeling": ["GptOssModel", "GptOssForCausalLM", "GptOssForCausalLMPipe"],
+
+    "telechat.configuration": ["TelechatConfig"],
+    "telechat.modeling": ["TelechatModel", "TelechatForCausalLM"],
+
     "minicpm3.configuration": ["MiniCPM3Config"],
     "minicpm3.modeling": [
         "MiniCPMDecoderLayer",
@@ -189,6 +193,7 @@ import_structure = {
         "GraniteForCausalLM",
         "GraniteForCausalLMPipe",
     ],
+
     "kimi_k25.vision_processor": ["KimiK25VisionProcessor"],
     "kimi_k25.processor": ["KimiK25Processor"],
     "kimi_k25.tokenizer": ["TikTokenTokenizer"],
@@ -351,6 +356,7 @@ import_structure = {
         "Qwen3NextPretrainingCriterion",
     ],
     "llama": [],
+    "telechat": [],
     "qwen2": [],
     "glm_ocr": [],
     "qwen3": [],
@@ -517,6 +523,7 @@ if TYPE_CHECKING:
     from .kimi_k3 import *
     from .paddleocr_vl import *
     from .llama import *
+    from .telechat import *
     from .optimization import *
     from .qwen2 import *
     from .qwen2_5_vl import *

--- a/paddleformers/transformers/__init__.py
+++ b/paddleformers/transformers/__init__.py
@@ -173,10 +173,8 @@ import_structure = {
     "paddleocr_vl.processor": ["PaddleOCRVLProcessor"],
     "gpt_oss.configuration": ["GptOssConfig"],
     "gpt_oss.modeling": ["GptOssModel", "GptOssForCausalLM", "GptOssForCausalLMPipe"],
-
     "telechat.configuration": ["TelechatConfig"],
     "telechat.modeling": ["TelechatModel", "TelechatForCausalLM"],
-
     "minicpm3.configuration": ["MiniCPM3Config"],
     "minicpm3.modeling": [
         "MiniCPMDecoderLayer",
@@ -193,7 +191,6 @@ import_structure = {
         "GraniteForCausalLM",
         "GraniteForCausalLMPipe",
     ],
-
     "kimi_k25.vision_processor": ["KimiK25VisionProcessor"],
     "kimi_k25.processor": ["KimiK25Processor"],
     "kimi_k25.tokenizer": ["TikTokenTokenizer"],

--- a/paddleformers/transformers/auto/configuration.py
+++ b/paddleformers/transformers/auto/configuration.py
@@ -43,6 +43,7 @@ CONFIG_MAPPING_NAMES = OrderedDict(
         ("ernie4_5_moe_vl", "Ernie4_5_VLConfig"),
         ("paddleocr_vl", "PaddleOCRVLConfig"),
         ("llama", "LlamaConfig"),
+        ("telechat", "TelechatConfig"),
         ("kimi_k2", "KimiK2Config"),
         ("kimi_k3", "KimiK3Config"),
         ("qwen2", "Qwen2Config"),
@@ -98,6 +99,8 @@ MODEL_NAMES_MAPPING = OrderedDict(
         ("ernie4_5_moe_vl", "Ernie4_5_VLMoeForConditionalGeneration"),
         ("paddleocr_vl", "PaddleOCRVLForConditionalGeneration"),
         ("llama", "Llama"),
+
+        ("telechat", "TelechatModel"),
         ("kimi_k3", "KimiK3"),
         ("qwen2", "Qwen2"),
         ("qwen2_5_vl", "Qwen2_5_VL"),

--- a/paddleformers/transformers/auto/configuration.py
+++ b/paddleformers/transformers/auto/configuration.py
@@ -99,7 +99,6 @@ MODEL_NAMES_MAPPING = OrderedDict(
         ("ernie4_5_moe_vl", "Ernie4_5_VLMoeForConditionalGeneration"),
         ("paddleocr_vl", "PaddleOCRVLForConditionalGeneration"),
         ("llama", "Llama"),
-
         ("telechat", "TelechatModel"),
         ("kimi_k3", "KimiK3"),
         ("qwen2", "Qwen2"),

--- a/paddleformers/transformers/auto/modeling.py
+++ b/paddleformers/transformers/auto/modeling.py
@@ -63,6 +63,7 @@ MAPPING_NAMES = OrderedDict(
         ("Ernie4_5_VLMoe", "ernie4_5_moe_vl"),
         ("PaddleOCRVL", "paddleocr_vl"),
         ("Llama", "llama"),
+        ("Telechat", "telechat"),
         ("KimiK2", "kimi_k2"),
         ("KimiK3", "kimi_k3"),
         ("Qwen2", "qwen2"),

--- a/paddleformers/transformers/telechat/__init__.py
+++ b/paddleformers/transformers/telechat/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+import sys
+from typing import TYPE_CHECKING
+
+from ...utils.lazy_import import _LazyModule
+
+_import_structure = {
+    "configuration": ["TelechatConfig"],
+    "modeling": ["TelechatModel", "TelechatForCausalLM"],
+}
+
+if TYPE_CHECKING:
+    from .configuration import *
+    from .modeling import *
+else:
+    sys.modules[__name__] = _LazyModule(__name__, globals()["__file__"], _import_structure, module_spec=__spec__)

--- a/paddleformers/transformers/telechat/configuration.py
+++ b/paddleformers/transformers/telechat/configuration.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..configuration_utils import PretrainedConfig
+
+
+class TelechatConfig(PretrainedConfig):
+    model_type = "telechat"
+    attribute_map = {"num_hidden_layers": "n_layer", "num_attention_heads": "n_head"}
+
+    def __init__(
+        self,
+        vocab_size=120000,
+        hidden_size=2048,
+        ffn_hidden_size=5460,
+        n_layer=16,
+        n_head=32,
+        layer_norm_epsilon=1e-5,
+        initializer_range=0.02,
+        hidden_dropout=0.0,
+        attention_dropout=0.0,
+        use_cache=True,
+        training_seqlen=8192,
+        base_seqlen=8192,
+        embed_layernorm=False,
+        apply_residual_connection_post_layernorm=False,
+        pad_token_id=3,
+        bos_token_id=1,
+        eos_token_id=2,
+        tie_word_embeddings=False,
+        **kwargs,
+    ):
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.ffn_hidden_size = ffn_hidden_size
+        self.n_layer = n_layer
+        self.n_head = n_head
+        self.layer_norm_epsilon = layer_norm_epsilon
+        self.initializer_range = initializer_range
+        self.hidden_dropout = hidden_dropout
+        self.attention_dropout = attention_dropout
+        self.use_cache = use_cache
+        self.training_seqlen = training_seqlen
+        self.base_seqlen = base_seqlen
+        self.embed_layernorm = embed_layernorm
+        self.apply_residual_connection_post_layernorm = apply_residual_connection_post_layernorm
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )

--- a/paddleformers/transformers/telechat/modeling.py
+++ b/paddleformers/transformers/telechat/modeling.py
@@ -1,0 +1,379 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+import paddle.nn.functional as F
+from paddle import nn
+
+from ...nn.attention.interface import ALL_ATTENTION_FUNCTIONS
+from ...nn.embedding import Embedding as GeneralEmbedding
+from ...nn.linear import Linear as GeneralLinear
+from ..cache_utils import DynamicCache
+from ..masking_utils import create_causal_mask_and_row_indices
+from ..model_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
+from ..model_utils import PretrainedModel, register_base_model
+from .configuration import TelechatConfig
+
+
+def rotate_half(x):
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return paddle.concat((-x2, x1), axis=-1)
+
+
+def apply_rotary_pos_emb(q, k, cos, sin):
+    cos = cos.unsqueeze(1)
+    sin = sin.unsqueeze(1)
+    dtype = q.dtype
+    q = q.astype("float32")
+    k = k.astype("float32")
+    return (q * cos + rotate_half(q) * sin).astype(dtype), (k * cos + rotate_half(k) * sin).astype(dtype)
+
+
+class TelechatRotaryEmbedding(nn.Layer):
+    def __init__(self, config):
+        super().__init__()
+        self.head_dim = config.hidden_size // config.n_head
+        inv_freq = 1.0 / (10000.0 ** (paddle.arange(0, self.head_dim, 2, dtype="float32") / self.head_dim))
+        self.register_buffer("inv_freq", inv_freq, persistable=False)
+
+    def forward(self, x, position_ids):
+        freqs = position_ids.astype("float32").unsqueeze(-1) * self.inv_freq.reshape([1, 1, -1])
+        emb = paddle.concat((freqs, freqs), axis=-1)
+        return emb.cos().astype(x.dtype), emb.sin().astype(x.dtype)
+
+
+class TelechatRMSNorm(nn.Layer):
+    def __init__(self, hidden_size, eps):
+        super().__init__()
+        self.weight = paddle.create_parameter(
+            shape=[hidden_size], dtype=paddle.get_default_dtype(), default_initializer=nn.initializer.Constant(1.0)
+        )
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states):
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.astype("float32")
+        variance = hidden_states.pow(2).mean(axis=-1, keepdim=True)
+        hidden_states = hidden_states * paddle.rsqrt(variance + self.variance_epsilon)
+        return hidden_states.astype(input_dtype) * self.weight.astype(input_dtype)
+
+
+class TelechatAttention(nn.Layer):
+    def __init__(self, config, layer_idx):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.head_dim = config.hidden_size // config.n_head
+        if self.head_dim * config.n_head != config.hidden_size:
+            raise ValueError("hidden_size must be divisible by n_head")
+        if config.tensor_model_parallel_size > 1:
+            if config.n_head % config.tensor_model_parallel_size != 0:
+                raise ValueError("n_head must be divisible by tensor_model_parallel_size")
+            self.num_heads = config.n_head // config.tensor_model_parallel_size
+        else:
+            self.num_heads = config.n_head
+        self.scaling = self.head_dim**-0.5
+        self.attention_dropout = config.attention_dropout
+        self.query = GeneralLinear.create(
+            config.hidden_size, config.hidden_size, has_bias=False, config=config, tp_plan="colwise"
+        )
+        self.key_value = GeneralLinear.create(
+            config.hidden_size, 2 * config.hidden_size, has_bias=False, config=config, tp_plan="colwise"
+        )
+        self.dense = GeneralLinear.create(
+            config.hidden_size, config.hidden_size, has_bias=True, config=config, tp_plan="rowwise"
+        )
+
+    def forward(
+        self,
+        hidden_states,
+        attention_mask=None,
+        attn_mask_startend_row_indices=None,
+        position_embeddings=None,
+        past_key_values=None,
+    ):
+        batch_size, seq_len, _ = hidden_states.shape
+        query_states = (
+            self.query(hidden_states)
+            .reshape([batch_size, seq_len, self.num_heads, self.head_dim])
+            .transpose([0, 2, 1, 3])
+        )
+        key_value_states = self.key_value(hidden_states).reshape(
+            [batch_size, seq_len, self.num_heads, 2, self.head_dim]
+        )
+        key_states = key_value_states[:, :, :, 0, :].transpose([0, 2, 1, 3])
+        value_states = key_value_states[:, :, :, 1, :].transpose([0, 2, 1, 3])
+        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, *position_embeddings)
+        if past_key_values is not None:
+            key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
+        attention_interface = ALL_ATTENTION_FUNCTIONS["sdpa"]
+        attn_output, _ = attention_interface(
+            self,
+            query=query_states,
+            key=key_states,
+            value=value_states,
+            attention_mask=attention_mask,
+            attn_mask_startend_row_indices=attn_mask_startend_row_indices,
+            dropout=self.attention_dropout if self.training else 0.0,
+            scaling=self.scaling,
+        )
+        return self.dense(attn_output.reshape([batch_size, seq_len, -1]))
+
+
+class TelechatMLP(nn.Layer):
+    def __init__(self, config):
+        super().__init__()
+        self.gate_proj = GeneralLinear.create(
+            config.hidden_size, config.ffn_hidden_size, has_bias=False, config=config, tp_plan="colwise"
+        )
+        self.up_proj = GeneralLinear.create(
+            config.hidden_size, config.ffn_hidden_size, has_bias=False, config=config, tp_plan="colwise"
+        )
+        self.down_proj = GeneralLinear.create(
+            config.ffn_hidden_size, config.hidden_size, has_bias=True, config=config, tp_plan="rowwise"
+        )
+
+    def forward(self, hidden_states):
+        return self.down_proj(F.silu(self.gate_proj(hidden_states)) * self.up_proj(hidden_states))
+
+
+class TelechatDecoderLayer(nn.Layer):
+    def __init__(self, config, layer_idx):
+        super().__init__()
+        self.self_attention = TelechatAttention(config, layer_idx)
+        self.input_layernorm = TelechatRMSNorm(config.hidden_size, config.layer_norm_epsilon)
+        self.post_attention_layernorm = TelechatRMSNorm(config.hidden_size, config.layer_norm_epsilon)
+        self.mlp = TelechatMLP(config)
+
+    def forward(
+        self,
+        hidden_states,
+        attention_mask=None,
+        attn_mask_startend_row_indices=None,
+        position_embeddings=None,
+        past_key_values=None,
+    ):
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states = residual + self.self_attention(
+            hidden_states, attention_mask, attn_mask_startend_row_indices, position_embeddings, past_key_values
+        )
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        return residual + self.mlp(hidden_states)
+
+
+class TelechatPretrainedModel(PretrainedModel):
+    config_class = TelechatConfig
+    base_model_prefix = "transformer"
+    transpose_weight_keys = ["query", "key_value", "dense", "gate_proj", "up_proj", "down_proj", "lm_head"]
+
+    @classmethod
+    def _gen_aoa_config(cls, config):
+        prefix = "" if cls == cls.base_model_class else "transformer."
+        statements = [
+            f"transformer.word_embeddings.weight -> {prefix}embed_tokens.weight",
+            f"transformer.ln_f.weight -> {prefix}norm.weight",
+            f"transformer.h.$LAYER_ID.input_layernorm.weight -> {prefix}layers.$LAYER_ID.input_layernorm.weight",
+            f"transformer.h.$LAYER_ID.post_attention_layernorm.weight -> {prefix}layers.$LAYER_ID.post_attention_layernorm.weight",
+        ]
+        for name in ("query", "key_value", "dense", "gate_proj", "up_proj", "down_proj"):
+            statements.append(
+                f"transformer.h.$LAYER_ID.{('self_attention' if name in ('query', 'key_value', 'dense') else 'mlp')}.{name}.weight^T -> {prefix}layers.$LAYER_ID.{('self_attention' if name in ('query', 'key_value', 'dense') else 'mlp')}.{name}.weight"
+            )
+        statements.append(
+            f"transformer.h.$LAYER_ID.self_attention.dense.bias -> {prefix}layers.$LAYER_ID.self_attention.dense.bias"
+        )
+        statements.append(f"transformer.h.$LAYER_ID.mlp.down_proj.bias -> {prefix}layers.$LAYER_ID.mlp.down_proj.bias")
+        if cls != cls.base_model_class:
+            statements.append("lm_head.weight^T -> lm_head.weight")
+        return {"aoa_statements": statements}
+
+    def _init_weights(self, layer):
+        if isinstance(layer, (nn.Linear, nn.Embedding)):
+            layer.weight.set_value(paddle.normal(0.0, self.config.initializer_range, layer.weight.shape))
+            if getattr(layer, "bias", None) is not None:
+                layer.bias.set_value(paddle.zeros_like(layer.bias))
+
+
+@register_base_model
+class TelechatModel(TelechatPretrainedModel):
+    def __init__(self, config):
+        super().__init__(config)
+        self.embed_tokens = GeneralEmbedding.create(
+            config, config.vocab_size, config.hidden_size, padding_idx=config.pad_token_id
+        )
+        self.embed_layernorm = (
+            TelechatRMSNorm(config.hidden_size, config.layer_norm_epsilon) if config.embed_layernorm else None
+        )
+        self.layers = nn.LayerList([TelechatDecoderLayer(config, i) for i in range(config.n_layer)])
+        self.norm = TelechatRMSNorm(config.hidden_size, config.layer_norm_epsilon)
+        self.rotary_emb = TelechatRotaryEmbedding(config)
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.embed_tokens = value
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        position_ids=None,
+        past_key_values=None,
+        inputs_embeds=None,
+        attn_mask_startend_row_indices=None,
+        use_cache=None,
+        output_hidden_states=None,
+        return_dict=None,
+    ):
+        use_cache = self.config.use_cache if use_cache is None else use_cache
+        output_hidden_states = (
+            self.config.output_hidden_states if output_hidden_states is None else output_hidden_states
+        )
+        return_dict = self.config.use_return_dict if return_dict is None else return_dict
+        if not ((input_ids is None) ^ (inputs_embeds is None)):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+        batch_size, seq_length, _ = inputs_embeds.shape
+        if self.embed_layernorm is not None:
+            inputs_embeds = self.embed_layernorm(inputs_embeds)
+        if use_cache and past_key_values is None:
+            past_key_values = DynamicCache(config=self.config)
+        cache_length = past_key_values.get_seq_length() if past_key_values is not None else 0
+        if position_ids is None:
+            position_ids = (
+                paddle.arange(cache_length, cache_length + seq_length, dtype="int64")
+                .unsqueeze(0)
+                .tile([batch_size, 1])
+            )
+        causal_mask, attn_mask_startend_row_indices = create_causal_mask_and_row_indices(
+            config=self.config,
+            inputs_embeds=inputs_embeds,
+            batch_size=batch_size,
+            seq_length=seq_length,
+            cache_length=cache_length,
+            attention_mask=attention_mask,
+            attn_mask_startend_row_indices=attn_mask_startend_row_indices,
+            prepare_decoder_attention_mask=self._prepare_decoder_attention_mask,
+        )
+        position_embeddings = self.rotary_emb(inputs_embeds, position_ids)
+        hidden_states = inputs_embeds
+        all_hidden_states = [] if output_hidden_states else None
+        for decoder_layer in self.layers:
+            if output_hidden_states:
+                all_hidden_states.append(hidden_states)
+            hidden_states = decoder_layer(
+                hidden_states, causal_mask, attn_mask_startend_row_indices, position_embeddings, past_key_values
+            )
+        hidden_states = self.norm(hidden_states)
+        if output_hidden_states:
+            all_hidden_states.append(hidden_states)
+            all_hidden_states = tuple(all_hidden_states)
+        if not return_dict:
+            return tuple(
+                v for v in (hidden_states, past_key_values if use_cache else None, all_hidden_states) if v is not None
+            )
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states, past_key_values=past_key_values, hidden_states=all_hidden_states
+        )
+
+
+class TelechatForCausalLM(TelechatPretrainedModel):
+    def __init__(self, config):
+        super().__init__(config)
+        self.transformer = TelechatModel(config)
+        self.lm_head = GeneralLinear.create(
+            config.hidden_size, config.vocab_size, has_bias=False, config=config, tp_plan="colwise", gather_output=True
+        )
+
+    def get_input_embeddings(self):
+        return self.transformer.get_input_embeddings()
+
+    def set_input_embeddings(self, value):
+        self.transformer.set_input_embeddings(value)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, value):
+        self.lm_head = value
+
+    def forward(
+        self,
+        input_ids=None,
+        position_ids=None,
+        attention_mask=None,
+        attn_mask_startend_row_indices=None,
+        inputs_embeds=None,
+        labels=None,
+        loss_mask=None,
+        use_cache=None,
+        past_key_values=None,
+        output_hidden_states=None,
+        return_dict=None,
+        **kwargs
+    ):
+        return_dict = self.config.use_return_dict if return_dict is None else return_dict
+        outputs = self.transformer(
+            input_ids,
+            attention_mask,
+            position_ids,
+            past_key_values,
+            inputs_embeds,
+            attn_mask_startend_row_indices,
+            use_cache,
+            output_hidden_states,
+            True,
+        )
+        logits = self.lm_head(outputs[0])
+        loss = None
+        if labels is not None:
+            shift_logits = logits[:, :-1].reshape([-1, logits.shape[-1]])
+            shift_labels = labels[:, 1:].reshape([-1])
+            valid = shift_labels != -100
+            if loss_mask is not None:
+                valid = valid & loss_mask[:, 1:].reshape([-1]).astype("bool")
+            safe_labels = paddle.where(valid, shift_labels, paddle.zeros_like(shift_labels))
+            log_probs = F.log_softmax(shift_logits, axis=-1)
+            selected = paddle.take_along_axis(log_probs, safe_labels.unsqueeze(-1), axis=-1).squeeze(-1)
+            valid_float = valid.astype(selected.dtype)
+            loss = -(selected * valid_float).sum() / paddle.clip(valid_float.sum(), min=1.0)
+        if not return_dict:
+            output = (logits,) + outputs[1:]
+            return (loss,) + output if loss is not None else output
+        return CausalLMOutputWithPast(
+            loss=loss, logits=logits, past_key_values=outputs.past_key_values, hidden_states=outputs.hidden_states
+        )
+
+    def prepare_inputs_for_generation(
+        self, input_ids, past_key_values=None, attention_mask=None, inputs_embeds=None, **kwargs
+    ):
+        if past_key_values is not None:
+            input_ids = input_ids[:, -1:]
+        model_inputs = (
+            {"inputs_embeds": inputs_embeds}
+            if inputs_embeds is not None and past_key_values is None
+            else {"input_ids": input_ids}
+        )
+        model_inputs.update(
+            {
+                "past_key_values": past_key_values,
+                "use_cache": kwargs.get("use_cache"),
+                "attention_mask": attention_mask,
+            }
+        )
+        return model_inputs

--- a/paddleformers/transformers/telechat/modeling.py
+++ b/paddleformers/transformers/telechat/modeling.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
+
 import paddle
 import paddle.nn.functional as F
 from paddle import nn
@@ -45,13 +47,30 @@ class TelechatRotaryEmbedding(nn.Layer):
     def __init__(self, config):
         super().__init__()
         self.head_dim = config.hidden_size // config.n_head
-        inv_freq = 1.0 / (10000.0 ** (paddle.arange(0, self.head_dim, 2, dtype="float32") / self.head_dim))
-        self.register_buffer("inv_freq", inv_freq, persistable=False)
+        self.base = 10000.0
+        self.base_seqlen = config.base_seqlen
+        self.training_seqlen = config.training_seqlen
+
+    def _get_mscale(self, scale=1.0):
+        if scale <= 1:
+            return 1.0
+        return 0.1 * math.log(scale) + 1.0
+
+    def _get_ntk_alpha(self, true_seq_len):
+        context_value = math.log(true_seq_len / self.base_seqlen, 2) + 1
+        ntk_alpha = 2 ** math.ceil(context_value) - 1
+        return max(ntk_alpha, 1)
 
     def forward(self, x, position_ids):
-        freqs = position_ids.astype("float32").unsqueeze(-1) * self.inv_freq.reshape([1, 1, -1])
+        seq_len = int(position_ids.max().item()) + 1
+        seq_len = max(seq_len, self.training_seqlen)
+        ntk_alpha = self._get_ntk_alpha(seq_len)
+        mscale = self._get_mscale(seq_len / self.training_seqlen)
+        base = self.base * ntk_alpha ** (self.head_dim / (self.head_dim - 2))
+        inv_freq = 1.0 / (base ** (paddle.arange(0, self.head_dim, 2, dtype="float32") / self.head_dim))
+        freqs = position_ids.astype("float32").unsqueeze(-1) * inv_freq.reshape([1, 1, -1])
         emb = paddle.concat((freqs, freqs), axis=-1)
-        return emb.cos().astype(x.dtype), emb.sin().astype(x.dtype)
+        return (mscale * emb.cos()).astype(x.dtype), (mscale * emb.sin()).astype(x.dtype)
 
 
 class TelechatRMSNorm(nn.Layer):
@@ -73,6 +92,7 @@ class TelechatRMSNorm(nn.Layer):
 class TelechatAttention(nn.Layer):
     def __init__(self, config, layer_idx):
         super().__init__()
+        self.config = config
         self.layer_idx = layer_idx
         self.head_dim = config.hidden_size // config.n_head
         if self.head_dim * config.n_head != config.hidden_size:
@@ -117,7 +137,7 @@ class TelechatAttention(nn.Layer):
         query_states, key_states = apply_rotary_pos_emb(query_states, key_states, *position_embeddings)
         if past_key_values is not None:
             key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
-        attention_interface = ALL_ATTENTION_FUNCTIONS["sdpa"]
+        attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
         attn_output, _ = attention_interface(
             self,
             query=query_states,
@@ -155,6 +175,8 @@ class TelechatDecoderLayer(nn.Layer):
         self.input_layernorm = TelechatRMSNorm(config.hidden_size, config.layer_norm_epsilon)
         self.post_attention_layernorm = TelechatRMSNorm(config.hidden_size, config.layer_norm_epsilon)
         self.mlp = TelechatMLP(config)
+        self.apply_residual_connection_post_layernorm = config.apply_residual_connection_post_layernorm
+        self.hidden_dropout = config.hidden_dropout
 
     def forward(
         self,
@@ -164,14 +186,24 @@ class TelechatDecoderLayer(nn.Layer):
         position_embeddings=None,
         past_key_values=None,
     ):
-        residual = hidden_states
-        hidden_states = self.input_layernorm(hidden_states)
-        hidden_states = residual + self.self_attention(
-            hidden_states, attention_mask, attn_mask_startend_row_indices, position_embeddings, past_key_values
+        layernorm_output = self.input_layernorm(hidden_states)
+        if self.apply_residual_connection_post_layernorm:
+            residual = layernorm_output
+        else:
+            residual = hidden_states
+        attention_output = self.self_attention(
+            layernorm_output, attention_mask, attn_mask_startend_row_indices, position_embeddings, past_key_values
         )
-        residual = hidden_states
-        hidden_states = self.post_attention_layernorm(hidden_states)
-        return residual + self.mlp(hidden_states)
+        attention_output = F.dropout(attention_output, p=self.hidden_dropout, training=self.training)
+        hidden_states = residual + attention_output
+
+        layernorm_output = self.post_attention_layernorm(hidden_states)
+        if self.apply_residual_connection_post_layernorm:
+            residual = layernorm_output
+        else:
+            residual = hidden_states
+        mlp_output = F.dropout(self.mlp(layernorm_output), p=self.hidden_dropout, training=self.training)
+        return residual + mlp_output
 
 
 class TelechatPretrainedModel(PretrainedModel):

--- a/tests/transformers/telechat/__init__.py
+++ b/tests/transformers/telechat/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/transformers/telechat/test_modeling.py
+++ b/tests/transformers/telechat/test_modeling.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 import unittest
 from unittest.mock import patch
 
@@ -43,6 +44,82 @@ class TelechatModelTest(unittest.TestCase):
         cos, sin = rotary_emb(x, position_ids)
         self.assertEqual(cos.dtype, paddle.float32)
         self.assertEqual(sin.dtype, paddle.float32)
+
+    def test_rotary_embedding_matches_base_formula_within_training_seqlen(self):
+        rotary_emb = TelechatRotaryEmbedding(self.config)
+        x = paddle.zeros([1])
+        position_ids = paddle.arange(8, dtype="int64").unsqueeze(0)
+        cos, sin = rotary_emb(x, position_ids)
+        inv_freq = 1.0 / (10000.0 ** (paddle.arange(0, 16, 2, dtype="float32") / 16))
+        freqs = position_ids.astype("float32").unsqueeze(-1) * inv_freq.reshape([1, 1, -1])
+        emb = paddle.concat((freqs, freqs), axis=-1)
+        self.assertTrue(bool(paddle.allclose(cos, emb.cos(), atol=1e-6)))
+        self.assertTrue(bool(paddle.allclose(sin, emb.sin(), atol=1e-6)))
+
+    def test_rotary_embedding_applies_ntk_scaling_beyond_training_seqlen(self):
+        config = TelechatConfig(
+            vocab_size=64, hidden_size=64, ffn_hidden_size=128, n_layer=2, n_head=4, training_seqlen=8, base_seqlen=8
+        )
+        rotary_emb = TelechatRotaryEmbedding(config)
+        x = paddle.zeros([1])
+        position_ids = paddle.arange(16, dtype="int64").unsqueeze(0)
+        cos, sin = rotary_emb(x, position_ids)
+
+        head_dim = config.hidden_size // config.n_head
+        ntk_alpha = 2 ** math.ceil(math.log(16 / config.base_seqlen, 2) + 1) - 1
+        mscale = 0.1 * math.log(16 / config.training_seqlen) + 1.0
+        base = 10000.0 * ntk_alpha ** (head_dim / (head_dim - 2))
+        inv_freq = 1.0 / (base ** (paddle.arange(0, head_dim, 2, dtype="float32") / head_dim))
+        freqs = position_ids.astype("float32").unsqueeze(-1) * inv_freq.reshape([1, 1, -1])
+        emb = paddle.concat((freqs, freqs), axis=-1)
+        self.assertGreater(ntk_alpha, 1)
+        self.assertTrue(bool(paddle.allclose(cos, mscale * emb.cos(), atol=1e-6)))
+        self.assertTrue(bool(paddle.allclose(sin, mscale * emb.sin(), atol=1e-6)))
+
+    def test_hidden_dropout_applied_in_training_mode(self):
+        config = TelechatConfig(
+            vocab_size=64, hidden_size=64, ffn_hidden_size=128, n_layer=2, n_head=4, hidden_dropout=0.5
+        )
+        model = TelechatForCausalLM(config)
+        model.train()
+        first = model(self.input_ids, return_dict=True).logits
+        second = model(self.input_ids, return_dict=True).logits
+        self.assertFalse(bool(paddle.allclose(first, second)))
+
+        model.eval()
+        eval_first = model(self.input_ids, return_dict=True).logits
+        eval_second = model(self.input_ids, return_dict=True).logits
+        self.assertTrue(bool(paddle.allclose(eval_first, eval_second)))
+
+    def test_apply_residual_connection_post_layernorm_changes_forward(self):
+        model_default = TelechatForCausalLM(self.config)
+        model_default.eval()
+        paddle.seed(42)
+        model_post = TelechatForCausalLM(
+            TelechatConfig(
+                vocab_size=64,
+                hidden_size=64,
+                ffn_hidden_size=128,
+                n_layer=2,
+                n_head=4,
+                apply_residual_connection_post_layernorm=True,
+            )
+        )
+        model_post.eval()
+        output_default = model_default(self.input_ids, return_dict=True).logits
+        output_post = model_post(self.input_ids, return_dict=True).logits
+        self.assertFalse(bool(paddle.allclose(output_default, output_post)))
+
+    def test_attention_backend_routing(self):
+        outputs = {}
+        for backend in ("sdpa", "eager"):
+            config = TelechatConfig(**self.config.to_dict())
+            config._attn_implementation = backend
+            paddle.seed(42)
+            model = TelechatForCausalLM(config)
+            model.eval()
+            outputs[backend] = model(self.input_ids, return_dict=True).logits
+        self.assertTrue(bool(paddle.allclose(outputs["sdpa"], outputs["eager"], atol=1e-5)))
 
     def test_attention_uses_local_heads_for_tensor_parallel_config(self):
         config = TelechatConfig(

--- a/tests/transformers/telechat/test_modeling.py
+++ b/tests/transformers/telechat/test_modeling.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import patch
+
+import paddle
+import paddle.nn.functional as F
+
+from paddleformers.cli.utils.llm_utils import get_lora_target_modules
+from paddleformers.transformers.auto.configuration import CONFIG_MAPPING
+from paddleformers.transformers.auto.modeling import AutoModel, AutoModelForCausalLM
+from paddleformers.transformers.telechat.configuration import TelechatConfig
+from paddleformers.transformers.telechat.modeling import (
+    TelechatAttention,
+    TelechatForCausalLM,
+    TelechatModel,
+    TelechatRotaryEmbedding,
+)
+
+
+class TelechatModelTest(unittest.TestCase):
+    def setUp(self):
+        paddle.seed(42)
+        self.config = TelechatConfig(vocab_size=64, hidden_size=64, ffn_hidden_size=128, n_layer=2, n_head=4)
+        self.input_ids = paddle.randint(0, 64, shape=[2, 5], dtype="int64")
+
+    def test_rotary_embedding_preserves_fp32_dtype(self):
+        rotary_emb = TelechatRotaryEmbedding(self.config)
+        x = paddle.randn([2, 5, self.config.hidden_size], dtype="float32")
+        position_ids = paddle.arange(5, dtype="int64").unsqueeze(0).tile([2, 1])
+        cos, sin = rotary_emb(x, position_ids)
+        self.assertEqual(cos.dtype, paddle.float32)
+        self.assertEqual(sin.dtype, paddle.float32)
+
+    def test_attention_uses_local_heads_for_tensor_parallel_config(self):
+        config = TelechatConfig(
+            vocab_size=64,
+            hidden_size=64,
+            ffn_hidden_size=128,
+            n_layer=2,
+            n_head=4,
+            tensor_model_parallel_size=2,
+        )
+
+        def create_linear(in_features, out_features, **kwargs):
+            if kwargs["tp_plan"] == "colwise":
+                out_features //= config.tensor_model_parallel_size
+            else:
+                in_features //= config.tensor_model_parallel_size
+            return paddle.nn.Linear(in_features, out_features, bias_attr=kwargs["has_bias"])
+
+        with patch("paddleformers.transformers.telechat.modeling.GeneralLinear.create", side_effect=create_linear):
+            attention = TelechatAttention(config, layer_idx=0)
+        hidden_states = paddle.randn([2, 5, config.hidden_size])
+        position_ids = paddle.arange(5, dtype="int64").unsqueeze(0).tile([2, 1])
+        position_embeddings = TelechatRotaryEmbedding(config)(hidden_states, position_ids)
+        output = attention(hidden_states, position_embeddings=position_embeddings)
+
+        self.assertEqual(attention.num_heads, 2)
+        self.assertEqual(list(output.shape), [2, 5, 64])
+
+    def test_lm_head_gathers_tensor_parallel_output(self):
+        config = TelechatConfig(vocab_size=97, hidden_size=64, ffn_hidden_size=128, n_layer=2, n_head=4)
+        with patch(
+            "paddleformers.transformers.telechat.modeling.GeneralLinear.create", return_value=paddle.nn.Identity()
+        ) as create:
+            TelechatForCausalLM(config)
+
+        lm_head_calls = [
+            call
+            for call in create.call_args_list
+            if call.args[1] == config.vocab_size and call.kwargs.get("tp_plan") == "colwise"
+        ]
+        self.assertTrue(any(call.kwargs.get("gather_output") is True for call in lm_head_calls))
+
+    def test_forward_shape_and_auto_config(self):
+        self.assertIs(CONFIG_MAPPING["telechat"], TelechatConfig)
+        model = TelechatModel(self.config)
+        result = model(self.input_ids, return_dict=True)
+        self.assertEqual(list(result.last_hidden_state.shape), [2, 5, 64])
+
+    def test_loss_mask_and_empty_mask(self):
+        model = TelechatForCausalLM(self.config)
+        labels = self.input_ids.clone()
+        loss_mask = paddle.ones_like(labels)
+        loss_mask[:, 2:4] = 0
+        output = model(self.input_ids, labels=labels, loss_mask=loss_mask, return_dict=True)
+        self.assertEqual(list(output.logits.shape), [2, 5, 64])
+        self.assertTrue(bool(paddle.isfinite(output.loss).item()))
+
+        shift_logits = output.logits[:, :-1].reshape([-1, self.config.vocab_size])
+        shift_labels = labels[:, 1:].reshape([-1])
+        valid = loss_mask[:, 1:].reshape([-1]).astype("bool")
+        expected_loss = F.cross_entropy(shift_logits[valid], shift_labels[valid])
+        self.assertTrue(bool(paddle.allclose(output.loss, expected_loss)))
+
+        empty_output = model(self.input_ids, labels=labels, loss_mask=paddle.zeros_like(labels), return_dict=True)
+        self.assertEqual(float(empty_output.loss), 0.0)
+
+    def test_auto_model_routing(self):
+        self.assertIsInstance(AutoModel.from_config(self.config), TelechatModel)
+        causal_lm_config = TelechatConfig(**self.config.to_dict())
+        causal_lm_config.architectures = ["TelechatForCausalLM"]
+        causal_lm_config.dtype = "float32"
+        self.assertIsInstance(AutoModelForCausalLM.from_config(causal_lm_config), TelechatForCausalLM)
+
+    def test_lora_target_modules(self):
+        self.assertEqual(
+            get_lora_target_modules(TelechatForCausalLM(self.config)),
+            [
+                ".*query.*",
+                ".*key_value.*",
+                ".*dense.*",
+                ".*gate_proj.*",
+                ".*up_proj.*",
+                ".*down_proj.*",
+            ],
+        )
+
+    def test_cached_decode_matches_full_forward(self):
+        model = TelechatForCausalLM(self.config)
+        model.eval()
+        prompt = self.input_ids[:, :3]
+        next_token = self.input_ids[:, 3:4]
+        cached = model(prompt, use_cache=True, return_dict=True)
+        decode = model(next_token, past_key_values=cached.past_key_values, use_cache=True, return_dict=True)
+        full = model(paddle.concat([prompt, next_token], axis=-1), use_cache=False, return_dict=True)
+        self.assertTrue(bool(paddle.allclose(decode.logits[:, -1], full.logits[:, -1], atol=1e-5)))
+
+    def test_generate(self):
+        model = TelechatForCausalLM(self.config)
+        model.eval()
+        generated = model.generate(self.input_ids[:, :3], max_new_tokens=2, decode_strategy="greedy_search")
+        if isinstance(generated, tuple):
+            generated = generated[0]
+        self.assertEqual(list(generated.shape), [2, 2])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
本 PR 完成 Tele-AI/TeleChat-1B 从 Transformers 到 PaddleFormers 的迁移，包含组网、权重转换、前向精度、生成、LoRA 训练 loss 对齐、LoRA 合并及单测验证。

### 1. 前向精度对齐

- 模型：`Tele-AI/TeleChat-1B`
- 通过官方 PyTorch 权重转换为 PaddleFormers 权重进行验证
- `AutoConfig`、`AutoModel`、`AutoModelForCausalLM` 本地加载验证通过
- PaddleFormers / Transformers logits：

  - mean abs diff：`1.5991124655556632e-06`
  - max abs diff：`2.6702880859375e-05`
  - argmax：完全一致

### 2. 模型生成

相同转换权重与 greedy 解码下验证通过，连续生成 8 个 token 与官方 PyTorch 实现逐 token 完全一致。

- Prompt：`<_user>你好<_bot>`
- PaddleFormers generated token ids：

```text
[20, 20, 20, 20, 20, 20, 20, 20]
```

### 3. 训练 loss 对齐

- 模型：`Tele-AI/TeleChat-1B`
- LoRA：rank=`8`，alpha=`16`，dropout=`0`
- 目标层：`query`、`key_value`、`dense`、`gate_proj`、`up_proj`、`down_proj`
- 使用相同输入、causal labels、固定 LoRA 权重进行 FP32 loss 对齐
- 注入 LoRA 线性层数：PyTorch / PaddleFormers 均为 `96`

首步 loss：

- PyTorch：`25.866153717041016`
- PaddleFormers：`25.86615562438965`
- absolute difference：`1.9073486328125e-06`

logits checksum：`476130.65625`，两端完全一致；所有位置 argmax 完全一致。

### 4. LoRA 训练、合并与确定性

- 单卡 FP16 LoRA SFT 训练跑通
- LoRA adapter 保存成功
- 使用 `get_merge_state_dict` 导出纯合并权重：
  - base checkpoint keys：`163`
  - 无 `lora_A` / `lora_B` 残留
  - 合并模型重新加载、前向和 greedy generation 验证通过
- 相同 seed、相同数据与顺序、相同配置连续运行两次 3-step LoRA 训练：
  - losses：`[10.734102249145508, 8.075804710388184, 3.176398754119873]`
  - adapter tensors：`192`
  - 两次最终 adapter SHA-256 完全一致：
    `eaf30ec683e4d5fe75a9c9fc3c9bf4f6a274cc1964d6c03089ff50f2bfbba45e`

### 5. 模型单测

覆盖：

- 前向输出 shape 与 AutoConfig 注册
- causal loss、`loss_mask` 与空监督 mask
- AutoModel / AutoModelForCausalLM 路由
- TeleChat 默认 LoRA target modules
- KV cache decode 与 full forward 一致性
- greedy generation

```text
pytest tests/transformers/telechat/test_modeling.py -q
6 passed
```

`git diff --check` 已通过。

不包含转换权重、训练配置、训练 checkpoint、LoRA adapter、合并模型或本地验证脚本。