### PR TITLE
Support configuring init_method_std via YAML/CLI and pin it in qwen3 single-card CI

### DIFF
--- a/paddleformers/transformers/configuration_utils.py
+++ b/paddleformers/transformers/configuration_utils.py
@@ -541,6 +541,12 @@ class LlmMetaConfig:
             "Method to initialize weights of the output layer of both attention and MLP blocks.",
         ),
         (
+            "init_method_std",
+            float,
+            0.02,
+            "Standard deviation for transformer/MoE weight initialization (Normal). Used to build the default init_method/output_layer_init_method when they are not explicitly set. Defaults to 0.02.",
+        ),
+        (
             "embedding_init_method",
             Optional[Any],
             None,

--- a/paddleformers/transformers/configuration_utils.py
+++ b/paddleformers/transformers/configuration_utils.py
@@ -544,7 +544,7 @@ class LlmMetaConfig:
             "init_method_std",
             float,
             0.02,
-            "Standard deviation for transformer/MoE weight initialization (Normal). Used to build the default init_method/output_layer_init_method when they are not explicitly set. Defaults to 0.02.",
+            "Standard deviation for initialization (Normal). Used to build the default init_method/output_layer_init_method when they are not explicitly set. Defaults to 0.02.",
         ),
         (
             "embedding_init_method",

--- a/tests/config/ci/qwen3_pt.yaml
+++ b/tests/config/ci/qwen3_pt.yaml
@@ -19,6 +19,7 @@ prefetch_factor: 24
 model_name_or_path: ./Qwen3-30B-A3B-Base
 _attn_implementation: flashmask
 use_qk_norm: true
+init_method_std: 0.001
 
 ### finetuning
 # base


### PR DESCRIPTION
### What
- Register `init_method_std` as an `LlmMetaConfig` model attribute so it becomes a valid training config key and propagates to the model provider's `init_method_std` (used to build the default `init_method` / `output_layer_init_method`). Default remains 0.02.
- Set `init_method_std: 0.001` in `tests/config/ci/qwen3_pt.yaml`.

### Why
The qwen3 single-card precision test showed run-to-run loss divergence. Root cause: larger MoE weight init std (0.02) amplifies the non-deterministic bf16 scatter-add accumulation in the MoE combine path, which compounds across steps. Shrinking init std back to 0.001 restores run-to-run bit-identical losses (verified over 9 consecutive runs).

### Verified
- With `init_method_std=0.001`: 9/9 consecutive single-card runs produce identical loss at every step.
- Log confirms provider now reports `init_method_std=0.001` with no unknown-argument error.