### PR TITLE
Support batched 3D input in muon slice funcs (axis=-1, simplify ffn/moe)

### DIFF
--- a/paddleformers/transformers/deepseek_v4/modeling.py
+++ b/paddleformers/transformers/deepseek_v4/modeling.py
@@ -95,20 +95,16 @@ class DeepseekV4PreTrainedModel(PretrainedModel):
         """
 
         def _ffn_gate_up(matrix, ortho_fn, intermediate_size=None):
-            """Slice FFN gate_up, orthogonalise gate and up independently."""
+            """Slice FFN gate_up, orthogonalise gate and up independently.
+
+            Handles both 2D (per-expert) and 3D (fused experts) weight tensors.
+            """
             import paddle
 
-            if matrix.ndim == 2:
-                gate, up = paddle.split(matrix, [intermediate_size, intermediate_size], axis=1)
-                return paddle.concat([ortho_fn(gate), ortho_fn(up)], axis=1)
-            elif matrix.ndim == 3:
-                expert_updates = []
-                for ei in range(matrix.shape[0]):
-                    gate, up = paddle.split(matrix[ei], [intermediate_size, intermediate_size], axis=1)
-                    expert_updates.append(paddle.concat([ortho_fn(gate), ortho_fn(up)], axis=1))
-                return paddle.stack(expert_updates, axis=0)
-            else:
-                raise ValueError(f"FFN gate_up split expects 2D or 3D tensor, got shape {matrix.shape}")
+            assert matrix.ndim == 2 or matrix.ndim == 3, "FFN gate_up split expects 2D or 3D tensor"
+
+            gate, up = paddle.split(matrix, [intermediate_size, intermediate_size], axis=-1)
+            return paddle.concat([ortho_fn(gate), ortho_fn(up)], axis=-1)
 
         def _mla_per_head(matrix_2d_global, ortho_fn, head_num=None, axis=None, head_split_sizes=None):
             """Slice MLA weights by heads."""
@@ -121,15 +117,11 @@ class DeepseekV4PreTrainedModel(PretrainedModel):
 
         def _moe_experts(matrix_3d_global, ortho_fn):
             """Slice MoE weights by experts."""
-            import paddle
 
             if matrix_3d_global.ndim != 3:
                 raise ValueError(f"MoE expert split expects 3D tensor, got shape {matrix_3d_global.shape}")
-            n_experts = matrix_3d_global.shape[0]
-            return paddle.stack(
-                [ortho_fn(matrix_3d_global[ei]) for ei in range(n_experts)],
-                axis=0,
-            )
+
+            return ortho_fn(matrix_3d_global)
 
         slice_config = {}
 
@@ -168,7 +160,7 @@ class DeepseekV4PreTrainedModel(PretrainedModel):
                     mla_slice_fn,
                     {
                         "head_num": num_attention_head,
-                        "axis": 1,
+                        "axis": -1,
                     },
                 )
 
@@ -178,7 +170,7 @@ class DeepseekV4PreTrainedModel(PretrainedModel):
                         mla_slice_fn,
                         {
                             "head_num": 1,
-                            "axis": 1,
+                            "axis": -1,
                             "head_split_sizes": [config.v_head_dim, config.v_head_dim],
                         },
                     )
@@ -186,7 +178,7 @@ class DeepseekV4PreTrainedModel(PretrainedModel):
                         mla_slice_fn,
                         {
                             "head_num": 1,
-                            "axis": 1,
+                            "axis": -1,
                             "head_split_sizes": [config.v_head_dim, config.v_head_dim],
                         },
                     )
@@ -197,7 +189,7 @@ class DeepseekV4PreTrainedModel(PretrainedModel):
                         mla_slice_fn,
                         {
                             "head_num": config.dsa_index_n_heads,
-                            "axis": 1,
+                            "axis": -1,
                         },
                     )
                     # Compressed weights
@@ -205,7 +197,7 @@ class DeepseekV4PreTrainedModel(PretrainedModel):
                         mla_slice_fn,
                         {
                             "head_num": 1,
-                            "axis": 1,
+                            "axis": -1,
                             "head_split_sizes": [config.dsa_index_head_dim, config.dsa_index_head_dim],
                         },
                     )
@@ -213,7 +205,7 @@ class DeepseekV4PreTrainedModel(PretrainedModel):
                         mla_slice_fn,
                         {
                             "head_num": 1,
-                            "axis": 1,
+                            "axis": -1,
                             "head_split_sizes": [config.dsa_index_head_dim, config.dsa_index_head_dim],
                         },
                     )
@@ -266,21 +258,21 @@ class DeepseekV4PreTrainedModel(PretrainedModel):
                     mla_slice_fn,
                     {
                         "head_num": num_attention_head,
-                        "axis": 1,
+                        "axis": -1,
                         "head_split_sizes": [config.qk_nope_head_dim, config.qk_rope_head_dim],
                     },
                 )
 
                 slice_config[f"{prefix}.self_attn.kv_a_proj_with_mqa.weight"] = (
                     mla_slice_fn,
-                    {"head_num": 1, "axis": 1, "head_split_sizes": [config.kv_lora_rank, config.qk_rope_head_dim]},
+                    {"head_num": 1, "axis": -1, "head_split_sizes": [config.kv_lora_rank, config.qk_rope_head_dim]},
                 )
 
                 slice_config[f"{prefix}.self_attn.kv_b_proj.weight"] = (
                     mla_slice_fn,
                     {
                         "head_num": num_attention_head,
-                        "axis": 1,
+                        "axis": -1,
                         "head_split_sizes": [config.qk_nope_head_dim, config.v_head_dim],
                     },
                 )
@@ -289,7 +281,7 @@ class DeepseekV4PreTrainedModel(PretrainedModel):
             if use_gated_attn and mla_slice_fn is not None:
                 slice_config[f"{prefix}.self_attn.gate_proj.weight"] = (
                     mla_slice_fn,
-                    {"head_num": num_attention_head, "axis": 1},
+                    {"head_num": num_attention_head, "axis": -1},
                 )
 
         # Main layers

--- a/paddleformers/transformers/glm_moe_dsa/modeling.py
+++ b/paddleformers/transformers/glm_moe_dsa/modeling.py
@@ -78,63 +78,56 @@ class GlmMoeDsaPreTrainedModel(PretrainedModel):
         def _qkv_per_head(matrix_2d_global, ortho_fn, kv_head_num=None, num_key_value_groups=None):
             import paddle
 
-            head_dim = matrix_2d_global.shape[1] // (num_key_value_groups * kv_head_num + 2 * kv_head_num)
-            groups = paddle.split(matrix_2d_global, kv_head_num, axis=1)
+            head_dim = matrix_2d_global.shape[-1] // (num_key_value_groups * kv_head_num + 2 * kv_head_num)
+            groups = paddle.split(matrix_2d_global, kv_head_num, axis=-1)
 
             processed_groups = []
             for group in groups:
                 q_part, k_head, v_head = paddle.split(
                     group,
                     [num_key_value_groups * head_dim, head_dim, head_dim],
-                    axis=1,
+                    axis=-1,
                 )
-                q_heads = paddle.split(q_part, num_key_value_groups, axis=1)
-                q_ortho = paddle.concat([ortho_fn(h) for h in q_heads], axis=1)
-                processed_groups.append(paddle.concat([q_ortho, ortho_fn(k_head), ortho_fn(v_head)], axis=1))
+                q_heads = paddle.split(q_part, num_key_value_groups, axis=-1)
+                q_ortho = paddle.concat([ortho_fn(h) for h in q_heads], axis=-1)
+                processed_groups.append(paddle.concat([q_ortho, ortho_fn(k_head), ortho_fn(v_head)], axis=-1))
 
-            return paddle.concat(processed_groups, axis=1)
+            return paddle.concat(processed_groups, axis=-1)
 
         def _qkv_sep(matrix_2d, ortho_fn, kv_head_num=None, num_key_value_groups=None):
             import paddle
 
-            head_dim = matrix_2d.shape[1] // (num_key_value_groups * kv_head_num + 2 * kv_head_num)
+            head_dim = matrix_2d.shape[-1] // (num_key_value_groups * kv_head_num + 2 * kv_head_num)
             q_group_size = num_key_value_groups * head_dim
 
-            groups = paddle.split(matrix_2d, kv_head_num, axis=1)
+            groups = paddle.split(matrix_2d, kv_head_num, axis=-1)
             q_parts, k_parts, v_parts = [], [], []
             for group in groups:
-                q_p, k_p, v_p = paddle.split(group, [q_group_size, head_dim, head_dim], axis=1)
+                q_p, k_p, v_p = paddle.split(group, [q_group_size, head_dim, head_dim], axis=-1)
                 q_parts.append(q_p)
                 k_parts.append(k_p)
                 v_parts.append(v_p)
 
-            q_ortho = ortho_fn(paddle.concat(q_parts, axis=1))
-            k_ortho = ortho_fn(paddle.concat(k_parts, axis=1))
-            v_ortho = ortho_fn(paddle.concat(v_parts, axis=1))
+            q_ortho = ortho_fn(paddle.concat(q_parts, axis=-1))
+            k_ortho = ortho_fn(paddle.concat(k_parts, axis=-1))
+            v_ortho = ortho_fn(paddle.concat(v_parts, axis=-1))
 
-            q_groups = paddle.split(q_ortho, kv_head_num, axis=1)
-            k_groups = paddle.split(k_ortho, kv_head_num, axis=1)
-            v_groups = paddle.split(v_ortho, kv_head_num, axis=1)
+            q_groups = paddle.split(q_ortho, kv_head_num, axis=-1)
+            k_groups = paddle.split(k_ortho, kv_head_num, axis=-1)
+            v_groups = paddle.split(v_ortho, kv_head_num, axis=-1)
 
             return paddle.concat(
-                [paddle.concat([q_groups[i], k_groups[i], v_groups[i]], axis=1) for i in range(kv_head_num)],
-                axis=1,
+                [paddle.concat([q_groups[i], k_groups[i], v_groups[i]], axis=-1) for i in range(kv_head_num)],
+                axis=-1,
             )
 
         def _ffn_gate_up(matrix, ortho_fn, intermediate_size=None):
             import paddle
 
-            if matrix.ndim == 2:
-                gate, up = paddle.split(matrix, [intermediate_size, intermediate_size], axis=1)
-                return paddle.concat([ortho_fn(gate), ortho_fn(up)], axis=1)
-            elif matrix.ndim == 3:
-                expert_updates = []
-                for ei in range(matrix.shape[0]):
-                    gate, up = paddle.split(matrix[ei], [intermediate_size, intermediate_size], axis=1)
-                    expert_updates.append(paddle.concat([ortho_fn(gate), ortho_fn(up)], axis=1))
-                return paddle.stack(expert_updates, axis=0)
-            else:
-                raise ValueError(f"FFN gate_up split expects 2D or 3D tensor, got shape {matrix.shape}")
+            assert matrix.ndim == 2 or matrix.ndim == 3, "FFN gate_up split expects 2D or 3D tensor"
+
+            gate, up = paddle.split(matrix, [intermediate_size, intermediate_size], axis=-1)
+            return paddle.concat([ortho_fn(gate), ortho_fn(up)], axis=-1)
 
         def _mla_per_head(matrix_2d_global, ortho_fn, head_num=None, axis=None, head_split_sizes=None):
             import paddle
@@ -145,15 +138,10 @@ class GlmMoeDsaPreTrainedModel(PretrainedModel):
             return paddle.concat(processed_groups, axis=axis)
 
         def _moe_experts(matrix_3d_global, ortho_fn):
-            import paddle
-
             if matrix_3d_global.ndim != 3:
                 raise ValueError(f"MoE expert split expects 3D tensor, got shape {matrix_3d_global.shape}")
-            n_experts = matrix_3d_global.shape[0]
-            return paddle.stack(
-                [ortho_fn(matrix_3d_global[ei]) for ei in range(n_experts)],
-                axis=0,
-            )
+
+            return ortho_fn(matrix_3d_global)
 
         slice_config = {}
 
@@ -232,21 +220,21 @@ class GlmMoeDsaPreTrainedModel(PretrainedModel):
                     mla_slice_fn,
                     {
                         "head_num": num_attention_head,
-                        "axis": 1,
+                        "axis": -1,
                         "head_split_sizes": [config.qk_nope_head_dim, config.qk_rope_head_dim],
                     },
                 )
 
                 slice_config[f"{prefix}.self_attn.kv_a_proj_with_mqa.weight"] = (
                     mla_slice_fn,
-                    {"head_num": 1, "axis": 1, "head_split_sizes": [config.kv_lora_rank, config.qk_rope_head_dim]},
+                    {"head_num": 1, "axis": -1, "head_split_sizes": [config.kv_lora_rank, config.qk_rope_head_dim]},
                 )
 
                 slice_config[f"{prefix}.self_attn.kv_b_proj.weight"] = (
                     mla_slice_fn,
                     {
                         "head_num": num_attention_head,
-                        "axis": 1,
+                        "axis": -1,
                         "head_split_sizes": [config.qk_nope_head_dim, config.v_head_dim],
                     },
                 )
@@ -254,7 +242,7 @@ class GlmMoeDsaPreTrainedModel(PretrainedModel):
             if use_gated_attn and mla_slice_fn is not None:
                 slice_config[f"{prefix}.self_attn.gate_proj.weight"] = (
                     mla_slice_fn,
-                    {"head_num": num_attention_head, "axis": 1},
+                    {"head_num": num_attention_head, "axis": -1},
                 )
 
         for layer_idx in range(num_hidden_layers):

--- a/paddleformers/transformers/minimax_m2/modeling.py
+++ b/paddleformers/transformers/minimax_m2/modeling.py
@@ -85,7 +85,7 @@ class MiniMaxM2PreTrainedModel(PretrainedModel):
 
         def _qkv_per_head(matrix_2d_global, ortho_fn, num_query_groups=None, split_dims=None):
             """Slice QKV by heads, orthogonalise each head independently."""
-            groups = paddle.split(matrix_2d_global, num_query_groups, axis=1)
+            groups = paddle.split(matrix_2d_global, num_query_groups, axis=-1)
             q_heads_per_group = split_dims[0] // split_dims[-2]
 
             processed_groups = []
@@ -94,83 +94,79 @@ class MiniMaxM2PreTrainedModel(PretrainedModel):
                     q_part, gate_part, k_head, v_head = paddle.split(
                         group,
                         split_dims,
-                        axis=1,
+                        axis=-1,
                     )
-                    q_heads = paddle.split(q_part, q_heads_per_group, axis=1)
-                    q_ortho = paddle.concat([ortho_fn(h) for h in q_heads], axis=1)
-                    gate_heads = paddle.split(gate_part, q_heads_per_group, axis=1)
-                    gate_ortho = paddle.concat([ortho_fn(g) for g in gate_heads], axis=1)
+                    q_heads = paddle.split(q_part, q_heads_per_group, axis=-1)
+                    q_ortho = paddle.concat([ortho_fn(h) for h in q_heads], axis=-1)
+                    gate_heads = paddle.split(gate_part, q_heads_per_group, axis=-1)
+                    gate_ortho = paddle.concat([ortho_fn(g) for g in gate_heads], axis=-1)
                     processed_groups.append(
-                        paddle.concat([q_ortho, gate_ortho, ortho_fn(k_head), ortho_fn(v_head)], axis=1)
+                        paddle.concat([q_ortho, gate_ortho, ortho_fn(k_head), ortho_fn(v_head)], axis=-1)
                     )
             else:
                 for group in groups:
                     q_part, k_head, v_head = paddle.split(
                         group,
                         split_dims,
-                        axis=1,
+                        axis=-1,
                     )
-                    q_heads = paddle.split(q_part, q_heads_per_group, axis=1)
-                    q_ortho = paddle.concat([ortho_fn(h) for h in q_heads], axis=1)
-                    processed_groups.append(paddle.concat([q_ortho, ortho_fn(k_head), ortho_fn(v_head)], axis=1))
+                    q_heads = paddle.split(q_part, q_heads_per_group, axis=-1)
+                    q_ortho = paddle.concat([ortho_fn(h) for h in q_heads], axis=-1)
+                    processed_groups.append(paddle.concat([q_ortho, ortho_fn(k_head), ortho_fn(v_head)], axis=-1))
 
-            return paddle.concat(processed_groups, axis=1)
+            return paddle.concat(processed_groups, axis=-1)
 
         def _qkv_sep(matrix_2d, ortho_fn, num_query_groups=None, split_dims=None):
             """Slice QKV into Q, K, V blocks, orthogonalise each as whole."""
 
-            groups = paddle.split(matrix_2d, num_query_groups, axis=1)
+            groups = paddle.split(matrix_2d, num_query_groups, axis=-1)
             q_parts, g_parts, k_parts, v_parts = [], [], [], []
             for group in groups:
                 if len(split_dims) == 4:
-                    q_p, g_p, k_p, v_p = paddle.split(group, split_dims, axis=1)
+                    q_p, g_p, k_p, v_p = paddle.split(group, split_dims, axis=-1)
                     g_parts.append(g_p)
                 else:
-                    q_p, k_p, v_p = paddle.split(group, split_dims, axis=1)
+                    q_p, k_p, v_p = paddle.split(group, split_dims, axis=-1)
                 q_parts.append(q_p)
                 k_parts.append(k_p)
                 v_parts.append(v_p)
 
-            q_ortho = ortho_fn(paddle.concat(q_parts, axis=1))
+            q_ortho = ortho_fn(paddle.concat(q_parts, axis=-1))
             if len(split_dims) == 4:
-                g_ortho = ortho_fn(paddle.concat(g_parts, axis=1))
-            k_ortho = ortho_fn(paddle.concat(k_parts, axis=1))
-            v_ortho = ortho_fn(paddle.concat(v_parts, axis=1))
+                g_ortho = ortho_fn(paddle.concat(g_parts, axis=-1))
+            k_ortho = ortho_fn(paddle.concat(k_parts, axis=-1))
+            v_ortho = ortho_fn(paddle.concat(v_parts, axis=-1))
 
-            q_groups = paddle.split(q_ortho, num_query_groups, axis=1)
+            q_groups = paddle.split(q_ortho, num_query_groups, axis=-1)
             if len(split_dims) == 4:
-                g_groups = paddle.split(g_ortho, num_query_groups, axis=1)
-            k_groups = paddle.split(k_ortho, num_query_groups, axis=1)
-            v_groups = paddle.split(v_ortho, num_query_groups, axis=1)
+                g_groups = paddle.split(g_ortho, num_query_groups, axis=-1)
+            k_groups = paddle.split(k_ortho, num_query_groups, axis=-1)
+            v_groups = paddle.split(v_ortho, num_query_groups, axis=-1)
 
             if len(split_dims) == 4:
                 return paddle.concat(
                     [
-                        paddle.concat([q_groups[i], g_groups[i], k_groups[i], v_groups[i]], axis=1)
+                        paddle.concat([q_groups[i], g_groups[i], k_groups[i], v_groups[i]], axis=-1)
                         for i in range(num_query_groups)
                     ],
-                    axis=1,
+                    axis=-1,
                 )
             else:
                 return paddle.concat(
-                    [paddle.concat([q_groups[i], k_groups[i], v_groups[i]], axis=1) for i in range(num_query_groups)],
-                    axis=1,
+                    [paddle.concat([q_groups[i], k_groups[i], v_groups[i]], axis=-1) for i in range(num_query_groups)],
+                    axis=-1,
                 )
 
         def _ffn_gate_up(matrix, ortho_fn, intermediate_size=None):
-            """Slice FFN gate_up, orthogonalise gate and up independently."""
+            """Slice FFN gate_up, orthogonalise gate and up independently.
 
-            if matrix.ndim == 2:
-                gate, up = paddle.split(matrix, [intermediate_size, intermediate_size], axis=1)
-                return paddle.concat([ortho_fn(gate), ortho_fn(up)], axis=1)
-            elif matrix.ndim == 3:
-                expert_updates = []
-                for ei in range(matrix.shape[0]):
-                    gate, up = paddle.split(matrix[ei], [intermediate_size, intermediate_size], axis=1)
-                    expert_updates.append(paddle.concat([ortho_fn(gate), ortho_fn(up)], axis=1))
-                return paddle.stack(expert_updates, axis=0)
-            else:
-                raise ValueError(f"FFN gate_up split expects 2D or 3D tensor, got shape {matrix.shape}")
+            Handles both 2D (per-expert) and 3D (fused experts) weight tensors.
+            """
+
+            assert matrix.ndim == 2 or matrix.ndim == 3, "FFN gate_up split expects 2D or 3D tensor"
+
+            gate, up = paddle.split(matrix, [intermediate_size, intermediate_size], axis=-1)
+            return paddle.concat([ortho_fn(gate), ortho_fn(up)], axis=-1)
 
         def _mla_per_head(matrix_2d_global, ortho_fn, head_num=None, axis=None, head_split_sizes=None):
             """Slice MLA weights by heads."""
@@ -185,11 +181,8 @@ class MiniMaxM2PreTrainedModel(PretrainedModel):
 
             if matrix_3d_global.ndim != 3:
                 raise ValueError(f"MoE expert split expects 3D tensor, got shape {matrix_3d_global.shape}")
-            n_experts = matrix_3d_global.shape[0]
-            return paddle.stack(
-                [ortho_fn(matrix_3d_global[ei]) for ei in range(n_experts)],
-                axis=0,
-            )
+
+            return ortho_fn(matrix_3d_global)
 
         slice_config = {}
 
@@ -239,7 +232,7 @@ class MiniMaxM2PreTrainedModel(PretrainedModel):
                     mla_slice_fn,
                     {
                         "head_num": num_attention_heads,
-                        "axis": 1,
+                        "axis": -1,
                     },
                 )
 
@@ -249,7 +242,7 @@ class MiniMaxM2PreTrainedModel(PretrainedModel):
                         mla_slice_fn,
                         {
                             "head_num": 1,
-                            "axis": 1,
+                            "axis": -1,
                             "head_split_sizes": [config.v_head_dim, config.v_head_dim],
                         },
                     )
@@ -257,7 +250,7 @@ class MiniMaxM2PreTrainedModel(PretrainedModel):
                         mla_slice_fn,
                         {
                             "head_num": 1,
-                            "axis": 1,
+                            "axis": -1,
                             "head_split_sizes": [config.v_head_dim, config.v_head_dim],
                         },
                     )
@@ -268,7 +261,7 @@ class MiniMaxM2PreTrainedModel(PretrainedModel):
                         mla_slice_fn,
                         {
                             "head_num": config.dsa_index_n_heads,
-                            "axis": 1,
+                            "axis": -1,
                         },
                     )
                     # Compressed weights
@@ -276,7 +269,7 @@ class MiniMaxM2PreTrainedModel(PretrainedModel):
                         mla_slice_fn,
                         {
                             "head_num": 1,
-                            "axis": 1,
+                            "axis": -1,
                             "head_split_sizes": [config.dsa_index_head_dim, config.dsa_index_head_dim],
                         },
                     )
@@ -284,7 +277,7 @@ class MiniMaxM2PreTrainedModel(PretrainedModel):
                         mla_slice_fn,
                         {
                             "head_num": 1,
-                            "axis": 1,
+                            "axis": -1,
                             "head_split_sizes": [config.dsa_index_head_dim, config.dsa_index_head_dim],
                         },
                     )
@@ -303,20 +296,20 @@ class MiniMaxM2PreTrainedModel(PretrainedModel):
                         v_head_dim = config.swa_v_head_dim if layer_is_swa else config.v_head_dim
                         slice_config[f"{prefix}.self_attn.q_proj.weight"] = (
                             _mla_per_head,
-                            {"head_num": g, "axis": 1, "head_split_sizes": [q_lora_rank]},
+                            {"head_num": g, "axis": -1, "head_split_sizes": [q_lora_rank]},
                         )
                         slice_config[f"{prefix}.self_attn.k_proj.weight"] = (
                             _mla_per_head,
-                            {"head_num": num_kv_heads, "axis": 1, "head_split_sizes": [head_dim]},
+                            {"head_num": num_kv_heads, "axis": -1, "head_split_sizes": [head_dim]},
                         )
                         slice_config[f"{prefix}.self_attn.v_proj.weight"] = (
                             _mla_per_head,
-                            {"head_num": num_kv_heads, "axis": 1, "head_split_sizes": [v_head_dim]},
+                            {"head_num": num_kv_heads, "axis": -1, "head_split_sizes": [v_head_dim]},
                         )
                         if use_gated_attn:
                             slice_config[f"{prefix}.self_attn.gate_proj.weight"] = (
                                 _mla_per_head,
-                                {"head_num": num_heads, "axis": 1, "head_split_sizes": [v_head_dim]},
+                                {"head_num": num_heads, "axis": -1, "head_split_sizes": [v_head_dim]},
                             )
                         if vha_premix_fn is not None:
                             slice_config[f"{prefix}.self_attn.vha_premix_weight"] = (vha_premix_fn, {})
@@ -376,21 +369,21 @@ class MiniMaxM2PreTrainedModel(PretrainedModel):
                     mla_slice_fn,
                     {
                         "head_num": num_attention_heads,
-                        "axis": 1,
+                        "axis": -1,
                         "head_split_sizes": [config.qk_nope_head_dim, config.qk_rope_head_dim],
                     },
                 )
 
                 slice_config[f"{prefix}.self_attn.kv_a_proj_with_mqa.weight"] = (
                     mla_slice_fn,
-                    {"head_num": 1, "axis": 1, "head_split_sizes": [config.kv_lora_rank, config.qk_rope_head_dim]},
+                    {"head_num": 1, "axis": -1, "head_split_sizes": [config.kv_lora_rank, config.qk_rope_head_dim]},
                 )
 
                 slice_config[f"{prefix}.self_attn.kv_b_proj.weight"] = (
                     mla_slice_fn,
                     {
                         "head_num": num_attention_heads,
-                        "axis": 1,
+                        "axis": -1,
                         "head_split_sizes": [config.qk_nope_head_dim, v_head_dim],
                     },
                 )
@@ -398,7 +391,7 @@ class MiniMaxM2PreTrainedModel(PretrainedModel):
                 if use_gated_attn:
                     slice_config[f"{prefix}.self_attn.gate_proj.weight"] = (
                         mla_slice_fn,
-                        {"head_num": num_attention_heads, "axis": 1},
+                        {"head_num": num_attention_heads, "axis": -1},
                     )
 
         # Main layers


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models

### Description
<!-- Describe what this PR does -->
Muon优化器slice函数，从默认的2D矩阵升级到支持3D矩阵的slice切分，从而支持muon batch更新，提高计算密度。
算子从`addmm`变成`baddbmm`，不能做到逐位对齐，会有精度diff。