### PR TITLE
[release/1.3] Support configuring init_method_std via YAML/CLI

### DIFF
--- a/paddleformers/transformers/configuration_utils.py
+++ b/paddleformers/transformers/configuration_utils.py
@@ -541,6 +541,12 @@ class LlmMetaConfig:
             "Method to initialize weights of the output layer of both attention and MLP blocks.",
         ),
         (
+            "init_method_std",
+            float,
+            0.02,
+            "Standard deviation for initialization (Normal). Used to build the default init_method/output_layer_init_method when they are not explicitly set. Defaults to 0.02.",
+        ),
+        (
             "embedding_init_method",
             Optional[Any],
             None,

--- a/tests/config/ci/qwen3_pt.yaml
+++ b/tests/config/ci/qwen3_pt.yaml
@@ -19,6 +19,7 @@ prefetch_factor: 24
 model_name_or_path: ./Qwen3-30B-A3B-Base
 _attn_implementation: flashmask
 use_qk_norm: true
+init_method_std: 0.001
 
 ### finetuning
 # base


### PR DESCRIPTION
## 改动内容

Backport commit `330593cfd0ba2bc23010e6a70d1b3277ce8887cd` 到 `release/1.3` 分支。

源 PR：#4771

包含改动：

- `paddleformers/transformers/configuration_utils.py`：新增 `init_method_std` 配置项
- `tests/config/ci/qwen3_pt.yaml`：固定 `init_method_std: 0.02`
