### PR TITLE
fix: wrap AdamWCustom/AdamWMini update in no_grad to fix leaf tensor inplace error

### DIFF
--- a/paddleformers/utils/optimizer.py
+++ b/paddleformers/utils/optimizer.py
@@ -137,26 +137,28 @@ class AdamWMini(AdamW):
         if not multi_precision:
             master_weight = None
         lr = learning_rate * lr_ratio
-        if master_weight is not None:
-            p = master_weight
-        else:
-            p = param
-        p *= 1.0 - lr * coeff
-        mom1 = moment1
-        mom2 = moment2
+        with paddle.no_grad():
+            if master_weight is not None:
+                master_weight.stop_gradient = True
+                p = master_weight
+            else:
+                p = param
+            p *= 1.0 - lr * coeff
+            mom1 = moment1
+            mom2 = moment2
 
-        mom1 = beta1 * mom1 + (1.0 - beta1) * grad
-        mom2 = beta2 * mom2 + (1.0 - beta2) * (grad * grad).mean()
-        denom = mom2.sqrt() / (1.0 - beta2_pow).sqrt() + epsilon
-        p += (mom1 / denom) * (-(lr / (1.0 - beta1_pow)))
-        if master_weight is not None:
-            master_weight[:] = p
-            param[:] = p.astype(param.dtype)
-        else:
-            param[:] = p
-        moment1[:] = mom1
-        moment2[:] = mom2
-        beta1_pow[:], beta2_pow[:] = beta1 * beta1_pow[:], beta2 * beta2_pow[:]
+            mom1 = beta1 * mom1 + (1.0 - beta1) * grad
+            mom2 = beta2 * mom2 + (1.0 - beta2) * (grad * grad).mean()
+            denom = mom2.sqrt() / (1.0 - beta2_pow).sqrt() + epsilon
+            p += (mom1 / denom) * (-(lr / (1.0 - beta1_pow)))
+            if master_weight is not None:
+                master_weight[:] = p
+                param[:] = p.astype(param.dtype)
+            else:
+                param[:] = p
+            moment1[:] = mom1
+            moment2[:] = mom2
+            beta1_pow[:], beta2_pow[:] = beta1 * beta1_pow[:], beta2 * beta2_pow[:]
         return
 
 
@@ -391,30 +393,32 @@ class AdamWCustom(AdamW):
         if not multi_precision:
             master_weight = None
         lr = learning_rate * lr_ratio
-        if master_weight is not None:
-            p = master_weight
-        else:
-            p = param
+        with paddle.no_grad():
+            if master_weight is not None:
+                master_weight.stop_gradient = True
+                p = master_weight
+            else:
+                p = param
 
-        p *= 1.0 - lr * coeff
-        moment_dtype = moment1.dtype
-        mom1 = moment1.astype("float32")
-        mom2 = moment2.astype("float32")
+            p *= 1.0 - lr * coeff
+            moment_dtype = moment1.dtype
+            mom1 = moment1.astype("float32")
+            mom2 = moment2.astype("float32")
 
-        mom1 = beta1 * mom1 + (1.0 - beta1) * grad
-        mom2 = beta2 * mom2 + (1.0 - beta2) * grad * grad
-        denom = mom2.sqrt() / (1.0 - beta2_pow).sqrt() + epsilon
-        p += (mom1 / denom) * (-(lr / (1.0 - beta1_pow)))
+            mom1 = beta1 * mom1 + (1.0 - beta1) * grad
+            mom2 = beta2 * mom2 + (1.0 - beta2) * grad * grad
+            denom = mom2.sqrt() / (1.0 - beta2_pow).sqrt() + epsilon
+            p += (mom1 / denom) * (-(lr / (1.0 - beta1_pow)))
 
-        if master_weight is not None:
-            master_weight[:] = p
-            if not skip_update_param:
-                param[:] = p.astype(param.dtype)
-        else:
-            param[:] = p
-        moment1[:] = mom1.astype(moment_dtype)
-        moment2[:] = mom2.astype(moment_dtype)
-        beta1_pow[:], beta2_pow[:] = beta1 * beta1_pow[:], beta2 * beta2_pow[:]
+            if master_weight is not None:
+                master_weight[:] = p
+                if not skip_update_param:
+                    param[:] = p.astype(param.dtype)
+            else:
+                param[:] = p
+            moment1[:] = mom1.astype(moment_dtype)
+            moment2[:] = mom2.astype(moment_dtype)
+            beta1_pow[:], beta2_pow[:] = beta1 * beta1_pow[:], beta2 * beta2_pow[:]
         return
 
     def offload_optim(self, p):


### PR DESCRIPTION
## Problem
Training with AdamWCustom raises:

    ValueError: (InvalidArgument) Leaf Tensor (embedding_0.w_0_fp32_master_0)
    that doesn't stop gradient can't use inplace strategy.

## Root cause
`master_weight` is created via `paddle.cast(param, "float32")` /
`dequantize(...).astype("float32")`, inheriting `stop_gradient=False` from the
trainable param, and it is a leaf tensor. Paddle forbids inplace ops
(`p *= ...`, `master_weight[:] = ...`, `param[:] = ...`) on leaf tensors that
don't stop gradient.

## Fix
Run the parameter update under `paddle.no_grad()` (as Paddle's built-in
optimizers do) and set `master_weight.stop_gradient = True`. This only affects
autograd bookkeeping, not the optimizer math. Applied to both
`AdamWCustom.adamw_custom` and `AdamWMini.adamw_python`.