### PR TITLE
fix bug moe_expert bf16 memory can not be clear when ema is on

### DIFF
--- a/paddleformers/trainer/trainer_utils.py
+++ b/paddleformers/trainer/trainer_utils.py
@@ -1943,7 +1943,6 @@ class EMAStateAssembler:
         self.optimizer_name_suffix = optimizer_name_suffix
         self.model = model
         self.optimizer = optimizer
-        self.model_sharded_state_dict = self.model.sharded_state_dict()
         self.is_gpt_model = GPTModel is not None and isinstance(self.model, GPTModel)
         n_routed_experts = self.model.config.n_routed_experts
 
@@ -2246,7 +2245,7 @@ class EMAStateAssembler:
 
         ema_sharded_state_dict = {}
 
-        for k, v in self.model_sharded_state_dict.items():
+        for k, v in self.model.sharded_state_dict().items():
             if v.local_tensor.dtype == paddle.bfloat16:
                 ema_tensor = ema_params_recovered[self._rename(k, False)]
                 expected_shape = v.local_shape
@@ -2283,8 +2282,8 @@ class EMAStateAssembler:
             extra_params = ema_state_dict
 
         for k, v in extra_params.items():
-            assert k in self.model_sharded_state_dict, f"[EMAStateAssembler] {k} not in model_sharded_state_dict"
-            ref_tensor = self.model_sharded_state_dict[k]
+            assert k in self.model.sharded_state_dict(), f"[EMAStateAssembler] {k} not in model_sharded_state_dict"
+            ref_tensor = self.model.sharded_state_dict()[k]
             expected_shape = ref_tensor.local_shape
             if "grouped_gemm_experts" in k:
                 v = paddle.reshape(v, expected_shape)

--- a/paddleformers/trainer/trainer_utils.py
+++ b/paddleformers/trainer/trainer_utils.py
@@ -2245,7 +2245,9 @@ class EMAStateAssembler:
 
         ema_sharded_state_dict = {}
 
-        for k, v in self.model.sharded_state_dict().items():
+        model_sharded_state_dict = self.model.sharded_state_dict()
+
+        for k, v in model_sharded_state_dict.items():
             if v.local_tensor.dtype == paddle.bfloat16:
                 ema_tensor = ema_params_recovered[self._rename(k, False)]
                 expected_shape = v.local_shape
@@ -2282,15 +2284,14 @@ class EMAStateAssembler:
             extra_params = ema_state_dict
 
         for k, v in extra_params.items():
-            assert k in self.model.sharded_state_dict(), f"[EMAStateAssembler] {k} not in model_sharded_state_dict"
-            ref_tensor = self.model.sharded_state_dict()[k]
+            assert k in model_sharded_state_dict, f"[EMAStateAssembler] {k} not in model_sharded_state_dict"
+            ref_tensor = model_sharded_state_dict[k]
             expected_shape = ref_tensor.local_shape
             if "grouped_gemm_experts" in k:
                 v = paddle.reshape(v, expected_shape)
             ema_sharded_state_dict[k] = create_sharded_weight_with_new_local(k, v, ref_tensor)
 
-        sharded_state_dict = self.model.sharded_state_dict()
-        for k, v in sharded_state_dict.items():
+        for k, v in model_sharded_state_dict.items():
             if v.local_tensor.stop_gradient and k not in ema_sharded_state_dict:
                 ema_sharded_state_dict[k] = v
         return ema_sharded_state_dict


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Description
fix bug moe_expert bf16 memory can not be clear when ema is on