### PR TITLE
[Config] Modify Config Default Value

### DIFF
--- a/examples/config/dpo-vl/full.yaml
+++ b/examples/config/dpo-vl/full.yaml
@@ -46,6 +46,7 @@ reference_free: false  # True only supports loss types of or, orpo, simpo, sigmo
 # performance
 tensor_model_parallel_size: 1
 pipeline_model_parallel_size: 1
+moe_token_dispatcher_type: deepep
 sharding: stage1
 recompute_granularity: full
 recompute_method: uniform
@@ -55,3 +56,10 @@ fp16_opt_level: O2
 unified_checkpoint: false
 save_checkpoint_format: "flex_checkpoint"
 load_checkpoint_format: "flex_checkpoint"
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/dpo-vl/full_fsdp.yaml
+++ b/examples/config/dpo-vl/full_fsdp.yaml
@@ -46,6 +46,7 @@ reference_free: false  # True only supports loss types of or, orpo, simpo, sigmo
 # performance
 tensor_model_parallel_size: 1
 pipeline_model_parallel_size: 1
+moe_token_dispatcher_type: deepep
 sharding: stage3
 recompute_granularity: full
 recompute_method: uniform
@@ -55,3 +56,10 @@ fp16_opt_level: O2
 unified_checkpoint: false
 save_checkpoint_format: "flex_checkpoint"
 load_checkpoint_format: "flex_checkpoint"
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/dpo-vl/full_tp.yaml
+++ b/examples/config/dpo-vl/full_tp.yaml
@@ -47,6 +47,7 @@ reference_free: false  # True only supports loss types of or, orpo, simpo, sigmo
 tensor_model_parallel_size: 2
 pipeline_model_parallel_size: 1
 sequence_parallel: true
+moe_token_dispatcher_type: deepep
 sharding: stage1
 recompute_granularity: full
 recompute_method: uniform
@@ -56,3 +57,10 @@ fp16_opt_level: O2
 unified_checkpoint: false
 save_checkpoint_format: "flex_checkpoint"
 load_checkpoint_format: "flex_checkpoint"
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/dpo-vl/lora.yaml
+++ b/examples/config/dpo-vl/lora.yaml
@@ -47,6 +47,7 @@ loss_type: sigmoid  # choices: [sigmoid (dpo), hinge, simpo, ipo, dpop, kto_pair
 # performance
 tensor_model_parallel_size: 1
 pipeline_model_parallel_size: 1
+moe_token_dispatcher_type: deepep
 sharding: stage1
 recompute_granularity: full
 recompute_method: uniform
@@ -56,3 +57,10 @@ fp16_opt_level: O2
 unified_checkpoint: false
 save_checkpoint_format: "flex_checkpoint"
 load_checkpoint_format: "flex_checkpoint"
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/dpo-vl/lora_fsdp.yaml
+++ b/examples/config/dpo-vl/lora_fsdp.yaml
@@ -47,6 +47,7 @@ loss_type: sigmoid  # choices: [sigmoid (dpo), hinge, simpo, ipo, dpop, kto_pair
 # performance
 tensor_model_parallel_size: 1
 pipeline_model_parallel_size: 1
+moe_token_dispatcher_type: deepep
 sharding: stage3
 recompute_granularity: full
 recompute_method: uniform
@@ -56,3 +57,10 @@ fp16_opt_level: O2
 unified_checkpoint: false
 save_checkpoint_format: "flex_checkpoint"
 load_checkpoint_format: "flex_checkpoint"
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/dpo-vl/lora_tp.yaml
+++ b/examples/config/dpo-vl/lora_tp.yaml
@@ -48,6 +48,7 @@ loss_type: sigmoid  # choices: [sigmoid (dpo), hinge, simpo, ipo, dpop, kto_pair
 tensor_model_parallel_size: 2
 pipeline_model_parallel_size: 1
 sequence_parallel: true
+moe_token_dispatcher_type: deepep
 sharding: stage1
 recompute_granularity: full
 recompute_method: uniform
@@ -57,3 +58,10 @@ fp16_opt_level: O2
 unified_checkpoint: false
 save_checkpoint_format: "flex_checkpoint"
 load_checkpoint_format: "flex_checkpoint"
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/dpo/full.yaml
+++ b/examples/config/dpo/full.yaml
@@ -46,6 +46,7 @@ reference_free: false  # True only supports loss types of or, orpo, simpo, sigmo
 # performance
 tensor_model_parallel_size: 1
 pipeline_model_parallel_size: 1
+moe_token_dispatcher_type: deepep
 sharding: stage1
 recompute_granularity: full
 recompute_method: uniform
@@ -55,3 +56,10 @@ fp16_opt_level: O2
 unified_checkpoint: false
 save_checkpoint_format: flex_checkpoint
 load_checkpoint_format: flex_checkpoint
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/dpo/full_function_call.yaml
+++ b/examples/config/dpo/full_function_call.yaml
@@ -49,6 +49,7 @@ reference_free: false  # True only supports loss types of or, orpo, simpo, sigmo
 # performance
 tensor_model_parallel_size: 1
 pipeline_model_parallel_size: 1
+moe_token_dispatcher_type: deepep
 sharding: stage1
 recompute_granularity: full
 recompute_method: uniform
@@ -58,3 +59,10 @@ fp16_opt_level: O2
 unified_checkpoint: false
 save_checkpoint_format: flex_checkpoint
 load_checkpoint_format: flex_checkpoint
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/dpo/full_tp_pp.yaml
+++ b/examples/config/dpo/full_tp_pp.yaml
@@ -53,6 +53,7 @@ clear_every_step_cache: true
 partial_send_recv: false
 
 sequence_parallel: true
+moe_token_dispatcher_type: deepep
 sharding: stage1
 recompute_granularity: full
 recompute_method: uniform
@@ -62,3 +63,10 @@ fp16_opt_level: O2
 unified_checkpoint: false
 save_checkpoint_format: flex_checkpoint
 load_checkpoint_format: flex_checkpoint
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/dpo/full_tp_pp_ep.yaml
+++ b/examples/config/dpo/full_tp_pp_ep.yaml
@@ -63,6 +63,7 @@ bf16: true
 fp16_opt_level: O2
 use_expert_parallel: true
 expert_model_parallel_size: 4
+moe_token_dispatcher_type: deepep
 
 # sharding_parallel_config
 split_param: true
@@ -75,3 +76,9 @@ sync_grad: true
 
 save_checkpoint_format: flex_checkpoint
 load_checkpoint_format: flex_checkpoint
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false

--- a/examples/config/dpo/lora.yaml
+++ b/examples/config/dpo/lora.yaml
@@ -47,6 +47,7 @@ loss_type: sigmoid  # choices: [sigmoid (dpo), hinge, simpo, ipo, dpop, kto_pair
 # performance
 tensor_model_parallel_size: 1
 pipeline_model_parallel_size: 1
+moe_token_dispatcher_type: deepep
 sharding: stage1
 recompute_granularity: full
 recompute_method: uniform
@@ -56,3 +57,10 @@ fp16_opt_level: O2
 unified_checkpoint: false
 save_checkpoint_format: flex_checkpoint
 load_checkpoint_format: flex_checkpoint
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/dpo/lora_tp_pp.yaml
+++ b/examples/config/dpo/lora_tp_pp.yaml
@@ -53,6 +53,7 @@ clear_every_step_cache: true
 partial_send_recv: false
 
 sequence_parallel: true
+moe_token_dispatcher_type: deepep
 sharding: stage1
 recompute_granularity: full
 recompute_method: uniform
@@ -62,3 +63,10 @@ fp16_opt_level: O2
 unified_checkpoint: false
 save_checkpoint_format: flex_checkpoint
 load_checkpoint_format: flex_checkpoint
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/dpo/lora_tp_pp_ep.yaml
+++ b/examples/config/dpo/lora_tp_pp_ep.yaml
@@ -50,6 +50,7 @@ pipeline_model_parallel_size: 2
 expert_model_parallel_size: 4
 use_expert_parallel: true
 sequence_parallel: true
+moe_token_dispatcher_type: deepep
 
 # pipeline_parallel_config
 clear_every_step_cache: true
@@ -64,3 +65,10 @@ fp16_opt_level: O2
 amp_master_grad: true
 save_checkpoint_format: flex_checkpoint
 load_checkpoint_format: flex_checkpoint
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/pt/eb45_pretrain/21b_8_gpus.yaml
+++ b/examples/config/pt/eb45_pretrain/21b_8_gpus.yaml
@@ -16,6 +16,7 @@ tokenizer_name_or_path: examples/experiments/ernie_pretrain/ernie/src/tokenizers
 moe_router_bias_update_rate: 0.001
 moe_with_send_router_loss: False
 moe_group: ep
+moe_token_dispatcher_type: deepep
 use_moe: true
 
 # train
@@ -95,3 +96,7 @@ ernie_model_config:
         spaq: true
         transpose_split_quant: true
     use_combine_before_a2a: true
+
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/pt/eb45_pretrain/300b_2016_gpus.yaml
+++ b/examples/config/pt/eb45_pretrain/300b_2016_gpus.yaml
@@ -18,6 +18,7 @@ tokenizer_name_or_path: examples/experiments/ernie_pretrain/ernie/src/tokenizers
 moe_router_bias_update_rate: 0.001
 moe_with_send_router_loss: False
 moe_group: ep
+moe_token_dispatcher_type: deepep
 use_moe: true
 
 # train
@@ -114,3 +115,6 @@ ernie_model_config:
         transpose_split_quant: true
 
     moe_gate: top2_fused
+
+save_safetensors: false
+batch_p2p_comm: true

--- a/examples/config/pt/eb45_pretrain/300b_4_nodes_ce.yaml
+++ b/examples/config/pt/eb45_pretrain/300b_4_nodes_ce.yaml
@@ -18,6 +18,7 @@ tokenizer_name_or_path: examples/experiments/ernie_pretrain/ernie/src/tokenizers
 moe_router_bias_update_rate: 0.001
 moe_with_send_router_loss: False
 moe_group: ep
+moe_token_dispatcher_type: deepep
 use_moe: true
 
 # train
@@ -123,3 +124,6 @@ ernie_model_config:
         transpose_split_quant: true
 
     moe_gate: top2_fused
+
+save_safetensors: false
+batch_p2p_comm: true

--- a/examples/config/pt/eb45_pretrain/300b_8_gpus_ci.yaml
+++ b/examples/config/pt/eb45_pretrain/300b_8_gpus_ci.yaml
@@ -16,6 +16,7 @@ tokenizer_name_or_path: examples/experiments/ernie_pretrain/ernie/src/tokenizers
 moe_router_bias_update_rate: 0.001
 moe_with_send_router_loss: False
 moe_group: ep
+moe_token_dispatcher_type: deepep
 use_moe: true
 
 # train
@@ -114,3 +115,6 @@ ernie_model_config:
         spaq: true
     transpose_split_quant: true
     moe_gate: top2_fused
+
+save_safetensors: false
+batch_p2p_comm: true

--- a/examples/config/pt/eb45_pretrain/300b_96gpus.yaml
+++ b/examples/config/pt/eb45_pretrain/300b_96gpus.yaml
@@ -18,6 +18,7 @@ tokenizer_name_or_path: examples/experiments/ernie_pretrain/ernie/src/tokenizers
 moe_router_bias_update_rate: 0.001
 moe_with_send_router_loss: False
 moe_group: ep
+moe_token_dispatcher_type: deepep
 use_moe: true
 
 # train
@@ -115,3 +116,6 @@ ernie_model_config:
         transpose_split_quant: true
 
     moe_gate: top2_fused
+
+save_safetensors: false
+batch_p2p_comm: true

--- a/examples/config/pt/eb45_pretrain/300b_96gpus_small_acc.yaml
+++ b/examples/config/pt/eb45_pretrain/300b_96gpus_small_acc.yaml
@@ -18,6 +18,7 @@ tokenizer_name_or_path: examples/experiments/ernie_pretrain/ernie/src/tokenizers
 moe_router_bias_update_rate: 0.001
 moe_with_send_router_loss: False
 moe_group: ep
+moe_token_dispatcher_type: deepep
 use_moe: true
 
 # train
@@ -118,3 +119,6 @@ ernie_model_config:
         transpose_split_quant: true
 
     moe_gate: top2_fused
+
+save_safetensors: false
+batch_p2p_comm: true

--- a/examples/config/pt/full.yaml
+++ b/examples/config/pt/full.yaml
@@ -51,3 +51,11 @@ fp16_opt_level: O2
 unified_checkpoint: false
 save_checkpoint_format: flex_checkpoint
 load_checkpoint_format: flex_checkpoint
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+moe_token_dispatcher_type: deepep
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/pt/full_offline_data.yaml
+++ b/examples/config/pt/full_offline_data.yaml
@@ -47,3 +47,11 @@ bf16: true
 fp16_opt_level: O2
 load_checkpoint_format: flex_checkpoint
 save_checkpoint_format: flex_checkpoint
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+moe_token_dispatcher_type: deepep
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/pt/full_tp_pp.yaml
+++ b/examples/config/pt/full_tp_pp.yaml
@@ -52,3 +52,11 @@ fp16_opt_level: O2
 unified_checkpoint: false
 save_checkpoint_format: flex_checkpoint
 load_checkpoint_format: flex_checkpoint
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+moe_token_dispatcher_type: deepep
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/pt/full_tp_pp_ep.yaml
+++ b/examples/config/pt/full_tp_pp_ep.yaml
@@ -70,3 +70,10 @@ sync_grad: true
 
 save_checkpoint_format: flex_checkpoint
 load_checkpoint_format: flex_checkpoint
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+moe_token_dispatcher_type: deepep
+save_safetensors: false
+overlap_p2p_comm: false

--- a/examples/config/pt/lora.yaml
+++ b/examples/config/pt/lora.yaml
@@ -53,3 +53,11 @@ fp16_opt_level: O2
 unified_checkpoint: false
 save_checkpoint_format: flex_checkpoint
 load_checkpoint_format: flex_checkpoint
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+moe_token_dispatcher_type: deepep
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/pt/lora_tp_pp.yaml
+++ b/examples/config/pt/lora_tp_pp.yaml
@@ -54,3 +54,11 @@ fp16_opt_level: O2
 unified_checkpoint: false
 save_checkpoint_format: flex_checkpoint
 load_checkpoint_format: flex_checkpoint
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+moe_token_dispatcher_type: deepep
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/pt/lora_tp_pp_ep.yaml
+++ b/examples/config/pt/lora_tp_pp_ep.yaml
@@ -70,3 +70,10 @@ sync_grad: true
 
 save_checkpoint_format: flex_checkpoint
 load_checkpoint_format: flex_checkpoint
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+moe_token_dispatcher_type: deepep
+save_safetensors: false
+overlap_p2p_comm: false

--- a/examples/config/sft-vl/full.yaml
+++ b/examples/config/sft-vl/full.yaml
@@ -44,6 +44,7 @@ learning_rate: 1.0e-5
 # performance
 tensor_model_parallel_size: 1
 pipeline_model_parallel_size: 1
+moe_token_dispatcher_type: deepep
 sharding: stage1
 recompute_granularity: full
 recompute_method: uniform
@@ -55,3 +56,10 @@ save_checkpoint_format: "flex_checkpoint"
 load_checkpoint_format: "flex_checkpoint"
 freeze_config: freeze_vision freeze_aligner
 high_precision_rope: true
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/sft-vl/full_fsdp.yaml
+++ b/examples/config/sft-vl/full_fsdp.yaml
@@ -44,6 +44,7 @@ learning_rate: 1.0e-5
 # performance
 tensor_model_parallel_size: 1
 pipeline_model_parallel_size: 1
+moe_token_dispatcher_type: deepep
 sharding: stage3
 recompute_granularity: full
 recompute_method: uniform
@@ -54,3 +55,10 @@ unified_checkpoint: false
 save_checkpoint_format: "flex_checkpoint"
 load_checkpoint_format: "flex_checkpoint"
 freeze_config: freeze_vision freeze_aligner
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/sft-vl/full_tp.yaml
+++ b/examples/config/sft-vl/full_tp.yaml
@@ -44,6 +44,7 @@ learning_rate: 1.0e-5
 # performance
 tensor_model_parallel_size: 2
 pipeline_model_parallel_size: 1
+moe_token_dispatcher_type: deepep
 sequence_parallel: true
 sharding: stage1
 recompute_granularity: full
@@ -56,3 +57,10 @@ save_checkpoint_format: "flex_checkpoint"
 load_checkpoint_format: "flex_checkpoint"
 freeze_config: freeze_vision freeze_aligner
 high_precision_rope: true
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/sft-vl/lora.yaml
+++ b/examples/config/sft-vl/lora.yaml
@@ -46,6 +46,7 @@ learning_rate: 1.0e-4
 # performance
 tensor_model_parallel_size: 1
 pipeline_model_parallel_size: 1
+moe_token_dispatcher_type: deepep
 sharding: stage1
 recompute_granularity: full
 recompute_method: uniform
@@ -57,3 +58,10 @@ save_checkpoint_format: "flex_checkpoint"
 load_checkpoint_format: "flex_checkpoint"
 freeze_config: freeze_vision freeze_aligner
 high_precision_rope: true
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/sft-vl/lora_fsdp.yaml
+++ b/examples/config/sft-vl/lora_fsdp.yaml
@@ -46,6 +46,7 @@ learning_rate: 1.0e-4
 # performance
 tensor_model_parallel_size: 1
 pipeline_model_parallel_size: 1
+moe_token_dispatcher_type: deepep
 sharding: stage3
 recompute_granularity: full
 recompute_method: uniform
@@ -56,3 +57,10 @@ unified_checkpoint: false
 save_checkpoint_format: "flex_checkpoint"
 load_checkpoint_format: "flex_checkpoint"
 freeze_config: freeze_vision freeze_aligner
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/sft-vl/lora_tp.yaml
+++ b/examples/config/sft-vl/lora_tp.yaml
@@ -46,6 +46,7 @@ learning_rate: 1.0e-4
 # performance
 tensor_model_parallel_size: 2
 pipeline_model_parallel_size: 1
+moe_token_dispatcher_type: deepep
 sequence_parallel: true
 sharding: stage1
 recompute_granularity: full
@@ -57,3 +58,10 @@ unified_checkpoint: false
 save_checkpoint_format: "flex_checkpoint"
 load_checkpoint_format: "flex_checkpoint"
 freeze_config: freeze_vision freeze_aligner
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/sft/full.yaml
+++ b/examples/config/sft/full.yaml
@@ -44,6 +44,7 @@ learning_rate: 1.0e-5
 # performance
 tensor_model_parallel_size: 1
 pipeline_model_parallel_size: 1
+moe_token_dispatcher_type: deepep
 sharding: stage1
 recompute_granularity: full
 recompute_method: uniform
@@ -53,3 +54,10 @@ fp16_opt_level: O2
 unified_checkpoint: false
 save_checkpoint_format: flex_checkpoint
 load_checkpoint_format: flex_checkpoint
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/sft/full_function_call.yaml
+++ b/examples/config/sft/full_function_call.yaml
@@ -47,6 +47,7 @@ learning_rate: 1.0e-5
 # performance
 tensor_model_parallel_size: 1
 pipeline_model_parallel_size: 1
+moe_token_dispatcher_type: deepep
 sharding: stage1
 recompute_granularity: full
 recompute_method: uniform
@@ -56,3 +57,10 @@ fp16_opt_level: O2
 unified_checkpoint: false
 save_checkpoint_format: flex_checkpoint
 load_checkpoint_format: flex_checkpoint
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/sft/full_map.yaml
+++ b/examples/config/sft/full_map.yaml
@@ -45,6 +45,7 @@ learning_rate: 1.0e-5
 # performance
 tensor_model_parallel_size: 1
 pipeline_model_parallel_size: 1
+moe_token_dispatcher_type: deepep
 sharding: stage1
 recompute_granularity: full
 recompute_method: uniform
@@ -54,3 +55,10 @@ fp16_opt_level: O2
 unified_checkpoint: false
 save_checkpoint_format: flex_checkpoint
 load_checkpoint_format: flex_checkpoint
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/sft/full_tp_pp.yaml
+++ b/examples/config/sft/full_tp_pp.yaml
@@ -44,6 +44,7 @@ learning_rate: 1.0e-5
 # performance
 tensor_model_parallel_size: 2
 pipeline_model_parallel_size: 2
+moe_token_dispatcher_type: deepep
 sequence_parallel: true
 sharding: stage1
 recompute_granularity: full
@@ -54,3 +55,10 @@ fp16_opt_level: O2
 unified_checkpoint: false
 save_checkpoint_format: flex_checkpoint
 load_checkpoint_format: flex_checkpoint
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/sft/full_tp_pp_ep.yaml
+++ b/examples/config/sft/full_tp_pp_ep.yaml
@@ -46,6 +46,7 @@ learning_rate: 1.0e-5
 # performance
 tensor_model_parallel_size: 2
 pipeline_model_parallel_size: 2
+moe_token_dispatcher_type: deepep
 sequence_parallel: true
 sharding: stage1
 recompute_granularity: full
@@ -72,3 +73,9 @@ sync_grad: true
 
 save_checkpoint_format: flex_checkpoint
 load_checkpoint_format: flex_checkpoint
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false

--- a/examples/config/sft/lora.yaml
+++ b/examples/config/sft/lora.yaml
@@ -46,6 +46,7 @@ learning_rate: 1.0e-4
 # performance
 tensor_model_parallel_size: 1
 pipeline_model_parallel_size: 1
+moe_token_dispatcher_type: deepep
 sharding: stage1
 recompute_granularity: full
 recompute_method: uniform
@@ -55,3 +56,10 @@ fp16_opt_level: O2
 unified_checkpoint: false
 save_checkpoint_format: flex_checkpoint
 load_checkpoint_format: flex_checkpoint
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/sft/lora_tp_pp.yaml
+++ b/examples/config/sft/lora_tp_pp.yaml
@@ -46,6 +46,7 @@ learning_rate: 1.0e-4
 # performance
 tensor_model_parallel_size: 2
 pipeline_model_parallel_size: 2
+moe_token_dispatcher_type: deepep
 sequence_parallel: true
 sharding: stage1
 recompute_granularity: full
@@ -56,3 +57,10 @@ fp16_opt_level: O2
 unified_checkpoint: false
 save_checkpoint_format: flex_checkpoint
 load_checkpoint_format: flex_checkpoint
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/sft/lora_tp_pp_ep.yaml
+++ b/examples/config/sft/lora_tp_pp_ep.yaml
@@ -48,6 +48,7 @@ tensor_model_parallel_size: 2
 pipeline_model_parallel_size: 2
 expert_model_parallel_size: 4
 use_expert_parallel: true
+moe_token_dispatcher_type: deepep
 sequence_parallel: true
 sharding: stage1
 recompute_granularity: full
@@ -58,3 +59,10 @@ fp16_opt_level: O2
 amp_master_grad: true
 save_checkpoint_format: flex_checkpoint
 load_checkpoint_format: flex_checkpoint
+
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/xpu/PaddleOCR-VL/sft/paddleocr-vl_full_16k_config.yaml
+++ b/examples/config/xpu/PaddleOCR-VL/sft/paddleocr-vl_full_16k_config.yaml
@@ -71,3 +71,9 @@ load_checkpoint_format: "flex_checkpoint"
 
 # device
 device: xpu
+
+moe_token_dispatcher_type: "deepep"
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/xpu/PaddleOCR-VL/sft/paddleocr-vl_lora_16k_config.yaml
+++ b/examples/config/xpu/PaddleOCR-VL/sft/paddleocr-vl_lora_16k_config.yaml
@@ -73,3 +73,9 @@ load_checkpoint_format: "flex_checkpoint"
 
 # device
 device: xpu
+
+moe_token_dispatcher_type: "deepep"
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/examples/config/xpu/PaddleOCR-VL/sft/paddleocr-vl_lora_export.yaml
+++ b/examples/config/xpu/PaddleOCR-VL/sft/paddleocr-vl_lora_export.yaml
@@ -4,3 +4,11 @@ model_name_or_path: PaddlePaddle/PaddleOCR-VL
 output_dir: ./PaddleOCR-VL-SFT-Bengali-lora
 copy_custom_file_list: "configuration_paddleocr_vl.py image_processing_paddleocr_vl.py modeling_paddleocr_vl.py processing_paddleocr_vl.py inference.yml"
 device: xpu
+
+moe_token_dispatcher_type: "deepep"
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/paddleformers/trainer/training_args.py
+++ b/paddleformers/trainer/training_args.py
@@ -548,7 +548,7 @@ class TrainingArguments:
         default=IntervalStrategy.STEPS,
         metadata={"help": "The logging strategy to use."},
     )
-    logging_first_step: bool = field(default=True, metadata={"help": "Log the first global_step"})
+    logging_first_step: bool = field(default=False, metadata={"help": "Log the first global_step"})
     logging_steps: int = field(default=5, metadata={"help": "Log every X updates steps."})
 
     save_strategy: IntervalStrategy = field(
@@ -1975,6 +1975,9 @@ class TrainingArguments:
                     raise ValueError(
                         "pipeline parallel is not compatible for sharding stage2 or stage3, please using sharding stage1"
                     )
+
+            if self.batch_p2p_comm is None:
+                self.batch_p2p_comm = not self.overlap_p2p_comm
 
             # TODO use paddle.distributed.is_initialized() after paddle 2.4rc
             if not paddle.distributed.parallel.parallel_helper._is_parallel_ctx_initialized():

--- a/paddleformers/trainer/training_args.py
+++ b/paddleformers/trainer/training_args.py
@@ -489,10 +489,10 @@ class TrainingArguments:
         metadata={"help": "Number of predictions steps to accumulate before moving the tensors to the CPU."},
     )
 
-    learning_rate: float = field(default=5e-5, metadata={"help": "The initial learning rate for AdamW."})
-    weight_decay: float = field(default=0.0, metadata={"help": "Weight decay for AdamW if we apply some."})
+    learning_rate: float = field(default=1e-5, metadata={"help": "The initial learning rate for AdamW."})
+    weight_decay: float = field(default=0.1, metadata={"help": "Weight decay for AdamW if we apply some."})
     adam_beta1: float = field(default=0.9, metadata={"help": "Beta1 for AdamW optimizer"})
-    adam_beta2: float = field(default=0.999, metadata={"help": "Beta2 for AdamW optimizer"})
+    adam_beta2: float = field(default=0.95, metadata={"help": "Beta2 for AdamW optimizer"})
     adam_epsilon: float = field(default=1e-8, metadata={"help": "Epsilon for AdamW optimizer."})
     max_grad_norm: float = field(default=1.0, metadata={"help": "Max gradient norm."})
 
@@ -514,7 +514,7 @@ class TrainingArguments:
     power: float = field(default=1.0, metadata={"help": "The power factor in the polynomial scheduler."})
     min_lr: float = field(default=0.0, metadata={"help": "The minimum learning rate in cosine scheduler."})
     moe_router_bias_update_rate: float = field(
-        default=0.0,
+        default=1.0e-3,
         metadata={
             "help": """The expert bias is updated based on the number of assigned tokens to each expert
         in a global batch, where the bias is increased for the experts with less assigned tokens
@@ -548,8 +548,8 @@ class TrainingArguments:
         default=IntervalStrategy.STEPS,
         metadata={"help": "The logging strategy to use."},
     )
-    logging_first_step: bool = field(default=False, metadata={"help": "Log the first global_step"})
-    logging_steps: int = field(default=500, metadata={"help": "Log every X updates steps."})
+    logging_first_step: bool = field(default=True, metadata={"help": "Log the first global_step"})
+    logging_steps: int = field(default=5, metadata={"help": "Log every X updates steps."})
 
     save_strategy: IntervalStrategy = field(
         default=IntervalStrategy.STEPS,
@@ -692,7 +692,7 @@ class TrainingArguments:
     )
 
     dsa_indexer_loss_coeff: float = field(
-        default=0.01,
+        default=0.0,
         metadata={"help": "Loss coefficient for the DSA indexer; controls the weight of the indexer loss term."},
     )
 
@@ -1401,11 +1401,11 @@ class TrainingArguments:
         default=False, metadata={"help": "Whether to use asynchronous reduce-scatter for sharding parallelism (SP)."}
     )
     overlap_p2p_comm: bool = field(
-        default=False,
-        metadata={"help": "Whether to overlap point-to-point (P2P) communication with computation. Defaults to True."},
+        default=True,
+        metadata={"help": "Whether to overlap point-to-point (P2P) communication with computation."},
     )
-    batch_p2p_comm: bool = field(
-        default=True, metadata={"help": "Whether to batch point-to-point (P2P) communication requests."}
+    batch_p2p_comm: Optional[bool] = field(
+        default=None, metadata={"help": "Whether to batch point-to-point (P2P) communication requests."}
     )
     variable_seq_lengths: bool = field(
         default=False,
@@ -1724,11 +1724,6 @@ class TrainingArguments:
         metadata={
             "help": "When enabled, the computation part of the moelayer will use the implementation provided by SonicMoE."
         },
-    )
-
-    dsa_indexer_loss_coeff: float = field(
-        default=0.01,
-        metadata={"help": "Loss coefficient for the DSA indexer; controls the weight of the indexer loss term."},
     )
 
     online_merge_ema: bool = field(

--- a/paddleformers/transformers/configuration_utils.py
+++ b/paddleformers/transformers/configuration_utils.py
@@ -300,19 +300,18 @@ class LlmMetaConfig:
             "The number of tokens in each subbatch for MoE model processing.",
         ),
         ("moe_router_force_load_balancing", bool, False, "Whether to fake gate."),
-        ("moe_token_dispatcher_type", str, "deepep", 'Communication type used by MoE module "deepep" or "alltoall". '),
+        (
+            "moe_token_dispatcher_type",
+            str,
+            "alltoall",
+            'Communication type used by MoE module "deepep" or "alltoall". ',
+        ),
         ("use_unified_moe", bool, False, "Whether to use unified moe."),
         (
             "moe_deepep_num_sms",
             Optional[bool],
             None,
             "Whether to enable DeepEP (Deep Expert Pruning) with SMS (Sub-Model Selection) for MoE. Defaults to False.",
-        ),
-        (
-            "moe_token_dispatcher_type",
-            str,
-            "deepep",
-            "Type of token dispatcher for MoE (e.g., 'round_robin', 'top_k'). Defaults to None (use default dispatcher).",
         ),
         (
             "moe_use_fusion_node",
@@ -420,7 +419,7 @@ class LlmMetaConfig:
         (
             "dsa_indexer_loss_coeff",
             float,
-            0.01,
+            0.0,
             "Loss coefficient for the DSA indexer; controls the weight of the indexer loss term.",
         ),
     ]
@@ -803,7 +802,7 @@ class PretrainedConfig:
             `"single_label_classification"` or `"multi_label_classification"`.
         moe_subbatch_token_num_before_dispatch (`int`, *optional*, defaults to 0):
             The number of tokens in a subbatch for MoE.
-        moe_token_dispatcher_type (`str`, *optional*, defaults to `deepep`):
+        moe_token_dispatcher_type (`str`, *optional*, defaults to `alltoall`):
             Communication type for expert parallel. Can be one of `deepep`, `alltoall`.
         use_unified_moe (`bool`, *optional*, defaults to `False`):
             Whether to use unified MoE.
@@ -956,7 +955,6 @@ class PretrainedConfig:
         self.dpo_config = kwargs.pop("dpo_config", None)
         self.kto_config = kwargs.pop("kto_config", None)
 
-        self.moe_token_dispatcher_type = kwargs.pop("moe_token_dispatcher_type", "deepep")
         self.use_unified_moe = kwargs.pop("use_unified_moe", False)
         self.moe_router_force_load_balancing = kwargs.pop("moe_router_force_load_balancing", False)
 

--- a/paddleformers/transformers/configuration_utils.py
+++ b/paddleformers/transformers/configuration_utils.py
@@ -995,11 +995,6 @@ class PretrainedConfig:
                 "Transformers. Using `model.gradient_checkpointing_enable()` instead, or if you are using the "
                 "`Trainer` API, pass `gradient_checkpointing=True` in your `TrainingArguments`."
             )
-        if "save_to_hf" in kwargs:
-            raise ValueError(
-                "The parameter `save_to_hf` has been renamed to `save_safetensors`. "
-                "Please update your code or config accordingly."
-            )
         self._save_safetensors = kwargs.pop("save_safetensors", True)
         self._unsavable_keys.add("_save_safetensors")
 
@@ -1100,11 +1095,6 @@ class PretrainedConfig:
 
         os.makedirs(save_directory, exist_ok=True)
 
-        if "save_to_hf" in kwargs:
-            raise ValueError(
-                "The parameter `save_to_hf` has been renamed to `save_safetensors`. "
-                "Please update your code or config accordingly."
-            )
         self._save_safetensors = kwargs.pop("save_safetensors", True)
 
         # If we have a custom config, we copy the file defining it in the folder and set the attributes so it can be

--- a/scripts/xpu_ci/config/ernie_21b_sft.yaml
+++ b/scripts/xpu_ci/config/ernie_21b_sft.yaml
@@ -58,5 +58,14 @@ load_checkpoint_format: flex_checkpoint
 save_checkpoint_format: flex_checkpoint
 
 moe_expert_fusion: false
+moe_token_dispatcher_type: "deepep"
 
 device: xpu
+
+# 显式固定历史默认值；避免新默认值改变此配置行为。
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true

--- a/scripts/xpu_ci/config/ernie_vl_28b_sft.yaml
+++ b/scripts/xpu_ci/config/ernie_vl_28b_sft.yaml
@@ -74,3 +74,10 @@ amp_master_grad: 1
 moe_expert_fusion: false
 
 device: xpu
+
+# 显式固定历史默认值；避免新默认值改变此配置行为。
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+batch_p2p_comm: true

--- a/tests/ai_edited_test/nn/test_ai_moe_deepep_layer.py
+++ b/tests/ai_edited_test/nn/test_ai_moe_deepep_layer.py
@@ -72,11 +72,6 @@ def _make_modular_moe_layer(
         moe_expert_capacity_factor=moe_expert_capacity_factor,
         moe_token_drop_policy="probs",
     )
-    # PretrainedConfig.__init__ has a bug where set_expected_keys correctly
-    # reads moe_token_dispatcher_type from kwargs, but a later line
-    # (kwargs.pop with default "deepep") overwrites it. Fix it here.
-    pretrained_config.moe_token_dispatcher_type = moe_token_dispatcher_type
-
     moe_config = {
         "gate_activation": "softmax",
         "eval_capacity_factor": 1.0,
@@ -165,6 +160,20 @@ class TestModularMoELayer(unittest.TestCase):
         """Test that shared_experts is created when num_shared_experts > 0."""
         layer = _make_modular_moe_layer(num_shared_experts=1)
         self.assertIsNotNone(layer.shared_experts)
+
+    def test_pretrained_config_preserves_dispatcher_type(self):
+        """Test default and explicit dispatcher types are preserved."""
+        from paddleformers.transformers.configuration_utils import PretrainedConfig
+
+        self.assertEqual(PretrainedConfig().moe_token_dispatcher_type, "alltoall")
+        self.assertEqual(
+            PretrainedConfig(moe_token_dispatcher_type="deepep").moe_token_dispatcher_type,
+            "deepep",
+        )
+        self.assertEqual(
+            PretrainedConfig(moe_token_dispatcher_type="alltoall").moe_token_dispatcher_type,
+            "alltoall",
+        )
 
     def test_init_has_communication(self):
         """Test that communication module is created."""

--- a/tests/config/ci/dpskv4_dist.yaml
+++ b/tests/config/ci/dpskv4_dist.yaml
@@ -60,6 +60,7 @@ lr_scheduler_type: cosine
 # MoE
 moe_deep_gemm: false
 moe_router_force_load_balancing: false
+moe_token_dispatcher_type: "deepep"
 
 # pp
 pp_delay_scale_loss: true
@@ -113,4 +114,3 @@ recompute_num_layers: 1
 # 显式固定历史默认值；避免新默认值改变此配置行为。
 moe_router_bias_update_rate: 0.0
 batch_p2p_comm: true
-mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/dpskv4_dist.yaml
+++ b/tests/config/ci/dpskv4_dist.yaml
@@ -110,3 +110,7 @@ continue_training: true
 recompute_granularity: full
 recompute_method: uniform
 recompute_num_layers: 1
+# 显式固定历史默认值；避免新默认值改变此配置行为。
+moe_router_bias_update_rate: 0.0
+batch_p2p_comm: true
+mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/glm45_dpo.yaml
+++ b/tests/config/ci/glm45_dpo.yaml
@@ -78,4 +78,3 @@ moe_router_bias_update_rate: 0.0
 save_safetensors: false
 overlap_p2p_comm: false
 batch_p2p_comm: true
-mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/glm45_dpo.yaml
+++ b/tests/config/ci/glm45_dpo.yaml
@@ -71,3 +71,11 @@ num_empty_layers_add_in_tail: 1
 
 router_aux_loss_coef: 0.001
 moe_deep_gemm: false
+# 显式固定历史默认值；避免新默认值改变此配置行为。
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true
+mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/glm45_dpo_lora.yaml
+++ b/tests/config/ci/glm45_dpo_lora.yaml
@@ -80,4 +80,3 @@ moe_router_bias_update_rate: 0.0
 save_safetensors: false
 overlap_p2p_comm: false
 batch_p2p_comm: true
-mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/glm45_dpo_lora.yaml
+++ b/tests/config/ci/glm45_dpo_lora.yaml
@@ -72,3 +72,12 @@ num_empty_layers_add_in_tail: 1
 
 router_aux_loss_coef: 0.001
 moe_deep_gemm: false
+
+# 显式固定历史默认值；避免新默认值改变此配置行为。
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true
+mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/glm45_lora.yaml
+++ b/tests/config/ci/glm45_lora.yaml
@@ -67,3 +67,10 @@ num_empty_layers_add_in_tail: 1
 
 router_aux_loss_coef: 0.001
 moe_deep_gemm: false
+# 显式固定历史默认值；避免新默认值改变此配置行为。
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+overlap_p2p_comm: false
+batch_p2p_comm: true
+mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/glm45_lora.yaml
+++ b/tests/config/ci/glm45_lora.yaml
@@ -73,4 +73,3 @@ adam_beta2: 0.999
 moe_router_bias_update_rate: 0.0
 overlap_p2p_comm: false
 batch_p2p_comm: true
-mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/glm45_pt.yaml
+++ b/tests/config/ci/glm45_pt.yaml
@@ -86,3 +86,12 @@ num_hidden_layers: 3
 apply_rope_fusion: true
 moe_router_fusion: true
 moe_deep_gemm: false
+
+# 显式固定历史默认值；避免新默认值改变此配置行为。
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true
+mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/glm45_pt.yaml
+++ b/tests/config/ci/glm45_pt.yaml
@@ -94,4 +94,3 @@ moe_router_bias_update_rate: 0.0
 save_safetensors: false
 overlap_p2p_comm: false
 batch_p2p_comm: true
-mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/glm45_pt_fp8.yaml
+++ b/tests/config/ci/glm45_pt_fp8.yaml
@@ -81,3 +81,11 @@ moe_router_fusion: true
 router_aux_loss_coef: 0.001
 fp8: "e4m3"
 moe_deep_gemm: false
+# 显式固定历史默认值；避免新默认值改变此配置行为。
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true
+mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/glm45_pt_fp8.yaml
+++ b/tests/config/ci/glm45_pt_fp8.yaml
@@ -88,4 +88,3 @@ moe_router_bias_update_rate: 0.0
 save_safetensors: false
 overlap_p2p_comm: false
 batch_p2p_comm: true
-mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/glm45_pt_grouped_gemm.yaml
+++ b/tests/config/ci/glm45_pt_grouped_gemm.yaml
@@ -87,4 +87,3 @@ moe_router_bias_update_rate: 0.0
 save_safetensors: false
 overlap_p2p_comm: false
 batch_p2p_comm: true
-mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/glm45_pt_grouped_gemm.yaml
+++ b/tests/config/ci/glm45_pt_grouped_gemm.yaml
@@ -80,3 +80,11 @@ router_aux_loss_coef: 0.001
 # expert fusion
 moe_expert_fusion: true
 moe_deep_gemm: false
+# 显式固定历史默认值；避免新默认值改变此配置行为。
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true
+mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/glm45_sft.yaml
+++ b/tests/config/ci/glm45_sft.yaml
@@ -88,3 +88,10 @@ num_empty_layers_add_in_head: 1
 
 moe_deep_gemm: false
 
+
+# 显式固定历史默认值；避免新默认值改变此配置行为。
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+batch_p2p_comm: true
+mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/glm45_sft.yaml
+++ b/tests/config/ci/glm45_sft.yaml
@@ -94,4 +94,3 @@ weight_decay: 0.0
 adam_beta2: 0.999
 moe_router_bias_update_rate: 0.0
 batch_p2p_comm: true
-mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/glm45_sft_cp.yaml
+++ b/tests/config/ci/glm45_sft_cp.yaml
@@ -84,4 +84,3 @@ weight_decay: 0.0
 adam_beta2: 0.999
 moe_router_bias_update_rate: 0.0
 batch_p2p_comm: true
-mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/glm45_sft_cp.yaml
+++ b/tests/config/ci/glm45_sft_cp.yaml
@@ -79,3 +79,9 @@ pp_release_grads: true
 num_empty_layers_add_in_head: 1
 
 moe_deep_gemm: false
+# 显式固定历史默认值；避免新默认值改变此配置行为。
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+batch_p2p_comm: true
+mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/glm45_single_pt-test.yaml
+++ b/tests/config/ci/glm45_single_pt-test.yaml
@@ -85,3 +85,11 @@ num_nextn_predict_layers: 0
 # routed_scaling_factor: 1.0
 pipeline_model_parallel_size: 1
 moe_deep_gemm: false
+# 显式固定历史默认值；避免新默认值改变此配置行为。
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true
+mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/glm45_single_pt-test.yaml
+++ b/tests/config/ci/glm45_single_pt-test.yaml
@@ -92,4 +92,3 @@ moe_router_bias_update_rate: 0.0
 save_safetensors: false
 overlap_p2p_comm: false
 batch_p2p_comm: true
-mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/internlm3_sft.yaml
+++ b/tests/config/ci/internlm3_sft.yaml
@@ -51,6 +51,7 @@ sharding: stage1
 recompute_granularity: full
 recompute_method: uniform
 recompute_num_layers: 1
+moe_token_dispatcher_type: deepep
 bf16: true
 fp16_opt_level: O2
 unified_checkpoint: false
@@ -65,4 +66,3 @@ moe_router_bias_update_rate: 0.0
 save_safetensors: false
 overlap_p2p_comm: false
 batch_p2p_comm: true
-mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/internlm3_sft.yaml
+++ b/tests/config/ci/internlm3_sft.yaml
@@ -57,3 +57,12 @@ unified_checkpoint: false
 save_checkpoint_format: flex_checkpoint
 load_checkpoint_format: flex_checkpoint
 continue_training: false
+
+# 显式固定历史默认值；避免新默认值改变此配置行为。
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true
+mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/phi4_sft.yaml
+++ b/tests/config/ci/phi4_sft.yaml
@@ -50,3 +50,12 @@ fp16_opt_level: O2
 amp_master_grad: false
 save_checkpoint_format: "flex_checkpoint"
 load_checkpoint_format: "flex_checkpoint"
+
+# 显式固定历史默认值；避免新默认值改变此配置行为。
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true
+mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/phi4_sft.yaml
+++ b/tests/config/ci/phi4_sft.yaml
@@ -45,6 +45,7 @@ tensor_model_parallel_size: 1
 pipeline_model_parallel_size: 1
 sharding: stage1
 recompute_granularity: ""
+moe_token_dispatcher_type: deepep
 bf16: true
 fp16_opt_level: O2
 amp_master_grad: false
@@ -58,4 +59,3 @@ moe_router_bias_update_rate: 0.0
 save_safetensors: false
 overlap_p2p_comm: false
 batch_p2p_comm: true
-mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/qwen3_multicard_lora.yaml
+++ b/tests/config/ci/qwen3_multicard_lora.yaml
@@ -79,3 +79,11 @@ load_checkpoint_format: "flex_checkpoint"
 
 router_aux_loss_coef: 0.0
 moe_deep_gemm: false
+# 显式固定历史默认值；避免新默认值改变此配置行为。
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true
+mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/qwen3_multicard_lora.yaml
+++ b/tests/config/ci/qwen3_multicard_lora.yaml
@@ -55,6 +55,7 @@ moe_router_fusion: false
 moe_router_force_load_balancing: true
 # moe_expert_fusion: true
 moe_use_fusion_node: false
+moe_token_dispatcher_type: deepep
 
 sharding: stage1
 split_param: true
@@ -86,4 +87,3 @@ moe_router_bias_update_rate: 0.0
 save_safetensors: false
 overlap_p2p_comm: false
 batch_p2p_comm: true
-mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/qwen3_multicard_pt.yaml
+++ b/tests/config/ci/qwen3_multicard_pt.yaml
@@ -94,3 +94,11 @@ save_checkpoint_format: "flex_checkpoint"
 load_checkpoint_format: "flex_checkpoint"
 
 router_aux_loss_coef: 0.0
+# 显式固定历史默认值；避免新默认值改变此配置行为。
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true
+mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/qwen3_multicard_pt.yaml
+++ b/tests/config/ci/qwen3_multicard_pt.yaml
@@ -66,6 +66,7 @@ moe_router_fusion: false
 moe_router_force_load_balancing: true
 moe_expert_fusion: true
 moe_deep_gemm: false
+moe_token_dispatcher_type: deepep
 
 sharding: "stage1"
 split_param: true
@@ -101,4 +102,3 @@ moe_router_bias_update_rate: 0.0
 save_safetensors: false
 overlap_p2p_comm: false
 batch_p2p_comm: true
-mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/qwen3_multicard_sft.yaml
+++ b/tests/config/ci/qwen3_multicard_sft.yaml
@@ -64,6 +64,7 @@ apply_rope_fusion: true
 moe_router_fusion: false
 moe_router_force_load_balancing: true
 moe_expert_fusion: true
+moe_token_dispatcher_type: deepep
 
 sharding: stage1
 split_param: true
@@ -107,4 +108,3 @@ adam_beta2: 0.999
 moe_router_bias_update_rate: 0.0
 save_safetensors: false
 batch_p2p_comm: true
-mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/qwen3_multicard_sft.yaml
+++ b/tests/config/ci/qwen3_multicard_sft.yaml
@@ -101,3 +101,10 @@ load_checkpoint_format: "flex_checkpoint"
 
 router_aux_loss_coef: 0.0
 moe_deep_gemm: false
+# 显式固定历史默认值；避免新默认值改变此配置行为。
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+batch_p2p_comm: true
+mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/qwen3_pt.yaml
+++ b/tests/config/ci/qwen3_pt.yaml
@@ -66,6 +66,7 @@ moe_router_fusion: true
 # 
 moe_ep_barrier: false
 moe_router_force_load_balancing: false
+moe_token_dispatcher_type: deepep
 
 
 optim: adamw
@@ -88,4 +89,3 @@ moe_router_bias_update_rate: 0.0
 save_safetensors: false
 overlap_p2p_comm: false
 batch_p2p_comm: true
-mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/qwen3_pt.yaml
+++ b/tests/config/ci/qwen3_pt.yaml
@@ -81,3 +81,11 @@ moe_router_fusion: false
 
 router_aux_loss_coef: 0.0
 moe_deep_gemm: false
+# 显式固定历史默认值；避免新默认值改变此配置行为。
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true
+mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/qwen3vl_lora.yaml
+++ b/tests/config/ci/qwen3vl_lora.yaml
@@ -60,6 +60,7 @@ freeze_config: freeze_vision freeze_aligner
 processor_use_fast: false
 high_precision_rope: true
 moe_deep_gemm: false
+moe_token_dispatcher_type: deepep
 # 显式固定历史默认值；避免新默认值改变此配置行为。
 weight_decay: 0.0
 adam_beta2: 0.999
@@ -67,4 +68,3 @@ moe_router_bias_update_rate: 0.0
 save_safetensors: false
 overlap_p2p_comm: false
 batch_p2p_comm: true
-mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/qwen3vl_lora.yaml
+++ b/tests/config/ci/qwen3vl_lora.yaml
@@ -60,3 +60,11 @@ freeze_config: freeze_vision freeze_aligner
 processor_use_fast: false
 high_precision_rope: true
 moe_deep_gemm: false
+# 显式固定历史默认值；避免新默认值改变此配置行为。
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true
+mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/qwen3vl_sft.yaml
+++ b/tests/config/ci/qwen3vl_sft.yaml
@@ -60,6 +60,7 @@ freeze_config: freeze_vision freeze_aligner
 processor_use_fast: false
 high_precision_rope: true
 moe_deep_gemm: false
+moe_token_dispatcher_type: deepep
 # 显式固定历史默认值；避免新默认值改变此配置行为。
 weight_decay: 0.0
 adam_beta2: 0.999
@@ -67,4 +68,3 @@ moe_router_bias_update_rate: 0.0
 save_safetensors: false
 overlap_p2p_comm: false
 batch_p2p_comm: true
-mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/qwen3vl_sft.yaml
+++ b/tests/config/ci/qwen3vl_sft.yaml
@@ -60,3 +60,11 @@ freeze_config: freeze_vision freeze_aligner
 processor_use_fast: false
 high_precision_rope: true
 moe_deep_gemm: false
+# 显式固定历史默认值；避免新默认值改变此配置行为。
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true
+mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/qwen3vl_sft_fsdp.yaml
+++ b/tests/config/ci/qwen3vl_sft_fsdp.yaml
@@ -58,3 +58,11 @@ freeze_config: freeze_vision freeze_aligner
 processor_use_fast: false
 high_precision_rope: true
 moe_deep_gemm: false
+# 显式固定历史默认值；避免新默认值改变此配置行为。
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true
+mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/qwen3vl_sft_fsdp.yaml
+++ b/tests/config/ci/qwen3vl_sft_fsdp.yaml
@@ -58,6 +58,7 @@ freeze_config: freeze_vision freeze_aligner
 processor_use_fast: false
 high_precision_rope: true
 moe_deep_gemm: false
+moe_token_dispatcher_type: deepep
 # 显式固定历史默认值；避免新默认值改变此配置行为。
 weight_decay: 0.0
 adam_beta2: 0.999
@@ -65,4 +66,3 @@ moe_router_bias_update_rate: 0.0
 save_safetensors: false
 overlap_p2p_comm: false
 batch_p2p_comm: true
-mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/qwen3vl_sft_moe.yaml
+++ b/tests/config/ci/qwen3vl_sft_moe.yaml
@@ -104,3 +104,10 @@ freeze_config: freeze_vision freeze_aligner
 tensorwise_offload_optimizer: true
 processor_use_fast: false
 high_precision_rope: true
+# 显式固定历史默认值；避免新默认值改变此配置行为。
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+batch_p2p_comm: true
+mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/qwen3vl_sft_moe.yaml
+++ b/tests/config/ci/qwen3vl_sft_moe.yaml
@@ -62,6 +62,7 @@ recompute_num_layers: 1
 
 moe_expert_fusion: true
 moe_deep_gemm: false
+moe_token_dispatcher_type: deepep
 
 apply_rope_fusion: False
 # fuse_rms_norm: true
@@ -110,4 +111,3 @@ adam_beta2: 0.999
 moe_router_bias_update_rate: 0.0
 save_safetensors: false
 batch_p2p_comm: true
-mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/qwen3vl_sft_moe_a100.yaml
+++ b/tests/config/ci/qwen3vl_sft_moe_a100.yaml
@@ -97,4 +97,3 @@ adam_beta2: 0.999
 moe_router_bias_update_rate: 0.0
 save_safetensors: false
 batch_p2p_comm: true
-mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/qwen3vl_sft_moe_a100.yaml
+++ b/tests/config/ci/qwen3vl_sft_moe_a100.yaml
@@ -91,3 +91,10 @@ prefetch_factor: 8
 freeze_config: freeze_vision freeze_aligner
 tensorwise_offload_optimizer: true
 high_precision_rope: true
+# 显式固定历史默认值；避免新默认值改变此配置行为。
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+batch_p2p_comm: true
+mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/qwen3vl_sft_single.yaml
+++ b/tests/config/ci/qwen3vl_sft_single.yaml
@@ -57,6 +57,7 @@ freeze_config: freeze_vision freeze_aligner
 processor_use_fast: false
 high_precision_rope: true
 moe_deep_gemm: false
+moe_token_dispatcher_type: deepep
 # 显式固定历史默认值；避免新默认值改变此配置行为。
 weight_decay: 0.0
 adam_beta2: 0.999
@@ -64,4 +65,3 @@ moe_router_bias_update_rate: 0.0
 save_safetensors: false
 overlap_p2p_comm: false
 batch_p2p_comm: true
-mtp_loss_scaling_factor: 0.3

--- a/tests/config/ci/qwen3vl_sft_single.yaml
+++ b/tests/config/ci/qwen3vl_sft_single.yaml
@@ -57,3 +57,11 @@ freeze_config: freeze_vision freeze_aligner
 processor_use_fast: false
 high_precision_rope: true
 moe_deep_gemm: false
+# 显式固定历史默认值；避免新默认值改变此配置行为。
+weight_decay: 0.0
+adam_beta2: 0.999
+moe_router_bias_update_rate: 0.0
+save_safetensors: false
+overlap_p2p_comm: false
+batch_p2p_comm: true
+mtp_loss_scaling_factor: 0.3

--- a/tests/trainer/test_trainer_callback.py
+++ b/tests/trainer/test_trainer_callback.py
@@ -225,17 +225,19 @@ class TrainerCallbackTest(unittest.TestCase):
         expected_callbacks = DEFAULT_CALLBACKS.copy() + [PrinterCallback] + [MyTestTrainerCallback]
         self.check_callbacks_equality(trainer.callback_handler.callbacks, expected_callbacks)
 
-        trainer = self.get_trainer(callbacks=[MyTestTrainerCallback], save_steps=5)
+        trainer = self.get_trainer(callbacks=[MyTestTrainerCallback], logging_steps=500, save_steps=5)
         trainer.train()
         events = trainer.callback_handler.callbacks[-2].events
         self.assertEqual(events, self.get_expected_events(trainer))
 
-        trainer = self.get_trainer(callbacks=[MyTestTrainerCallback], eval_steps=5, evaluation_strategy="steps")
+        trainer = self.get_trainer(
+            callbacks=[MyTestTrainerCallback], logging_steps=500, eval_steps=5, evaluation_strategy="steps"
+        )
         trainer.train()
         events = trainer.callback_handler.callbacks[-2].events
         self.assertEqual(events, self.get_expected_events(trainer))
 
-        trainer = self.get_trainer(callbacks=[MyTestTrainerCallback], evaluation_strategy="epoch")
+        trainer = self.get_trainer(callbacks=[MyTestTrainerCallback], logging_steps=500, evaluation_strategy="epoch")
         trainer.train()
         events = trainer.callback_handler.callbacks[-2].events
         self.assertEqual(events, self.get_expected_events(trainer))
@@ -256,6 +258,7 @@ class TrainerCallbackTest(unittest.TestCase):
         # from paddleformers import transformers
         with patch("paddleformers.trainer.logger.warning") as warn_mock:
             trainer = self.get_trainer(
+                logging_steps=500,
                 callbacks=[MyTestTrainerCallback, MyTestTrainerCallback],
             )
             assert str(MyTestTrainerCallback) in warn_mock.call_args[0][0]


### PR DESCRIPTION

### PR types
Breaking changes

### PR changes
Models

### Description
fix(training_args): 调整默认训练参数以对齐 Megatron-Swift [https://swift.readthedocs.io/en/latest/Megatron-SWIFT/Command-line-parameters.html](https://swift.readthedocs.io/en/latest/Megatron-SWIFT/Command-line-parameters.html)

- 将learning_rate默认值从5e-5改为1e-5，weight_decay从0.0改为0.1
- 将adam_beta2默认值从0.999改为0.95
- 将moe_router_bias_update_rate默认值从0.0改为1e-3
- 将logging_steps从500改为5
- 将dsa_indexer_loss_coeff默认值从0.01改为0.0
- 将overlap_p2p_comm默认值设为True
- 将batch_p2p_comm字段类型改为Optional[bool]且默认值为None，并在验证阶段根据overlap_p2p_comm自动调整
- 将moe_token_dispatcher_type从deepep改为alltoall
- 移除重复的dsa_indexer_loss_coeff字段定义



