### PR TITLE
change default value to moe_dequant_input

### DIFF
--- a/paddleformers/transformers/configuration_utils.py
+++ b/paddleformers/transformers/configuration_utils.py
@@ -372,8 +372,8 @@ class LlmMetaConfig:
         (
             "moe_dequant_input",
             bool,
-            False,
-            "Whether to dequantize inputs to MoE experts (only applicable if inputs are quantized). Defaults to False (enable only for quantized inference/training pipelines).",
+            True,
+            "Whether to dequantize inputs to MoE experts (only applicable if inputs are quantized). Defaults to True to keep the fp8-dispatch fusion path consistent with FusionMoePyLayer's historical default.",
         ),
         (
             "moe_expert_fusion",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->

https://github.com/PaddlePaddle/PaddleFleet/pull/1536/changes

1. paddlefleet中发现MoELayer及FusionMoePyLayer一直没有透传moe_dequant_input这个参数，并且在FusionMoePyLayer中默认值为True，因此paddleformer中透传也没有生效，及时设置为false实际运行时仍为true。
2. 现在为fleet透传这个参数后，发现ci中有模型报错" AssertionError: 如果传入了scale, 说明a2a使用了fp8,。必须开启dequant_input"
3. 因此期望修改fleet及formers中默认值均为True，与旧逻辑保持一致

<img width="473" height="332" alt="image" src="https://github.com/user-attachments/assets/4039bc64-69fe-454e-978c-26a1e0674578" />

