### PR TITLE
fix: preserve Qwen3.5 MoE provider configuration

### DIFF
--- a/paddleformers/transformers/qwen3_5/configuration.py
+++ b/paddleformers/transformers/qwen3_5/configuration.py
@@ -158,7 +158,7 @@ class Qwen3_5TextConfig(PretrainedConfig):
     >>> configuration = model.config
     ```"""
 
-    model_type = "qwen3_vl_moe_text"
+    model_type = "qwen3_5_text"
     base_config_key = "text_config"
     keys_to_ignore_at_inference = ["past_key_values"]
 

--- a/paddleformers/transformers/qwen3_5/modeling_fleet.py
+++ b/paddleformers/transformers/qwen3_5/modeling_fleet.py
@@ -116,6 +116,14 @@ class Qwen3_5TextModelProvider(GPTModelProvider):
     rotary_percent: float = 0.25
     mrope_section: list = None
 
+    @classmethod
+    def from_config(cls, config):
+        # PretrainedConfig keeps model_type as a class attribute, while the
+        # provider converter only copies instance attributes.
+        provider_config = copy.copy(config)
+        provider_config.model_type = config.model_type
+        return super().from_config(provider_config)
+
     def __post_init__(self):
         super().__post_init__()
         # Qwen3.5 uses multimodal RoPE with 3D position_ids

--- a/paddleformers/transformers/qwen3_5_moe/configuration.py
+++ b/paddleformers/transformers/qwen3_5_moe/configuration.py
@@ -158,7 +158,7 @@ class Qwen3_5MoETextConfig(PretrainedConfig):
     >>> configuration = model.config
     ```"""
 
-    model_type = "qwen3_vl_moe_text"
+    model_type = "qwen3_5_moe_text"
     base_config_key = "text_config"
     keys_to_ignore_at_inference = ["past_key_values"]
 

--- a/tests/ai_edited_test/transformers/test_ai_qwen3_5_provider.py
+++ b/tests/ai_edited_test/transformers/test_ai_qwen3_5_provider.py
@@ -1,0 +1,45 @@
+from paddleformers.transformers.qwen3_5.configuration import Qwen3_5TextConfig
+from paddleformers.transformers.qwen3_5.modeling_fleet import Qwen3_5TextModelProvider
+from paddleformers.transformers.qwen3_5_moe.configuration import Qwen3_5MoETextConfig
+
+
+def provider_from(config):
+    return Qwen3_5TextModelProvider.from_config(config)
+
+
+def test_dense_provider_clears_default_expert_fields():
+    config = Qwen3_5TextConfig(
+        num_hidden_layers=2,
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        intermediate_size=128,
+        head_dim=16,
+    )
+
+    provider = provider_from(config)
+
+    assert provider.model_type == "qwen3_5_text"
+    assert provider.n_routed_experts is None
+    assert provider.n_shared_experts == 0
+    assert provider.moe_shared_expert_gate is False
+
+
+def test_moe_provider_preserves_routed_experts():
+    config = Qwen3_5MoETextConfig(
+        num_hidden_layers=2,
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        intermediate_size=128,
+        head_dim=16,
+        num_experts=8,
+        num_experts_per_tok=2,
+    )
+
+    provider = provider_from(config)
+
+    assert provider.model_type == "qwen3_5_moe_text"
+    assert provider.n_routed_experts == 8
+    assert provider.n_shared_experts == 1
+    assert provider.moe_shared_expert_gate is True

--- a/tests/ai_edited_test/transformers/test_ai_qwen3_5_provider.py
+++ b/tests/ai_edited_test/transformers/test_ai_qwen3_5_provider.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from paddleformers.transformers.qwen3_5.configuration import Qwen3_5TextConfig
 from paddleformers.transformers.qwen3_5.modeling_fleet import Qwen3_5TextModelProvider
 from paddleformers.transformers.qwen3_5_moe.configuration import Qwen3_5MoETextConfig


### PR DESCRIPTION
## Summary

- preserve the official nested Qwen3.5 text `model_type` while converting PaddleFormers configs into the PaddleFleet provider
- distinguish dense `qwen3_5_text` from MoE `qwen3_5_moe_text`
- keep dense configs on dense MLPs while retaining routed experts for MoE configs

## Reproduction

Before this patch, `Qwen3_5TextModelProvider.from_config(Qwen3_5MoETextConfig(num_experts=8))` produced `n_routed_experts=None` and `n_shared_experts=0`. `PretrainedConfig.model_type` is a class attribute, but the provider converter only copied instance attributes, so the provider could not distinguish dense from MoE and cleared expert fields.

The model type values match the official `Qwen/Qwen3.5-0.8B` and `Qwen/Qwen3.5-35B-A3B` `text_config.model_type` values.

## Validation

```text
python -m pytest -q tests/ai_edited_test/transformers/test_ai_qwen3_5_provider.py tests/ai_edited_test/transformers/test_ai_qwen3_5_moe.py
4 passed, 1 skipped

git diff --check
passed
```

The existing skip is unchanged: the inheritance test is disabled because of different module identity in CI.

## Scope

This validates config-to-provider preservation only. It does not claim an official-weight Qwen3.5 training run or cross-framework numerical alignment.
