### PR TITLE
[release/1.3][Deps] Update PaddleFleet to 597fb717859

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,7 @@ try:
         install_requires=REQUIRED_PACKAGES,
         entry_points={"console_scripts": get_console_scripts()},
         extras_require={
-            "paddlefleet": ["paddlefleet==0.4.0.post20260728+712fd29a930"],
+            "paddlefleet": ["paddlefleet==0.4.0.post20260731+597fb717859"],
         },
         python_requires=">=3.8",
         classifiers=[


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description

Update the optional PaddleFleet dependency on `release/1.3` from `paddlefleet==0.4.0.post20260728+712fd29a930` to `paddlefleet==0.4.0.post20260731+597fb717859`.

Develop PR: #4820 (pending merge).

The new nightly wheel was built from PaddleFleet [`release/0.4` commit `597fb717859ab836cb9f8cd00e9fc45b5f28bef8`](https://github.com/PaddlePaddle/PaddleFleet/commit/597fb717859ab836cb9f8cd00e9fc45b5f28bef8). The commit is the current `release/0.4` head. No additional source compatibility adjustment is needed on `release/1.3`; its existing dependency format and CI commit parser already support this release-wheel convention.

### Validation

- Confirmed the PaddleFleet `release/0.4` ref resolves to `597fb717859ab836cb9f8cd00e9fc45b5f28bef8`.
- Confirmed the published wheel's `METADATA` version is `0.4.0.post20260731+597fb717859` and its generated `_version.py` records the full target commit.
- Confirmed the wheel is downloadable from the nightly `cu129`, `cu130`, and `cu132` indexes.
- `python3 -m py_compile setup.py scripts/ci_utils/get_fleet_commit.py`
- `python3 scripts/ci_utils/get_fleet_commit.py` → `597fb717859`
- `git diff --check`
