### PR TITLE
[release/1.3][Deps] Update PaddleFleet to 30c0e6de355

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,7 @@ try:
         install_requires=REQUIRED_PACKAGES,
         entry_points={"console_scripts": get_console_scripts()},
         extras_require={
-            "paddlefleet": ["paddlefleet==0.4.0.post20260731+597fb717859"],
+            "paddlefleet": ["paddlefleet==0.4.0.post20260801+30c0e6de355"],
         },
         python_requires=">=3.8",
         classifiers=[


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description

Update the optional PaddleFleet dependency on release/1.3 from paddlefleet==0.4.0.post20260731+597fb717859 to paddlefleet==0.4.0.post20260801+30c0e6de355.

Develop PR: [#4827](https://github.com/PaddlePaddle/PaddleFormers/pull/4827). This release PR must be merged only after the develop PR is merged.

The new nightly wheel was built from PaddleFleet [release/0.4 commit 30c0e6de355794e284a2b74c3b4dd688ac139114](https://github.com/PaddlePaddle/PaddleFleet/commit/30c0e6de355794e284a2b74c3b4dd688ac139114), the authoritative branch head after [PaddleFleet #1616](https://github.com/PaddlePaddle/PaddleFleet/pull/1616) merged. This follows the corresponding develop dependency update in [PaddleFleet #1615](https://github.com/PaddlePaddle/PaddleFleet/pull/1615).

No additional source compatibility adjustment is needed on release/1.3; its existing dependency format and CI commit parser already support this release-wheel convention.

### Validation

- Confirmed PaddleFleet #1615 and #1616 are actually merged.
- Confirmed the PaddleFleet release/0.4 ref resolves to 30c0e6de355794e284a2b74c3b4dd688ac139114.
- Confirmed the published nightly wheel's METADATA version is 0.4.0.post20260801+30c0e6de355 and its generated _version.py records the full target commit.
- Confirmed the matching wheel is downloadable from the nightly cu126, cu129, cu130, and cu132 indexes.
- Confirmed a fresh virtual environment resolves and installs the exact version from the nightly cu129 index, with the installed _version.py recording the full target commit.
- python3 -m py_compile setup.py scripts/ci_utils/get_fleet_commit.py
- python3 scripts/ci_utils/get_fleet_commit.py → 30c0e6de355
- git diff --check
