### PR TITLE
[release/1.3][Deps] Update PaddleFleet to 83b700a4fb9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,7 @@ try:
         install_requires=REQUIRED_PACKAGES,
         entry_points={"console_scripts": get_console_scripts()},
         extras_require={
-            "paddlefleet": ["paddlefleet==0.4.0.post20260801+30c0e6de355"],
+            "paddlefleet": ["paddlefleet==0.4.0.post20260801+83b700a4fb9"],
         },
         python_requires=">=3.8",
         classifiers=[


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description

Update the optional PaddleFleet dependency on release/1.3 from paddlefleet==0.4.0.post20260801+30c0e6de355 to paddlefleet==0.4.0.post20260801+83b700a4fb9.

Develop PR: [#4829](https://github.com/PaddlePaddle/PaddleFormers/pull/4829). This release PR must be merged only after the develop PR is merged.

The new nightly wheel was built from PaddleFleet [release/0.4 commit 83b700a4fb9af10be588c0f832f845fab8750041](https://github.com/PaddlePaddle/PaddleFleet/commit/83b700a4fb9af10be588c0f832f845fab8750041), verified as the current authoritative remote branch head. The upstream change adds internal DSv4 YaRN/grouped-matmul optimizations with default-compatible configuration, so no PaddleFormers source compatibility adjustment is required.

### Validation

- Confirmed the PaddleFleet release/0.4 remote ref resolves to 83b700a4fb9af10be588c0f832f845fab8750041 via both Git and the GitHub API.
- Confirmed the [PaddleFleet wheel publishing run](https://github.com/PaddlePaddle/PaddleFleet/actions/runs/30692011302) completed successfully on attempt 2.
- Confirmed the wheel's METADATA version is 0.4.0.post20260801+83b700a4fb9 and its generated _version.py records the full target commit.
- Confirmed the wheel is downloadable from the nightly cu126, cu129, cu130, and cu132 indexes.
- Confirmed a fresh virtual environment resolves and installs the exact version from the nightly cu129 index, with the installed _version.py recording the full target commit.
- python3 -m py_compile setup.py scripts/ci_utils/get_fleet_commit.py
- python3 scripts/ci_utils/get_fleet_commit.py → 83b700a4fb9
- git diff --check
