### PR TITLE
[ZCC] Fix offload barrier never waiting for the in-flight D2H

### DIFF
--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -2414,6 +2414,17 @@ class Trainer:
 
                 for inputs in inputs_list:
                     if step_control % args.gradient_accumulation_steps == 0:
+                        # The ZCC snapshot of the previous step reads GPU buffers over CUDA IPC
+                        # from a separate process. It must be finished before any callback or
+                        # optimizer mutates those buffers, and the earliest mutator is
+                        # `on_step_begin` (FP8 expert quantization clears the bf16 param storage),
+                        # which runs before `on_optimizer_begin`. Sync here, not there.
+                        if (
+                            not args.enable_auto_parallel
+                            and self.args.enable_zero_cost_checkpoint
+                            and self.zcc_manager is not None
+                        ):
+                            self.zcc_manager.maybe_sync_offload_status()
                         self.control = self.callback_handler.on_step_begin(args, self.state, self.control)
                         self.timers and self.timers("forward-backward").start()
 

--- a/paddleformers/trainer/utils/zero_cost_checkpoint.py
+++ b/paddleformers/trainer/utils/zero_cost_checkpoint.py
@@ -596,6 +596,11 @@ class ZeroCostCheckpointCallback(TrainerCallback):
     on_optimizer_begin: call sync_offload_status, unset set manager.current_worker
         maybe optimizer reload
         maybe optimizer offload
+
+    NOTE: the offload handshake is additionally synced at the beginning of the next step
+    (`Trainer._inner_training_loop` -> `manager.maybe_sync_offload_status`), because
+    `on_step_begin` callbacks may already mutate the GPU buffers that the worker is
+    still reading over CUDA IPC.
     """
 
     def __init__(self, args, zcc_manager, timer, sharding_io):
@@ -624,10 +629,17 @@ class ZeroCostCheckpointCallback(TrainerCallback):
         if not control.should_save:
             if args.zcc_save_ema_coef is not None and state.global_step % self.zcc_ema_interval == 0:
                 self.maybe_update_zcc_worker(args, model, optimizer, state.global_step)
+                # `maybe_update_zcc_worker` only reaches `update_zcc_workers` (which assigns
+                # `manager.global_step`) on the very first save of a run, because the
+                # `fused_buffer_version == cache_version` guard short-circuits afterwards.
+                # Refresh it here so `sync_offload_status` compares against the step that is
+                # actually being offloaded instead of a permanently frozen value.
+                self.manager.global_step = state.global_step
                 self.manager.get_idle_worker_for_saving(((None, None), (None, state, None)))  # prepare for dumping
         else:
             self.runtime_timer.start("checkpoint saving time")
             self.maybe_update_zcc_worker(args, model, optimizer, state.global_step)
+            self.manager.global_step = state.global_step  # see comment above
             checkpoint_folder = f"{PREFIX_CHECKPOINT_DIR}-{state.global_step}"
             save_infos = self._get_save_infos_based_on_steps(state, args, checkpoint_folder)
             non_cached_objects = (lr_scheduler.state_dict(), state, self.get_rng_states(args))
@@ -956,6 +968,28 @@ class ZeroCostCheckpointManager:
         logger.info(
             f"[ZCC manager] after putting task for prepare, dumping={save_infos_and_non_cached_objects is not None}"
         )
+
+    def maybe_sync_offload_status(self):
+        """Idempotent variant of `sync_offload_status`, safe to call at the beginning of a step.
+
+        The ZCC worker is a separate process that reads the trainer's fused GPU buffers
+        through CUDA IPC on its own stream, so there is no CUDA stream ordering between
+        the trainer's compute stream and the worker's copy stream. The only ordering is
+        this handshake. It therefore has to be reached before *any* mutation of those
+        buffers in the next step, which happens earlier than `on_optimizer_begin`
+        (e.g. FP8 expert-weight quantization / `clear_param_storage` in `on_step_begin`).
+        """
+        if self.current_worker is None:
+            return
+        if self.current_pipeline_hook_step != self.pipeline_hooks_steps:
+            # The offload is still being sliced across pipeline hooks (PP > 1, or
+            # gradient_accumulation_steps > 1). The remaining chunks are only dispatched
+            # during this step's forward/backward, so waiting here would deadlock. Those
+            # configurations keep synchronizing at `on_optimizer_begin` as before.
+            return
+        logger.info("[ZCC manager] Start syncing checkpoints (step begin)")
+        self.sync_offload_status()
+        logger.info("[ZCC manager] Synced checkpoints (step begin).")
 
     def sync_offload_status(self):
         self.report_error_worker()


### PR DESCRIPTION
Merged in dev: #4838

## Problem

The ZCC offload barrier never waits. `ZeroCostCheckpointManager.sync_offload_status()` compares
`self.current_worker.global_step.value` against `self.global_step`, but:

1. `manager.global_step` is only ever assigned inside `update_zcc_workers()`, whose sole caller
   `maybe_update_zcc_worker()` short-circuits on `inner_opt.fused_buffer_version == self.manager.cache_version`.
   `fused_buffer_version` does not change in steady state, so the value is written **once per run**
   (the step of the first save) and then frozen.
2. The worker simply echoes the value it received back (`self.global_step.value = global_step`),
   so the manager ends up comparing `X` against its own `X`.

The barrier therefore passes on the very first comparison from the second save onwards.

This matters because the ZCC worker is a `spawn`-ed process that maps the trainer's fused GPU
buffers over CUDA IPC and does the D2H copy on **its own CUDA context and stream**. There is no
CUDA stream ordering between the trainer's compute stream and the worker's copy stream — this
handshake is the only ordering guarantee. With it broken, nothing stops step `N+1` from mutating
GPU memory that the step-`N` snapshot is still reading, which can silently corrupt saved
parameters / optimizer moments.

### Evidence from a 2496-GPU run

| log line | count |
|---|---|
| `Waiting current worker offloading done` (the branch that actually waits) | **0** |
| `Current worker offloading done` | 48, every one with the same frozen `manager_step` |

The run had `Offload chunks: 1` (~9 GB per card in a single D2H), and an `on_step_begin`
callback that quantizes MoE expert weights to FP8 and calls `optimizer.clear_param_storage(...)`,
i.e. a GPU mutation ~3s *before* `on_optimizer_begin` where the barrier used to sit.

## Changes

1. **`manager.global_step` is refreshed every step it is used.** Both branches of
   `ZeroCostCheckpointCallback.on_step_end` now assign `self.manager.global_step = state.global_step`
   right after `maybe_update_zcc_worker()` and before requesting a worker. This is what the
   `# set 'on-step-end'` comment on the attribute declaration originally intended.
   `state.global_step` is already incremented before `on_step_end`, so the value stays `>= 1`
   and the `assert global_step != 0` in `get_idle_worker_for_saving` is preserved.

2. **The synchronization point moves to the beginning of the next step.** Even a working barrier
   at `on_optimizer_begin` is too late, because `on_step_begin` callbacks may already mutate the
   buffers. New `ZeroCostCheckpointManager.maybe_sync_offload_status()` is called from
   `Trainer._inner_training_loop` just before `on_step_begin`. It is guarded by
   `current_pipeline_hook_step != pipeline_hooks_steps`: when the offload is still being sliced
   across pipeline hooks (PP > 1, or `pipeline_hooks_steps > 1`), the remaining chunks are only
   dispatched during *this* step, so waiting there would deadlock — those topologies keep
   synchronizing at `on_optimizer_begin` exactly as before. The original
   `on_optimizer_begin` sync is left in place as a backstop.

Two files, +45 lines, no deletions.

## Known remaining limitations (pre-existing, not addressed here)

- When `pipeline_hooks_steps > 1`, only the first chunk is dispatched at `on_step_end`; the rest
  come from the next step's `on_substep_end` / PP hooks, i.e. after any `on_step_begin` mutation.
  The step-begin guard correctly declines to wait for those topologies.
- The EMA-only branch of `on_step_end` does not call `zcc_pipeline_hook`, so its chunk is also
  dispatched by the next step's `on_substep_end`.
- The wait is for the D2H only (the worker writes `global_step.value` after both `wait_all()`
  calls and before `process_dump_task`), not for the disk write.
- `get_fused_param_mappings()` captures `buffer.param_buffer_ipc_meta` once per run, but
  `clear_param_storage()` / `reset_param_storage()` free and re-allocate `param_storage` for the
  cleared colors on every step, so the IPC handles held by the worker stay valid only while the
  caching allocator happens to hand back the same block. Out of scope here.
- Throughput cost: if an `on_step_begin` callback mutates the fused buffers, the D2H can no
  longer overlap the next step's forward/backward at all. That is inherent to the design, and
  the correct trade against saving corrupt state.

## Verification

`ZeroCostCheckpointManager` was instantiated via `object.__new__` with a fake worker whose
`global_step.value` write-back is delayed by a configurable number of polls, and module-level
`time.sleep` monkeypatched to count polls. This exercises the real `sync_offload_status`,
`maybe_sync_offload_status` and `zcc_pipeline_hook`:

- pre-fix frozen step reproduces "barrier returns immediately";
- post-fix the barrier really polls until the worker echoes the current step;
- the guard returns immediately (no deadlock) for `pipeline_hooks_steps > 1` and PP > 1;
- multiple workers with monotonically increasing step numbers never let a stale echo through.
