### PR TITLE
Add reshard bucketed broadcast

### DIFF
--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -361,6 +361,14 @@ class Trainer:
             args = TrainingArguments(output_dir=output_dir)
 
         self.args = args
+        # Apply the reshard broadcast toggle once here: Trainer.__init__ is the
+        # single point every reshard/EMA path runs after, so all_gather_state_dict
+        # need not thread the flag and no construction site is missed (incl. the
+        # non-ZCC EMA assembler that bypasses create_ema_state_assembler). Difers
+        reshard_util.set_bucketed_broadcast(getattr(self.args, "use_reshard_bucketed_broadcast", False))
+        reshard_util.set_broadcast_max_chunk_bytes(
+            int(getattr(self.args, "reshard_bucketed_broadcast_max_chunk_gb", 2.0) * (1024**3))
+        )
         self.is_in_train = False
         # self.do_grad_scaling = args.fp16
 
@@ -1132,12 +1140,6 @@ class Trainer:
             self.copy_custom_files(output_dir)
 
     def create_ema_state_assembler(self):
-        # EMA assembly reshards master weights without going through ShardingIO,
-        # so apply the reshard broadcast toggle here as well. Difers
-        reshard_util.set_bucketed_broadcast(self.args.use_reshard_bucketed_broadcast)
-        reshard_util.set_broadcast_max_chunk_bytes(
-            int(self.args.reshard_bucketed_broadcast_max_chunk_gb * (1024**3))
-        )
         global_steps = self.state.global_step
         memory_growth_threshold_bytes = self.args.save_hf_memory_growth_threshold * (2**30)
         self.ema_state_assembler = EMAStateAssembler(
@@ -1208,13 +1210,6 @@ class Trainer:
             f.write("1")
 
     def _load_flex_checkpoint(self, resume_from_checkpoint):
-        # ShardingIO is only built for sharding-stage1 paths, so apply the
-        # reshard broadcast toggle here too for the flex-checkpoint path. Difers
-        reshard_util.set_bucketed_broadcast(self.args.use_reshard_bucketed_broadcast)
-        reshard_util.set_broadcast_max_chunk_bytes(
-            int(self.args.reshard_bucketed_broadcast_max_chunk_gb * (1024**3))
-        )
-
         def get_metadata_file_name(path):
             files = os.listdir(path)
             metadata_files = [f for f in files if f.endswith(".metadata")]

--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -1132,6 +1132,12 @@ class Trainer:
             self.copy_custom_files(output_dir)
 
     def create_ema_state_assembler(self):
+        # EMA assembly reshards master weights without going through ShardingIO,
+        # so apply the reshard broadcast toggle here as well. Difers
+        reshard_util.set_bucketed_broadcast(self.args.use_reshard_bucketed_broadcast)
+        reshard_util.set_broadcast_max_chunk_bytes(
+            int(self.args.reshard_bucketed_broadcast_max_chunk_gb * (1024**3))
+        )
         global_steps = self.state.global_step
         memory_growth_threshold_bytes = self.args.save_hf_memory_growth_threshold * (2**30)
         self.ema_state_assembler = EMAStateAssembler(
@@ -1202,6 +1208,13 @@ class Trainer:
             f.write("1")
 
     def _load_flex_checkpoint(self, resume_from_checkpoint):
+        # ShardingIO is only built for sharding-stage1 paths, so apply the
+        # reshard broadcast toggle here too for the flex-checkpoint path. Difers
+        reshard_util.set_bucketed_broadcast(self.args.use_reshard_bucketed_broadcast)
+        reshard_util.set_broadcast_max_chunk_bytes(
+            int(self.args.reshard_bucketed_broadcast_max_chunk_gb * (1024**3))
+        )
+
         def get_metadata_file_name(path):
             files = os.listdir(path)
             metadata_files = [f for f in files if f.endswith(".metadata")]

--- a/paddleformers/trainer/training_args.py
+++ b/paddleformers/trainer/training_args.py
@@ -760,9 +760,11 @@ class TrainingArguments:
         metadata={
             "help": (
                 "Only used when use_reshard_bucketed_broadcast is True. Max size (in GB, 1024**3 bytes) of a "
-                "broadcast chunk kept resident on GPU at once; this is the peak-memory knob for the bucketed "
-                "path. Lower it to reduce peak GPU memory (at the cost of more, smaller coalesced broadcasts). "
-                "Values below the 128MiB bucket size are floored to it. Default 2.0."
+                "broadcast chunk kept resident on GPU at once. Values below the 128MiB bucket size are floored "
+                "to it. Default 2.0. NOTE: this only caps the AGGREGATION of multiple buckets into one chunk; "
+                "it does not split a single tensor/bucket. A tensor larger than this cap is still transmitted "
+                "whole (one bucket), exactly like the non-bucketed path, so peak is not reduced for such tensors "
+                "(bucketing is no worse than per-tensor here, just not better)."
             )
         },
     )

--- a/paddleformers/trainer/training_args.py
+++ b/paddleformers/trainer/training_args.py
@@ -743,6 +743,30 @@ class TrainingArguments:
         metadata={"help": "Whether to load sharded model from EMA."},
     )
 
+    use_reshard_bucketed_broadcast: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "During checkpoint reshard, pack many small state tensors into large buckets and "
+                "coalesce their broadcasts, reducing NCCL/H2D calls from O(#tensors) to O(#buckets). "
+                "This speeds up reshard at large sharding degree but raises peak GPU memory, since a "
+                "chunk (~2GiB) stays resident on device during broadcast. Default False (per-tensor path)."
+            )
+        },
+    )
+
+    reshard_bucketed_broadcast_max_chunk_gb: float = field(
+        default=2.0,
+        metadata={
+            "help": (
+                "Only used when use_reshard_bucketed_broadcast is True. Max size (in GB, 1024**3 bytes) of a "
+                "broadcast chunk kept resident on GPU at once; this is the peak-memory knob for the bucketed "
+                "path. Lower it to reduce peak GPU memory (at the cost of more, smaller coalesced broadcasts). "
+                "Values below the 128MiB bucket size are floored to it. Default 2.0."
+            )
+        },
+    )
+
     tensor_model_parallel_size: int = field(
         default=-1,
         metadata={

--- a/paddleformers/trainer/utils/reshard/__init__.py
+++ b/paddleformers/trainer/utils/reshard/__init__.py
@@ -25,6 +25,8 @@ from .common import (
     is_sharding_opt,
     merge_model_state,
     merge_opt_state,
+    set_broadcast_max_chunk_bytes,
+    set_bucketed_broadcast,
     split_model_state,
     split_opt_state,
     split_structure_name_mapping,

--- a/paddleformers/trainer/utils/reshard/common.py
+++ b/paddleformers/trainer/utils/reshard/common.py
@@ -35,6 +35,20 @@ try:
 except (ImportError, ModuleNotFoundError):
     _coalescing_manager = None
 
+try:
+    from paddle.device.cuda import _annotate_memory_history
+except (ImportError, ModuleNotFoundError):
+    _annotate_memory_history = None
+
+
+def _mark_mem(message):
+    # Drop a named marker into the GPU memory history so the bucketed-broadcast
+    # chunk residency/peak is visible in memory-viz timelines. No-op when the
+    # API (or CUDA) is unavailable. Difers
+    if _annotate_memory_history is not None:
+        _annotate_memory_history(message)
+
+
 from paddle.distributed.fleet.utils.log_util import logger
 
 from paddleformers.utils.tools import get_env_device
@@ -633,6 +647,18 @@ def _dtype_itemsize(dtype):
     return paddle.empty([0], dtype=dtype, device="cpu").element_size()
 
 
+def _normalize_np_dtype_str(dtype_str):
+    # Paddle has no numpy-native bf16, so it stores BF16 as numpy uint16 (e.g.
+    # Tensor.numpy() / paddle.load(return_numpy=True)) and paddle.to_tensor maps
+    # that uint16 back to bfloat16. Record the *paddle-effective* dtype so the
+    # meta string matches the reconstructed tensor's dtype; otherwise the pack
+    # assert compares a numpy-domain name ("uint16") against a paddle-domain name
+    # ("bfloat16") and wrongly fails on BF16 reshard. Difers
+    if dtype_str == "uint16":
+        return "bfloat16"
+    return dtype_str
+
+
 def _build_state_dict_broadcast_buckets(meta_list, bucket_size_bytes):
     assert bucket_size_bytes > 0
 
@@ -688,6 +714,12 @@ def _build_state_dict_broadcast_buckets(meta_list, bucket_size_bytes):
 
 
 def _iter_state_dict_bucket_chunks(buckets, chunk_size, max_chunk_bytes):
+    # max_chunk_bytes only caps the AGGREGATION of multiple buckets into one
+    # chunk; it does not split a bucket. A single bucket larger than the cap
+    # (an oversized tensor kept whole by _build_state_dict_broadcast_buckets) is
+    # still emitted as its own chunk and transmitted whole, exactly like the
+    # per-tensor path. So the cap bounds peak for many small tensors, not for a
+    # single tensor bigger than the cap. Difers
     assert chunk_size > 0
     assert max_chunk_bytes > 0
 
@@ -892,7 +924,7 @@ def _all_gather_state_dict_bucketed(state_dict, filter_func, group):
             meta_dict[k] = (str(v.dtype).split(".")[-1], list(v.shape), group_rank)
             state_dict[k] = v.numpy()
         else:
-            meta_dict[k] = (str(v.dtype), list(v.shape), group_rank)
+            meta_dict[k] = (_normalize_np_dtype_str(str(v.dtype)), list(v.shape), group_rank)
 
     meta_dict_list = all_gather_simple_object(meta_dict, group)
 
@@ -925,6 +957,10 @@ def _all_gather_state_dict_bucketed(state_dict, filter_func, group):
             f"nranks={group.nranks}, group_id={group.id}"
         )
 
+    _mark_mem(
+        f"reshard/bucketed begin: {len(meta_list)} tensors, {len(buckets)} buckets, "
+        f"max_chunk={_broadcast_max_chunk_bytes // (1024 * 1024)}MiB, group_id={group.id}"
+    )
     bucket_chunks = _iter_state_dict_bucket_chunks(
         buckets,
         _STATE_DICT_BROADCAST_CHUNK_SIZE,
@@ -939,6 +975,11 @@ def _all_gather_state_dict_bucketed(state_dict, filter_func, group):
     done_chunks = 0
     for chunk in bucket_chunks:
         t0 = time.time()
+        chunk_nbytes = sum(b["nbytes"] for b in chunk)
+        _mark_mem(
+            f"reshard/bucketed chunk{done_chunks} pack: {len(chunk)} buckets, "
+            f"{chunk_nbytes // (1024 * 1024)}MiB, group_id={group.id}"
+        )
         gpu_buckets = []
         for bucket in chunk:
             if bucket["rank"] == group_rank:
@@ -956,6 +997,7 @@ def _all_gather_state_dict_bucketed(state_dict, filter_func, group):
         # Release the chunk before packing the next one; keeping the list alive
         # would hold every bucket of this chunk in device memory.
         del gpu_buckets
+        _mark_mem(f"reshard/bucketed chunk{done_chunks} released, group_id={group.id}")
 
         t3 = time.time()
         pack_seconds += t1 - t0
@@ -989,6 +1031,7 @@ def _all_gather_state_dict_bucketed(state_dict, filter_func, group):
         )
 
     assert not state_dict
+    _mark_mem(f"reshard/bucketed done: {len(buckets)} buckets, group_id={group.id}")
     return OrderedDict((k, gathered[k]) for k, _ in meta_list if k in selected_keys)
 
 

--- a/paddleformers/trainer/utils/reshard/common.py
+++ b/paddleformers/trainer/utils/reshard/common.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
 from collections import OrderedDict
 
 import numpy as np
@@ -29,6 +30,11 @@ try:
 except (ImportError, ModuleNotFoundError):
     MuonShardingOptimizer = None
 
+try:
+    from paddle.distributed.communication.batch_isend_irecv import _coalescing_manager
+except (ImportError, ModuleNotFoundError):
+    _coalescing_manager = None
+
 from paddle.distributed.fleet.utils.log_util import logger
 
 from paddleformers.utils.tools import get_env_device
@@ -37,6 +43,17 @@ from ....transformers.model_utils import unwrap_optimizer
 
 SHARDING_STRATEGY_V1 = "ShardingV1"
 SHARDING_STRATEGY_V2 = "ShardingV2"
+
+_STATE_DICT_BROADCAST_BUCKET_SIZE_BYTES = 128 * 1024 * 1024
+_STATE_DICT_BROADCAST_CHUNK_SIZE = 256
+_STATE_DICT_BROADCAST_MAX_CHUNK_BYTES = 2 * 1024 * 1024 * 1024
+_STATE_DICT_BROADCAST_LOG_INTERVAL_SECONDS = 10
+
+# Mutable peak-memory knob for the bucketed broadcast path: the max bytes of a
+# chunk kept resident on GPU at once. Sourced from TrainingArguments
+# .reshard_bucketed_broadcast_max_chunk_gb via set_broadcast_max_chunk_bytes()
+# at the reshard entry points; defaults to the constant above. Difers
+_broadcast_max_chunk_bytes = _STATE_DICT_BROADCAST_MAX_CHUNK_BYTES
 
 
 def is_sharding_opt(optimizer):
@@ -606,7 +623,199 @@ def all_gather_simple_object(obj, group):
     return res
 
 
+def _shape_numel(shape):
+    if len(shape) == 0:
+        return 1
+    return int(np.prod(shape, dtype=np.int64))
+
+
+def _dtype_itemsize(dtype):
+    return paddle.empty([0], dtype=dtype, device="cpu").element_size()
+
+
+def _build_state_dict_broadcast_buckets(meta_list, bucket_size_bytes):
+    assert bucket_size_bytes > 0
+
+    grouped_items = OrderedDict()
+    empty_items = []
+    for k, (dtype, shape, rank) in meta_list:
+        numel = _shape_numel(shape)
+        item = (k, shape, numel)
+        if numel == 0:
+            empty_items.append((k, (dtype, shape, rank)))
+            continue
+        grouped_items.setdefault((rank, dtype), []).append(item)
+
+    buckets = []
+    for (rank, dtype), items in grouped_items.items():
+        itemsize = _dtype_itemsize(dtype)
+        bucket_items = []
+        bucket_numel = 0
+
+        def flush_bucket():
+            nonlocal bucket_items, bucket_numel
+            if not bucket_items:
+                return
+            buckets.append(
+                {
+                    "rank": rank,
+                    "dtype": dtype,
+                    "numel": bucket_numel,
+                    "nbytes": bucket_numel * itemsize,
+                    "items": bucket_items,
+                }
+            )
+            bucket_items = []
+            bucket_numel = 0
+
+        for k, shape, numel in items:
+            item_nbytes = numel * itemsize
+            if bucket_items and (bucket_numel * itemsize + item_nbytes > bucket_size_bytes):
+                flush_bucket()
+
+            begin = bucket_numel
+            bucket_items.append((k, shape, begin, begin + numel))
+            bucket_numel += numel
+
+            # Oversized tensors stay in their own bucket instead of increasing
+            # the peak memory of neighboring tensors.
+            if item_nbytes >= bucket_size_bytes:
+                flush_bucket()
+
+        flush_bucket()
+
+    return buckets, empty_items
+
+
+def _iter_state_dict_bucket_chunks(buckets, chunk_size, max_chunk_bytes):
+    assert chunk_size > 0
+    assert max_chunk_bytes > 0
+
+    chunk = []
+    chunk_bytes = 0
+    for bucket in buckets:
+        bucket_bytes = bucket["nbytes"]
+        if chunk and (len(chunk) >= chunk_size or chunk_bytes + bucket_bytes > max_chunk_bytes):
+            yield chunk
+            chunk = []
+            chunk_bytes = 0
+        chunk.append(bucket)
+        chunk_bytes += bucket_bytes
+    if chunk:
+        yield chunk
+
+
+def _pack_state_dict_bucket(bucket, state_dict):
+    items = bucket["items"]
+    first_key = items[0][0]
+    assert first_key in state_dict
+    np_dtype = np.asarray(state_dict[first_key]).dtype
+
+    # Scatter the whole bucket on the host first so it takes a single
+    # host-to-device copy instead of one small copy per state tensor.
+    staged = np.empty([bucket["numel"]], dtype=np_dtype)
+    for k, _, begin, end in items:
+        assert k in state_dict
+        value = np.asarray(state_dict.pop(k)).reshape([-1])
+        assert value.shape[0] == end - begin
+        assert value.dtype == np_dtype
+        staged[begin:end] = value
+        del value
+
+    tensor = paddle.to_tensor(staged)
+    assert tensor.shape[0] == bucket["numel"]
+    assert str(tensor.dtype).split(".")[-1] == bucket["dtype"]
+    return tensor
+
+
+def _unpack_state_dict_bucket(bucket, tensor, selected_keys, gathered):
+    selected_items = [item for item in bucket["items"] if item[0] in selected_keys]
+    if not selected_items:
+        return
+
+    if len(selected_items) == len(bucket["items"]):
+        cpu_tensor = tensor.cpu()
+        for k, shape, begin, end in selected_items:
+            # Every item of the bucket is selected, so the slices exactly cover
+            # the bucket storage. Hand out views instead of per-item copies:
+            # cloning here would duplicate the whole bucket for no gain.
+            gathered[k] = cpu_tensor[begin:end].reshape(shape)
+        del cpu_tensor
+        return
+
+    # Sharded restore normally keeps only a small subset of each bucket on a
+    # rank. Copy just those slices instead of staging the complete bucket on
+    # every rank. ``.cpu()`` already allocates fresh host storage sized to the
+    # slice, so no extra clone is needed.
+    for k, shape, begin, end in selected_items:
+        gathered[k] = tensor[begin:end].cpu().reshape(shape)
+
+
+def _broadcast_state_dict_chunk(gpu_buckets, group):
+    if group.nranks < 2:
+        return
+
+    if _coalescing_manager is None:
+        for bucket, tensor in gpu_buckets:
+            paddle.distributed.broadcast(
+                tensor,
+                src=group.ranks[bucket["rank"]],
+                group=group,
+                sync_op=True,
+            )
+        return
+
+    # Every bucket has its own broadcast root, so a chunk is a batch of small
+    # multi-root messages. At large nranks the per-call launch and rendezvous
+    # cost dominates the payload, so aggregate the whole chunk into a single
+    # ncclGroupStart/End instead of paying it once per bucket.
+    tasks = []
+    with _coalescing_manager(group, tasks):
+        for bucket, tensor in gpu_buckets:
+            paddle.distributed.stream.broadcast(
+                tensor,
+                src=group.ranks[bucket["rank"]],
+                group=group,
+                sync_op=True,
+                use_calc_stream=True,
+            )
+
+
+# The bucketed path packs many small state tensors into large buckets and
+# coalesces their broadcasts, cutting NCCL/H2D calls from O(#tensors) to
+# O(#buckets). The tradeoff is that a whole ~2GiB chunk must stay resident on
+# GPU at once, so it raises peak device memory for small-tensor-heavy reshards
+# (see _STATE_DICT_BROADCAST_MAX_CHUNK_BYTES). Default to the original
+# per-tensor path. The value is driven by TrainingArguments
+# .use_reshard_bucketed_broadcast, applied via set_bucketed_broadcast() at the
+# reshard entry points that hold args, so the deep all_gather_state_dict call
+# chain does not have to thread the flag through every function. Difers
+_USE_BUCKETED_BROADCAST = False
+
+
+def set_bucketed_broadcast(enabled):
+    global _USE_BUCKETED_BROADCAST
+    _USE_BUCKETED_BROADCAST = bool(enabled)
+
+
+def set_broadcast_max_chunk_bytes(nbytes):
+    global _broadcast_max_chunk_bytes
+    nbytes = int(nbytes)
+    if nbytes <= 0:
+        _broadcast_max_chunk_bytes = _STATE_DICT_BROADCAST_MAX_CHUNK_BYTES
+        return
+    # A chunk must hold at least one full bucket, otherwise every bucket lands in
+    # its own chunk and the broadcast coalescing is lost. Floor at bucket size.
+    _broadcast_max_chunk_bytes = max(nbytes, _STATE_DICT_BROADCAST_BUCKET_SIZE_BYTES)
+
+
 def all_gather_state_dict(state_dict, filter_func, group):
+    if _USE_BUCKETED_BROADCAST:
+        return _all_gather_state_dict_bucketed(state_dict, filter_func, group)
+    return _all_gather_state_dict_legacy(state_dict, filter_func, group)
+
+
+def _all_gather_state_dict_legacy(state_dict, filter_func, group):
     res = OrderedDict()
 
     group_rank = max(group.rank, 0)
@@ -670,6 +879,117 @@ def all_gather_state_dict(state_dict, filter_func, group):
             del tensor
 
     return res
+
+
+def _all_gather_state_dict_bucketed(state_dict, filter_func, group):
+    group_rank = max(group.rank, 0)
+
+    # Convert source tensors to numpy first so packing does not retain their
+    # original GPU allocations.
+    meta_dict = {}
+    for (k, v) in state_dict.items():
+        if isinstance(v, paddle.Tensor):
+            meta_dict[k] = (str(v.dtype).split(".")[-1], list(v.shape), group_rank)
+            state_dict[k] = v.numpy()
+        else:
+            meta_dict[k] = (str(v.dtype), list(v.shape), group_rank)
+
+    meta_dict_list = all_gather_simple_object(meta_dict, group)
+
+    total_meta_dict = {}
+    for meta_dict in meta_dict_list:
+        for (k, v) in meta_dict.items():
+            assert k not in total_meta_dict
+            total_meta_dict[k] = v
+
+    meta_list = list(total_meta_dict.items())
+    meta_list = sorted(meta_list, key=lambda x: (x[1][2], x[0]))
+    selected_keys = {k for k, _ in meta_list if filter_func(k)}
+    buckets, empty_items = _build_state_dict_broadcast_buckets(meta_list, _STATE_DICT_BROADCAST_BUCKET_SIZE_BYTES)
+    gathered = {}
+
+    for k, (dtype, shape, rank) in empty_items:
+        if rank == group_rank:
+            assert k in state_dict
+            del state_dict[k]
+        if k in selected_keys:
+            gathered[k] = paddle.empty(shape, dtype=dtype, device="cpu")
+
+    if group_rank == 0:
+        logger.info(
+            f"broadcast {len(meta_list)} state tensors in {len(buckets)} buckets, "
+            f"bucket_size={_STATE_DICT_BROADCAST_BUCKET_SIZE_BYTES // (1024 * 1024)} MiB, "
+            f"chunk_size={_STATE_DICT_BROADCAST_CHUNK_SIZE}, "
+            f"max_chunk={_broadcast_max_chunk_bytes // (1024 * 1024)} MiB, "
+            f"coalescing={_coalescing_manager is not None}, "
+            f"nranks={group.nranks}, group_id={group.id}"
+        )
+
+    bucket_chunks = _iter_state_dict_bucket_chunks(
+        buckets,
+        _STATE_DICT_BROADCAST_CHUNK_SIZE,
+        _broadcast_max_chunk_bytes,
+    )
+    start = time.time()
+    last_log = start
+    pack_seconds = 0.0
+    bcast_seconds = 0.0
+    unpack_seconds = 0.0
+    done_buckets = 0
+    done_chunks = 0
+    for chunk in bucket_chunks:
+        t0 = time.time()
+        gpu_buckets = []
+        for bucket in chunk:
+            if bucket["rank"] == group_rank:
+                tensor = _pack_state_dict_bucket(bucket, state_dict)
+            else:
+                tensor = paddle.empty([bucket["numel"]], dtype=bucket["dtype"])
+            gpu_buckets.append((bucket, tensor))
+
+        t1 = time.time()
+        _broadcast_state_dict_chunk(gpu_buckets, group)
+
+        t2 = time.time()
+        for bucket, tensor in gpu_buckets:
+            _unpack_state_dict_bucket(bucket, tensor, selected_keys, gathered)
+        # Release the chunk before packing the next one; keeping the list alive
+        # would hold every bucket of this chunk in device memory.
+        del gpu_buckets
+
+        t3 = time.time()
+        pack_seconds += t1 - t0
+        bcast_seconds += t2 - t1
+        unpack_seconds += t3 - t2
+        done_buckets += len(chunk)
+        done_chunks += 1
+
+        # This loop can run for minutes without emitting anything at large
+        # nranks, which is indistinguishable from a hang. Report progress.
+        if group_rank == 0 and (
+            done_buckets == len(buckets) or t3 - last_log >= _STATE_DICT_BROADCAST_LOG_INTERVAL_SECONDS
+        ):
+            last_log = t3
+            elapsed = t3 - start
+            logger.info(
+                f"broadcast progress {done_buckets}/{len(buckets)} buckets "
+                f"({100.0 * done_buckets / len(buckets):.1f}%), chunks={done_chunks}, "
+                f"elapsed={elapsed:.1f}s, "
+                f"eta={elapsed * (len(buckets) - done_buckets) / done_buckets:.1f}s, "
+                f"pack={pack_seconds:.1f}s, bcast={bcast_seconds:.1f}s, "
+                f"unpack={unpack_seconds:.1f}s, group_id={group.id}"
+            )
+
+    if group_rank == 0 and buckets:
+        logger.info(
+            f"broadcast done: {len(buckets)} buckets, {len(meta_list)} tensors, "
+            f"total={time.time() - start:.1f}s, pack={pack_seconds:.1f}s, "
+            f"bcast={bcast_seconds:.1f}s, unpack={unpack_seconds:.1f}s, "
+            f"nranks={group.nranks}, group_id={group.id}"
+        )
+
+    assert not state_dict
+    return OrderedDict((k, gathered[k]) for k, _ in meta_list if k in selected_keys)
 
 
 def _all_gather_state_dict(state_dict, filter_func, group):

--- a/paddleformers/trainer/utils/sharding_io.py
+++ b/paddleformers/trainer/utils/sharding_io.py
@@ -267,6 +267,9 @@ class GroupGetter:
 class ShardingIO:
     def __init__(self, args, model, optimizer=None, hcg=None, remap_parameter_name=False, is_ema=False):
         self.args = args
+        # Apply the reshard broadcast toggle here
+        reshard_util.set_bucketed_broadcast(args.use_reshard_bucketed_broadcast)
+        reshard_util.set_broadcast_max_chunk_bytes(int(args.reshard_bucketed_broadcast_max_chunk_gb * (1024**3)))
         self.model = model
         self.optimizer = optimizer
         self.hcg = hcg

--- a/tests/ai_edited_test/trainer/test_ai_reshard_bucketed_broadcast.py
+++ b/tests/ai_edited_test/trainer/test_ai_reshard_bucketed_broadcast.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+"""Tests for the bucketed broadcast path in trainer/utils/reshard/common.py.
+
+Mirrors the existing single-process reshard unit tests: no real collective is
+started. all_gather_state_dict short-circuits the broadcast when group.nranks
+< 2, yet still runs the full bucket/pack/unpack/dtype logic, so a fake 1-rank
+group lets us diff the legacy vs bucketed paths in-process. The true multi-root
+collective sequence (>=2 ranks) is out of scope here and belongs to a
+launch-based integration test.
+"""
+
+import unittest
+from collections import OrderedDict
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import paddle
+
+from paddleformers.trainer.utils.reshard import common as reshard_common
+from paddleformers.trainer.utils.reshard.common import (
+    _iter_state_dict_bucket_chunks,
+    _normalize_np_dtype_str,
+    all_gather_state_dict,
+    set_broadcast_max_chunk_bytes,
+    set_bucketed_broadcast,
+)
+
+_DEFAULT_MAX_CHUNK = reshard_common._STATE_DICT_BROADCAST_MAX_CHUNK_BYTES
+
+
+def _fake_group(nranks=1, rank=0, gid=0):
+    g = MagicMock()
+    g.nranks = nranks
+    g.rank = rank
+    g.id = gid
+    g.ranks = list(range(nranks))
+    return g
+
+
+def _copy_sd(state_dict):
+    # all_gather_state_dict consumes (pops) its input, so hand each run a copy.
+    out = OrderedDict()
+    for k, v in state_dict.items():
+        out[k] = v.copy() if isinstance(v, np.ndarray) else v.clone()
+    return out
+
+
+def _bf16_uint16(np_float_array):
+    # Reproduce ShardingIO's paddle.load(return_numpy=True) for a BF16 tensor:
+    # the bytes come back as numpy uint16.
+    return paddle.to_tensor(np_float_array).astype("bfloat16").numpy()
+
+
+class TestNormalizeNpDtypeStr(unittest.TestCase):
+    def test_uint16_maps_to_bfloat16(self):
+        # paddle has no numpy-native bf16; it stores bf16 as uint16 and to_tensor
+        # restores bfloat16, so meta must record the paddle-effective dtype.
+        self.assertEqual(_normalize_np_dtype_str("uint16"), "bfloat16")
+
+    def test_other_dtypes_unchanged(self):
+        for dt in ("float32", "float16", "int64", "bfloat16"):
+            self.assertEqual(_normalize_np_dtype_str(dt), dt)
+
+
+class TestIterBucketChunks(unittest.TestCase):
+    def test_oversized_bucket_stays_alone(self):
+        # A single bucket larger than max_chunk_bytes is NOT split; it lands in
+        # its own chunk (documented limitation, matches the per-tensor path).
+        buckets = [{"nbytes": 100}, {"nbytes": 100}, {"nbytes": 5000}, {"nbytes": 100}]
+        chunks = list(_iter_state_dict_bucket_chunks(buckets, chunk_size=256, max_chunk_bytes=1000))
+        self.assertEqual(len(chunks), 3)
+        self.assertEqual(chunks[0], buckets[0:2])  # small ones aggregate up to cap
+        self.assertEqual(chunks[1], [buckets[2]])  # oversized alone (5000 > 1000)
+        self.assertEqual(chunks[2], [buckets[3]])
+
+    def test_chunk_size_count_cap(self):
+        buckets = [{"nbytes": 1} for _ in range(5)]
+        chunks = list(_iter_state_dict_bucket_chunks(buckets, chunk_size=2, max_chunk_bytes=10**9))
+        self.assertEqual([len(c) for c in chunks], [2, 2, 1])
+
+
+class TestBucketedMatchesLegacy(unittest.TestCase):
+    """all_gather_state_dict must return identical results in both modes."""
+
+    def tearDown(self):
+        set_bucketed_broadcast(False)
+        set_broadcast_max_chunk_bytes(_DEFAULT_MAX_CHUNK)
+
+    def _gather(self, state_dict, filter_func, bucketed, max_chunk_bytes=None):
+        set_bucketed_broadcast(bucketed)
+        if max_chunk_bytes is not None:
+            set_broadcast_max_chunk_bytes(max_chunk_bytes)
+        return all_gather_state_dict(_copy_sd(state_dict), filter_func, _fake_group())
+
+    def _assert_same(self, a, b):
+        self.assertEqual(set(a.keys()), set(b.keys()))
+        for k in a:
+            ta, tb = a[k], b[k]
+            self.assertEqual(list(ta.shape), list(tb.shape), f"shape mismatch for {k}")
+            self.assertEqual(str(ta.dtype), str(tb.dtype), f"dtype mismatch for {k}")
+            na = ta.astype("float32").numpy()
+            nb = tb.astype("float32").numpy()
+            np.testing.assert_array_equal(na, nb, err_msg=f"value mismatch for {k}")
+        return a
+
+    def test_basic_fp32(self):
+        sd = OrderedDict(
+            a=np.random.rand(4, 8).astype("float32"),
+            b=np.random.rand(16).astype("float32"),
+            c=np.random.rand(2, 2, 2).astype("float32"),
+        )
+        legacy = self._gather(sd, lambda x: True, bucketed=False)
+        bucketed = self._gather(sd, lambda x: True, bucketed=True)
+        self._assert_same(legacy, bucketed)
+        # also check absolute correctness vs input for one key
+        np.testing.assert_array_equal(bucketed["a"].numpy(), sd["a"])
+
+    def test_bf16_return_numpy_uint16(self):
+        # Regression: BF16 checkpoint loaded via return_numpy=True is uint16.
+        # Bucketed must normalize dtype to bfloat16 (not trip the pack assert).
+        base = np.random.rand(3, 5).astype("float32")
+        sd = OrderedDict(w=_bf16_uint16(base), s=np.random.rand(8).astype("float32"))
+        self.assertEqual(str(sd["w"].dtype), "uint16")
+        legacy = self._gather(sd, lambda x: True, bucketed=False)
+        bucketed = self._gather(sd, lambda x: True, bucketed=True)
+        out = self._assert_same(legacy, bucketed)
+        self.assertEqual(str(out["w"].dtype).split(".")[-1], "bfloat16")
+
+    def test_partial_filter(self):
+        sd = OrderedDict(
+            keep0=np.random.rand(4).astype("float32"),
+            drop=np.random.rand(4).astype("float32"),
+            keep1=np.random.rand(4).astype("float32"),
+        )
+        f = lambda k: k.startswith("keep")
+        legacy = self._gather(sd, f, bucketed=False)
+        bucketed = self._gather(sd, f, bucketed=True)
+        self.assertEqual(set(bucketed.keys()), {"keep0", "keep1"})
+        self._assert_same(legacy, bucketed)
+
+    def test_empty_and_scalar(self):
+        sd = OrderedDict(
+            empty=np.zeros([0], dtype="float32"),
+            empty2d=np.zeros([2, 0], dtype="float32"),
+            scalar=np.asarray(3.14, dtype="float32"),
+            normal=np.random.rand(5).astype("float32"),
+        )
+        legacy = self._gather(sd, lambda x: True, bucketed=False)
+        bucketed = self._gather(sd, lambda x: True, bucketed=True)
+        self._assert_same(legacy, bucketed)
+        self.assertEqual(list(bucketed["scalar"].shape), [])
+
+    def test_oversized_tensor_small_max_chunk(self):
+        # Shrink bucket/chunk caps so tiny tensors exercise the multi-chunk and
+        # oversized-single-bucket paths with real data (no GB allocations).
+        with patch.object(reshard_common, "_STATE_DICT_BROADCAST_BUCKET_SIZE_BYTES", 256):
+            sd = OrderedDict(
+                big=np.random.rand(400).astype("float32"),  # 1600B > cap -> own bucket
+                s0=np.random.rand(8).astype("float32"),
+                s1=np.random.rand(8).astype("float32"),
+            )
+            legacy = self._gather(sd, lambda x: True, bucketed=False, max_chunk_bytes=512)
+            bucketed = self._gather(sd, lambda x: True, bucketed=True, max_chunk_bytes=512)
+            self._assert_same(legacy, bucketed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs
### Description
<!-- Describe what this PR does -->
添加 reshard 的 分桶广播（bucketed broadcast)。

改动

  - 把 all_gather_state_dict 拆成两个实现：
    - _all_gather_state_dict_legacy——原始逐 tensor 广播（现为默认）。
    - _all_gather_state_dict_bucketed——打包 + 合并广播（按需开启）。
  - 新增两个 TrainingArguments：
    - use_reshard_bucketed_broadcast: bool = False——是否启用分桶路径。
    - reshard_bucketed_broadcast_max_chunk_gb: float = 2.0——峰值旋钮（单个 chunk 常驻 GPU 的最大字节数；低于桶大小会被下限锁到桶大小）。
  - 开关在持有 args 的 reshard 入口处应用（ShardingIO.__init__、Trainer._load_flex_checkpoint、Trainer.create_ema_state_assembler），通过轻量的 module 级 setter
  生效，避免把参数透传穿过整条 all_gather_state_dict 调用链。

  行为

  - 默认（use_reshard_bucketed_broadcast=False）：与原逐 tensor 行为完全一致，显存峰值无变化。
  - 开启（=True）：大 sharding 度下 reshard 更快，代价是更高的 GPU 显存峰值，上限由 reshard_bucketed_broadcast_max_chunk_gb 控制。

