### PR TITLE
 [ZCC] Add regression tests for offload barrier sync

### DIFF
--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -2491,6 +2491,17 @@ class Trainer:
 
                 for inputs in inputs_list:
                     if step_control % args.gradient_accumulation_steps == 0:
+                        # The ZCC snapshot of the previous step reads GPU buffers over CUDA IPC
+                        # from a separate process. It must be finished before any callback or
+                        # optimizer mutates those buffers, and the earliest mutator is
+                        # `on_step_begin` (FP8 expert quantization clears the bf16 param storage),
+                        # which runs before `on_optimizer_begin`. Sync here, not there.
+                        if (
+                            not args.enable_auto_parallel
+                            and self.args.enable_zero_cost_checkpoint
+                            and self.zcc_manager is not None
+                        ):
+                            self.zcc_manager.maybe_sync_offload_status()
                         self.control = self.callback_handler.on_step_begin(args, self.state, self.control)
                         self.timers and self.timers("forward-backward").start()
 

--- a/paddleformers/trainer/utils/zero_cost_checkpoint.py
+++ b/paddleformers/trainer/utils/zero_cost_checkpoint.py
@@ -596,6 +596,11 @@ class ZeroCostCheckpointCallback(TrainerCallback):
     on_optimizer_begin: call sync_offload_status, unset set manager.current_worker
         maybe optimizer reload
         maybe optimizer offload
+
+    NOTE: the offload handshake is additionally synced at the beginning of the next step
+    (`Trainer._inner_training_loop` -> `manager.maybe_sync_offload_status`), because
+    `on_step_begin` callbacks may already mutate the GPU buffers that the worker is
+    still reading over CUDA IPC.
     """
 
     def __init__(self, args, zcc_manager, timer, sharding_io):
@@ -624,10 +629,17 @@ class ZeroCostCheckpointCallback(TrainerCallback):
         if not control.should_save:
             if args.zcc_save_ema_coef is not None and state.global_step % self.zcc_ema_interval == 0:
                 self.maybe_update_zcc_worker(args, model, optimizer, state.global_step)
+                # `maybe_update_zcc_worker` only reaches `update_zcc_workers` (which assigns
+                # `manager.global_step`) on the very first save of a run, because the
+                # `fused_buffer_version == cache_version` guard short-circuits afterwards.
+                # Refresh it here so `sync_offload_status` compares against the step that is
+                # actually being offloaded instead of a permanently frozen value.
+                self.manager.global_step = state.global_step
                 self.manager.get_idle_worker_for_saving(((None, None), (None, state, None)))  # prepare for dumping
         else:
             self.runtime_timer.start("checkpoint saving time")
             self.maybe_update_zcc_worker(args, model, optimizer, state.global_step)
+            self.manager.global_step = state.global_step  # see comment above
             checkpoint_folder = f"{PREFIX_CHECKPOINT_DIR}-{state.global_step}"
             save_infos = self._get_save_infos_based_on_steps(state, args, checkpoint_folder)
             non_cached_objects = (lr_scheduler.state_dict(), state, self.get_rng_states(args))
@@ -956,6 +968,28 @@ class ZeroCostCheckpointManager:
         logger.info(
             f"[ZCC manager] after putting task for prepare, dumping={save_infos_and_non_cached_objects is not None}"
         )
+
+    def maybe_sync_offload_status(self):
+        """Idempotent variant of `sync_offload_status`, safe to call at the beginning of a step.
+
+        The ZCC worker is a separate process that reads the trainer's fused GPU buffers
+        through CUDA IPC on its own stream, so there is no CUDA stream ordering between
+        the trainer's compute stream and the worker's copy stream. The only ordering is
+        this handshake. It therefore has to be reached before *any* mutation of those
+        buffers in the next step, which happens earlier than `on_optimizer_begin`
+        (e.g. FP8 expert-weight quantization / `clear_param_storage` in `on_step_begin`).
+        """
+        if self.current_worker is None:
+            return
+        if self.current_pipeline_hook_step != self.pipeline_hooks_steps:
+            # The offload is still being sliced across pipeline hooks (PP > 1, or
+            # gradient_accumulation_steps > 1). The remaining chunks are only dispatched
+            # during this step's forward/backward, so waiting here would deadlock. Those
+            # configurations keep synchronizing at `on_optimizer_begin` as before.
+            return
+        logger.info("[ZCC manager] Start syncing checkpoints (step begin)")
+        self.sync_offload_status()
+        logger.info("[ZCC manager] Synced checkpoints (step begin).")
 
     def sync_offload_status(self):
         self.report_error_worker()

--- a/tests/ai_edited_test/trainer/test_ai_zero_cost_ckpt.py
+++ b/tests/ai_edited_test/trainer/test_ai_zero_cost_ckpt.py
@@ -3,17 +3,53 @@
 
 import hashlib
 import unittest
-from unittest.mock import MagicMock
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import paddle
 
 from paddleformers.trainer.utils.zero_cost_checkpoint import (
     ZCCTaskType,
     ZCCWorkerStatus,
+    ZeroCostCheckpointCallback,
+    ZeroCostCheckpointManager,
     _unwrap_opt_for_fused_states,
     md5,
     sharded_state_dict_compatibility,
 )
+
+
+class _FakeValue:
+    """Stand-in for a `multiprocessing.Value`; only `.value` is accessed."""
+
+    def __init__(self, value):
+        self.value = value
+
+
+class _FakeWorker:
+    """Minimal ZCC worker double exposing the fields the manager barrier reads."""
+
+    def __init__(self, worker_id=0, status=ZCCWorkerStatus.IDLE.value, global_step=0):
+        self.worker_id = worker_id
+        self.status = _FakeValue(status)
+        self.global_step = _FakeValue(global_step)
+        self.task_queue = MagicMock()  # get_idle_worker_for_saving puts PREPARE tasks here
+
+
+def _bare_manager(**overrides):
+    """Build a ZeroCostCheckpointManager without spawning worker processes.
+
+    The offload barrier only touches a handful of plain attributes, so we bypass
+    __init__ (which would spawn processes / require fleet) and set them directly.
+    """
+    m = ZeroCostCheckpointManager.__new__(ZeroCostCheckpointManager)
+    m.workers = overrides.get("workers", [])
+    m.current_worker = overrides.get("current_worker", None)
+    m.global_step = overrides.get("global_step", 0)
+    m.pipeline_hooks_steps = overrides.get("pipeline_hooks_steps", 1)
+    m.current_pipeline_hook_step = overrides.get("current_pipeline_hook_step", 1)
+    m.ready_to_save = overrides.get("ready_to_save", True)
+    return m
 
 
 class TestZCCTaskType(unittest.TestCase):
@@ -110,6 +146,203 @@ class TestShardedStateDictCompatibility(unittest.TestCase):
             return state_dict
 
         self.assertEqual(my_function.__name__, "my_function")
+
+
+class TestSyncOffloadStatus(unittest.TestCase):
+    """Barrier semantics of `ZeroCostCheckpointManager.sync_offload_status`.
+
+    The worker only publishes `global_step.value` after the *whole* D2H of that step
+    finishes (zero_cost_checkpoint.py: `offloaded_numels == all_numel`). The barrier
+    must therefore keep polling until the worker's step catches up to the manager's
+    current step -- it must not accept the worker's stale echo of a previous step.
+    """
+
+    def test_stale_worker_step_keeps_polling(self):
+        # manager is offloading step 5; worker still reports step 4 (previous offload
+        # not finished). The barrier must wait rather than pass on the stale value.
+        worker = _FakeWorker(global_step=4)
+        m = _bare_manager(workers=[worker], current_worker=worker, global_step=5)
+
+        def _advance(_seconds):
+            # Simulate the worker finishing the in-flight D2H after two poll cycles.
+            _advance.calls += 1
+            if _advance.calls >= 2:
+                worker.global_step.value = 5
+
+        _advance.calls = 0
+        with patch("paddleformers.trainer.utils.zero_cost_checkpoint.time.sleep", side_effect=_advance) as slept:
+            m.sync_offload_status()
+
+        self.assertGreaterEqual(slept.call_count, 2)  # actually waited
+        self.assertIsNone(m.current_worker)  # released only after the step matched
+        self.assertEqual(m.current_pipeline_hook_step, 0)
+
+    def test_matching_step_returns_without_waiting(self):
+        worker = _FakeWorker(global_step=7)
+        m = _bare_manager(workers=[worker], current_worker=worker, global_step=7)
+        with patch("paddleformers.trainer.utils.zero_cost_checkpoint.time.sleep") as slept:
+            m.sync_offload_status()
+        slept.assert_not_called()
+        self.assertIsNone(m.current_worker)
+        self.assertEqual(m.current_pipeline_hook_step, 0)
+
+
+class TestMaybeSyncOffloadStatus(unittest.TestCase):
+    """Step-begin variant added by the fix: sync only when it is safe to block."""
+
+    def test_no_current_worker_is_noop(self):
+        m = _bare_manager(current_worker=None)
+        m.sync_offload_status = MagicMock()
+        m.maybe_sync_offload_status()
+        m.sync_offload_status.assert_not_called()
+
+    def test_single_chunk_synced_at_step_begin(self):
+        # Whole offload already dispatched in one chunk -> safe to wait at step begin.
+        worker = _FakeWorker(global_step=5)
+        m = _bare_manager(
+            workers=[worker],
+            current_worker=worker,
+            global_step=5,
+            pipeline_hooks_steps=1,
+            current_pipeline_hook_step=1,
+        )
+        m.maybe_sync_offload_status()
+        self.assertIsNone(m.current_worker)  # sync_offload_status ran
+        self.assertEqual(m.current_pipeline_hook_step, 0)
+
+    def test_multi_chunk_not_fully_dispatched_does_not_wait(self):
+        # PP>1 / grad-accum: remaining chunks are only sent during this step's fwd/bwd,
+        # so blocking here would deadlock. Must decline and leave state untouched.
+        worker = _FakeWorker(global_step=4)
+        m = _bare_manager(
+            workers=[worker],
+            current_worker=worker,
+            global_step=5,
+            pipeline_hooks_steps=4,
+            current_pipeline_hook_step=1,
+        )
+        m.sync_offload_status = MagicMock()
+        m.maybe_sync_offload_status()
+        m.sync_offload_status.assert_not_called()
+        self.assertIs(m.current_worker, worker)  # unchanged
+        self.assertEqual(m.current_pipeline_hook_step, 1)
+
+
+class TestOnStepEndRefreshesGlobalStep(unittest.TestCase):
+    """`on_step_end` must refresh `manager.global_step` on every offloading step.
+
+    Without this the value stays frozen at the first save's step, and the barrier
+    ends up comparing a value against itself (worker echo) and never waits.
+    """
+
+    def _make_callback(self, manager):
+        cb = ZeroCostCheckpointCallback.__new__(ZeroCostCheckpointCallback)
+        cb.manager = manager
+        cb.runtime_timer = MagicMock()
+        cb.zcc_ema_interval = 2
+        # Stub the heavy collaborators; only the global_step bookkeeping is under test.
+        cb.maybe_update_zcc_worker = MagicMock()
+        cb._get_save_infos_based_on_steps = MagicMock(return_value=(None, None))
+        cb.get_rng_states = MagicMock(return_value=None)
+        return cb
+
+    def test_save_branch_writes_current_step(self):
+        manager = MagicMock()
+        manager.global_step = 3  # stale value from a previous save
+        cb = self._make_callback(manager)
+        args = SimpleNamespace(zcc_save_ema_coef=None, pipeline_model_parallel_size=1)
+        state = SimpleNamespace(global_step=7)
+        control = SimpleNamespace(should_save=True)
+        cb.on_step_end(args, state, control, model=MagicMock(), lr_scheduler=MagicMock(), optimizer=MagicMock())
+        self.assertEqual(manager.global_step, 7)
+
+    def test_ema_branch_writes_current_step(self):
+        manager = MagicMock()
+        manager.global_step = 3
+        cb = self._make_callback(manager)
+        args = SimpleNamespace(zcc_save_ema_coef=0.999, pipeline_model_parallel_size=1)
+        state = SimpleNamespace(global_step=8)  # 8 % zcc_ema_interval(2) == 0
+        control = SimpleNamespace(should_save=False)
+        cb.on_step_end(args, state, control, model=MagicMock(), lr_scheduler=MagicMock(), optimizer=MagicMock())
+        self.assertEqual(manager.global_step, 8)
+
+    def test_ema_branch_skipped_off_interval_does_not_touch_step(self):
+        manager = MagicMock()
+        sentinel = object()
+        manager.global_step = sentinel
+        cb = self._make_callback(manager)
+        args = SimpleNamespace(zcc_save_ema_coef=0.999, pipeline_model_parallel_size=1)
+        state = SimpleNamespace(global_step=7)  # 7 % 2 != 0 -> no offload this step
+        control = SimpleNamespace(should_save=False)
+        cb.on_step_end(args, state, control, model=MagicMock(), lr_scheduler=MagicMock(), optimizer=MagicMock())
+        self.assertIs(manager.global_step, sentinel)
+
+
+_SLEEP = "paddleformers.trainer.utils.zero_cost_checkpoint.time.sleep"
+
+
+class TestMultiWorkerPoolBarrier(unittest.TestCase):
+    """Concurrency: with a real worker pool, idle-selection + reuse must never let a
+    *historical* global_step echo (from any worker) release the current barrier.
+
+    Drives the real `get_idle_worker_for_saving` (idle pick) and `sync_offload_status`
+    (barrier) across 3 consecutive saves: fresh pick, pick-around-a-busy-worker, and
+    reuse of a worker still carrying a stale step.
+    """
+
+    def _drive_barrier(self, m, target, decoys):
+        """Poll the barrier: on the 1st tick the decoys echo the *current* step (must be
+        ignored); only on a later tick does `target` actually finish. A regression that
+        watches any worker instead of `current_worker` would exit after the 1st tick,
+        leaving `target` still stale and the sleep count at 1 -- the asserts below catch it.
+        """
+        ticks = {"n": 0}
+
+        def _advance(_seconds):
+            ticks["n"] += 1
+            if ticks["n"] == 1:
+                for d in decoys:
+                    d.global_step.value = m.global_step  # adversarial / historical echo
+                self.assertIsNotNone(m.current_worker)  # still engaged, not released early
+            else:
+                target.global_step.value = m.global_step  # the real completion
+
+        with patch(_SLEEP, side_effect=_advance) as slept:
+            m.sync_offload_status()
+
+        self.assertGreaterEqual(slept.call_count, 2)  # ignored the decoy echo, kept polling
+        self.assertEqual(target.global_step.value, m.global_step)
+        self.assertIsNone(m.current_worker)  # released only after `target` reached the step
+
+    def test_pool_selection_and_reuse_ignore_stale_echo(self):
+        wA, wB, wC = (_FakeWorker(worker_id=i) for i in range(3))
+        m = _bare_manager(workers=[wA, wB, wC], global_step=0)
+        save = (("flash", "persistent"), ("lr", "state", "rng"))  # dummy PREPARE payload
+
+        # save #1 @10: all idle -> first idle (A) picked; A completes.
+        m.global_step = 10
+        m.get_idle_worker_for_saving(save)
+        self.assertIs(m.current_worker, wA)
+        wA.status.value = ZCCWorkerStatus.OFFLOADING.value
+        self._drive_barrier(m, target=wA, decoys=[])
+
+        # save #2 @20: A still DUMPING -> idle pick skips to B; A's echo must not release B.
+        m.global_step = 20
+        wA.status.value = ZCCWorkerStatus.DUMPING.value
+        m.get_idle_worker_for_saving(save)
+        self.assertIs(m.current_worker, wB)  # selection skipped the busy worker A
+        wB.status.value = ZCCWorkerStatus.OFFLOADING.value
+        self._drive_barrier(m, target=wB, decoys=[wA])
+
+        # save #3 @30: A idle again but carries a stale echo -> reused; only A finishing releases.
+        m.global_step = 30
+        wA.status.value = ZCCWorkerStatus.IDLE.value
+        wB.status.value = ZCCWorkerStatus.DUMPING.value
+        self.assertLess(wA.global_step.value, 30)  # historical echo from an earlier save
+        m.get_idle_worker_for_saving(save)
+        self.assertIs(m.current_worker, wA)  # reused
+        wA.status.value = ZCCWorkerStatus.OFFLOADING.value
+        self._drive_barrier(m, target=wA, decoys=[wB, wC])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
PR types

  Bug fixes

  PR changes

  Others

  Description

  修复 ZCC offload 握手屏障从不真正等待 in-flight D2H 的问题，并补充回归测试与设计文档。

  问题

  ZeroCostCheckpointManager.sync_offload_status() 本应挡住 trainer，直到 ZCC worker 把上一步
  快照的 D2H 拷贝完成。ZCC worker 是一个 spawn 出来的独立进程，通过 CUDA IPC 映射 trainer 的
  fused GPU buffer，并在它自己的 CUDA stream 上做拷贝——所以这个握手是两个进程之间唯一的
  顺序保证。但它是坏的：从第二次保存起，屏障在第一次比较时就通过、从不等待。于是 on_step_begin
  里对这些 buffer 的改写（FP8 专家权重量化 + clear_param_storage）可能与仍在进行的拷贝竞争，
  静默损坏 checkpoint。

  两个独立成因：
  1. manager.global_step 只在 update_zcc_workers() 里赋值，而其调用者
  maybe_update_zcc_worker() 在 fused_buffer_version == cache_version 时短路返回。稳态下
  该值整个 run 只写一次（首次保存那步），之后冻结。
  2. worker 只是把收到的值原样回写，导致 manager 最终拿一个冻结的 X 和它自己的 X 比较。

  而且即使在 on_optimizer_begin 处修好比较也已太晚——on_step_begin 回调更早就改写了 buffer。

  现网佐证（2496 卡）：真正会等待的分支日志 Waiting current worker offloading done 出现 0 次；
  "done" 分支出现 48 次，且每次都是同一个冻结的 manager_step。

  改动

  1. 每步刷新 manager.global_step：ZeroCostCheckpointCallback.on_step_end 的两个分支都补上
  self.manager.global_step = state.global_step（该值已 >= 1，保留了
  get_idle_worker_for_saving 中的 assert global_step != 0）。
  2. 把同步点提前到下一步开头：新增 ZeroCostCheckpointManager.maybe_sync_offload_status()，
  在 Trainer._inner_training_loop 中紧挨 on_step_begin 之前调用。它由
  current_pipeline_hook_step != pipeline_hooks_steps 守护：当 offload 仍被切片、分散到多个
  pipeline hook（PP > 1 / 梯度累积导致的多 chunk）时，剩余分片要靠本步的前向/反向才发出，此处
  等待会死锁——这些拓扑仍沿用原 on_optimizer_begin 同步。原 on_optimizer_begin 同步保留作兜底。
  3. 回归测试（tests/ai_edited_test/trainer/test_ai_zero_cost_ckpt.py，纯 mock，不依赖
  GPU / worker 进程）：旧 step 持续轮询、不接受 stale echo；单 chunk 在 step begin 同步；多 chunk
  未发完时不等待（防死锁）；current_worker is None 时 no-op；on_step_end 两分支都刷新 step；
  非 offload 步不误写 step；以及一个 3-worker 池用例，覆盖 idle 选择 + 复用，验证任何 worker 的
  历史 global_step echo 都不会提前释放当前屏障。
  4. 设计文档 docs/zh/zcc_offload_barrier_fix.md：包含机制说明、根因图解、修复方案、完整调用链
  以及多 chunk 限制分析。

  已知限制（先前就存在，本 PR 未完全修复）

  本 PR 彻底修好了单 chunk 路径。对于多 chunk（PP，或梯度累积使 pipeline_hooks_steps >= 2），
  覆盖参数区的分片是在下一步的子步里派发的，即发生在 on_step_begin 改写之后，因此 step-begin 的
  守护会选择在此不等待。在 ernie 这类配置下（bf16 + DygraphShardingOptimizerV2 + flex_checkpoint）
  实际是良性的：唯一被损坏的是 bf16 moe_expert 快照，而恢复时它会被过滤掉、并由完好的 fp32 master
  weight 重建；master weight 本身在改写之前就先被 offload、且不会被 clear_param_storage 清除。这
  并非对所有配置的通用保证。后续需要一个跟进：在 on_step_begin 改写之前，为参数区建立完整的 D2H
  顺序（代价是牺牲多 chunk 的重叠）。