### PR TITLE
cherry-pick: fix vpp mapping (#4825)

### DIFF
--- a/paddleformers/transformers/model_utils.py
+++ b/paddleformers/transformers/model_utils.py
@@ -3565,17 +3565,19 @@ class PipelinePretrainedModel(PretrainedModel):
             pp_to_single_mapping = {}
 
             state_dict_keys = list(super().state_dict().keys())
-            first_key = ""
-            for k in state_dict_keys:
-                if "shared_layers" not in k:
-                    first_key = k
-                    break
-            first_key = first_key.split(".")
-            # if use virtual pp_degree, the prefix is like 0.0.xxx
-            # else it will be like 0.xxx
-            use_virtual_pipeline_model_parallel_size = first_key[0].isdigit() and first_key[1].isdigit()
+            # Whether the layers are chunked is a property of the model, not something the
+            # key shapes can tell: a chunk key is `{chunk_start}.{local_idx}.xxx`, but an
+            # ordinary PP `LayerDesc(nn.Sequential, ...)` also yields
+            # `{global_idx}.{sublayer_idx}.xxx`, and conversely the first key of a chunked
+            # stage may be a shared layer alias or a directly added layer, both of which
+            # keep a non digit second segment. Ask the pipeline layer itself; dualpipev
+            # chunks the layers as well.
+            use_virtual_pipeline_model_parallel_size = self._num_virtual_pipeline_stages > 1 or self._use_dualpipev
 
             prefixes = self.get_sequential_name_prefixes()
+            shared_layer_names = {
+                layer.layer_name for layer in self._layers_desc if isinstance(layer, SharedLayerDesc)
+            }
             for k in state_dict_keys:
                 name_splited = k.split(".")
                 if use_virtual_pipeline_model_parallel_size:
@@ -3584,12 +3586,22 @@ class PipelinePretrainedModel(PretrainedModel):
                             idx = str(int(name_splited[0]) + int(name_splited[1]))
                             single_name = [prefixes[idx]]
                             single_name.extend(name_splited[2:])
-                        else:
-                            single_name = [prefixes[str(len(prefixes) - 1)]]
+                        elif name_splited[1] in shared_layer_names:
+                            # A SharedLayerDesc with `forward_func` is registered on the chunk
+                            # itself under VPP, so its key is `{chunk_start}.{shared_name}.rest`.
+                            # It aliases the same parameter as `shared_layers.{shared_name}.rest`
+                            # and must resolve to the same single card name.
+                            single_name = [self.get_shardlayer_prefix(name_splited, SharedLayerDesc)]
                             single_name.extend(name_splited[2:])
-                            logger.warning(
-                                f"Please check! we treat this key as last layer, get {k}, set origin name as {'.'.join(single_name)}"
-                            )
+                        else:
+                            # Layers directly added to the PipelineLayer under VPP (e.g. lm_head) are
+                            # named `{global_idx}.rest` instead of `{chunk_start}.{local_idx}.rest`, so
+                            # the first segment is already the global index. Resolve them per layer like
+                            # the non-VPP branch, otherwise every such key collapses onto the last layer
+                            # prefix, drops its submodule name and collides with its siblings.
+                            idx = name_splited[0]
+                            single_name = [] if prefixes[idx] == "" else [prefixes[idx]]
+                            single_name.extend(name_splited[1:])
                     elif name_splited[0] == "shared_layers":
                         single_name = [self.get_shardlayer_prefix(name_splited, SharedLayerDesc)]
                         single_name.extend(name_splited[2:])

--- a/tests/transformers/test_modeling_utils.py
+++ b/tests/transformers/test_modeling_utils.py
@@ -15,8 +15,16 @@
 import os
 import unittest
 from tempfile import TemporaryDirectory
+from unittest import mock
+
+import paddle.nn as nn
+from paddle.distributed.fleet.meta_parallel import LayerDesc, SharedLayerDesc
 
 from paddleformers.transformers import Qwen3ForCausalLM
+from paddleformers.transformers.model_utils import (
+    PipelinePretrainedModel,
+    PretrainedModel,
+)
 from paddleformers.utils.env import CONFIG_NAME, PADDLE_WEIGHTS_NAME
 from tests.testing_utils import slow
 
@@ -55,3 +63,142 @@ class TestModeling(unittest.TestCase):
             self.assertTrue(os.path.exists(os.path.join(tempdir, model_name, PADDLE_WEIGHTS_NAME)))
             # check against double appending model_name in cache_dir
             self.assertFalse(os.path.exists(os.path.join(tempdir, model_name, model_name)))
+
+
+class TestVirtualPipelineNameMapping(unittest.TestCase):
+    """Test _set_pipeline_name_mapping for virtual pipeline parallelism.
+
+    Under VPP, layers directly added to the PipelineLayer (e.g. lm_head) are named
+    `{global_idx}.rest` while layers inside a chunk are named `{chunk_start}.{local_idx}.rest`.
+    Both forms must map back to their single card names without collision.
+    """
+
+    # 4 layers split into 2 chunks of 2 layers, lm_head is the last layer.
+    PREFIXES = {
+        "0": "model.embed_tokens",
+        "1": "model.layers.0",
+        "2": "model.layers.1",
+        "3": "model.lm_head",
+    }
+
+    def _build_mapping(self, pp_keys, layers_desc=(), stage_id=0, index_to_stage=None, num_virtual_pipeline_stages=2):
+        model = PipelinePretrainedModel.__new__(PipelinePretrainedModel)
+        model._layers_desc = list(layers_desc)
+        model._stage_id = stage_id
+        model._num_virtual_pipeline_stages = num_virtual_pipeline_stages
+        model._use_dualpipev = False
+        model.get_stage_from_index = lambda idx: (index_to_stage or {}).get(idx, stage_id)
+        with mock.patch.object(
+            PretrainedModel, "state_dict", return_value={k: None for k in pp_keys}
+        ), mock.patch.object(PipelinePretrainedModel, "get_sequential_name_prefixes", return_value=self.PREFIXES):
+            model._set_pipeline_name_mapping()
+        return model._pp_to_single_mapping
+
+    def test_directly_added_layer_keys_do_not_collide(self):
+        pp_keys = [
+            # chunk 0: `{chunk_start}.{local_idx}.rest`
+            "0.0.embed_tokens.weight",
+            "0.1.self_attn.o_proj.weight",
+            # chunk 1 and the directly added lm_head, whose composite params all
+            # share the `3.` prefix.
+            "2.0.self_attn.o_proj.weight",
+            "3.weight",
+            "3.norm.weight",
+            "3.enorm.weight",
+            "3.transformer_layer.self_attn.o_proj.weight",
+        ]
+        mapping = self._build_mapping(pp_keys)
+
+        self.assertEqual(
+            mapping,
+            {
+                "0.0.embed_tokens.weight": "model.embed_tokens.embed_tokens.weight",
+                "0.1.self_attn.o_proj.weight": "model.layers.0.self_attn.o_proj.weight",
+                "2.0.self_attn.o_proj.weight": "model.layers.1.self_attn.o_proj.weight",
+                "3.weight": "model.lm_head.weight",
+                "3.norm.weight": "model.lm_head.norm.weight",
+                "3.enorm.weight": "model.lm_head.enorm.weight",
+                "3.transformer_layer.self_attn.o_proj.weight": "model.lm_head.transformer_layer.self_attn.o_proj.weight",
+            },
+        )
+        # every pipeline key keeps a unique single card name
+        self.assertEqual(len(set(mapping.values())), len(pp_keys))
+
+    def test_chunk_shared_layer_keys_follow_shared_layer_rule(self):
+        # A SharedLayerDesc with `forward_func` is registered on the chunk itself under
+        # VPP, so the same parameter shows up both as `shared_layers.{name}.rest` and as
+        # `{chunk_start}.{name}.rest`. Both aliases must resolve to the same name.
+        layers_desc = [
+            SharedLayerDesc("embed_weight_share", nn.Linear, shared_weight_attr="weight"),
+            LayerDesc(nn.Linear),
+            LayerDesc(nn.Linear),
+            SharedLayerDesc(
+                "embed_weight_share",
+                nn.Linear,
+                forward_func=lambda layer, x: x,
+                shared_weight_attr="weight",
+            ),
+        ]
+        pp_keys = [
+            "shared_layers.embed_weight_share.weight",
+            "1.0.self_attn.o_proj.weight",
+            "3.embed_weight_share.weight",
+        ]
+        # stage 1 of a pp=2, vpp=2 run owns virtual stages 1 and 3
+        mapping = self._build_mapping(
+            pp_keys, layers_desc=layers_desc, stage_id=1, index_to_stage={0: 0, 1: 1, 2: 0, 3: 1}
+        )
+
+        self.assertEqual(
+            mapping,
+            {
+                "shared_layers.embed_weight_share.weight": "model.lm_head.weight",
+                "1.0.self_attn.o_proj.weight": "model.layers.0.self_attn.o_proj.weight",
+                "3.embed_weight_share.weight": "model.lm_head.weight",
+            },
+        )
+
+    def test_mapping_when_shared_key_comes_first(self):
+        # If the first chunk registers the SharedLayerDesc with `forward_func`, the first
+        # non `shared_layers` key is `{chunk_start}.{name}.rest`, whose second segment is
+        # not a digit. The `{chunk_start}.{local_idx}.rest` keys of the other chunks must
+        # still be resolved as chunk keys.
+        shared = SharedLayerDesc(
+            "embed_weight_share", nn.Linear, forward_func=lambda layer, x: x, shared_weight_attr="weight"
+        )
+        layers_desc = [shared, LayerDesc(nn.Linear), LayerDesc(nn.Linear), shared]
+        pp_keys = [
+            "shared_layers.embed_weight_share.weight",
+            "0.embed_weight_share.weight",
+            "2.0.self_attn.o_proj.weight",
+        ]
+        # stage 0 of a pp=2, vpp=2 run owns virtual stages 0 and 2
+        mapping = self._build_mapping(
+            pp_keys, layers_desc=layers_desc, stage_id=0, index_to_stage={0: 0, 1: 1, 2: 0, 3: 1}
+        )
+
+        self.assertEqual(
+            mapping,
+            {
+                "shared_layers.embed_weight_share.weight": "model.embed_tokens.weight",
+                "0.embed_weight_share.weight": "model.embed_tokens.weight",
+                "2.0.self_attn.o_proj.weight": "model.layers.1.self_attn.o_proj.weight",
+            },
+        )
+
+    def test_ordinary_pp_keeps_numeric_sublayer_names(self):
+        # Without chunking, `LayerDesc(nn.Sequential, ...)` yields
+        # `{global_idx}.{sublayer_idx}.rest`, which looks exactly like a chunk key. The
+        # numeric sublayer name has to survive, so the chunked form must not be inferred
+        # from the key shape.
+        pp_keys = ["1.0.weight", "1.1.bias", "2.self_attn.o_proj.weight"]
+        mapping = self._build_mapping(pp_keys, num_virtual_pipeline_stages=1)
+
+        self.assertEqual(
+            mapping,
+            {
+                "1.0.weight": "model.layers.0.0.weight",
+                "1.1.bias": "model.layers.0.1.bias",
+                "2.self_attn.o_proj.weight": "model.layers.1.self_attn.o_proj.weight",
+            },
+        )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Merged in dev: #4825 (7f2a81bbf9286c3d61df9b3fc286e2a37c1b07aa)

Fix the parameter name mapping of `PipelinePretrainedModel._set_pipeline_name_mapping` under virtual pipeline parallelism, where `model.lm_head.weight` used to be occupied by a 1-D norm weight and made HF checkpoints fail to load with `AssertionError: ... the target_tensor has 2 dimensions, but the tensor in output_vars has 1 dimensions`.
