### PR TITLE
[release/1.3][Deps] Update PaddleFleet to 054c7a9b0a8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,7 @@ try:
         install_requires=REQUIRED_PACKAGES,
         entry_points={"console_scripts": get_console_scripts()},
         extras_require={
-            "paddlefleet": ["paddlefleet==0.4.0.post20260801+83b700a4fb9"],
+            "paddlefleet": ["paddlefleet==0.4.0.post20260808+054c7a9b0a8"],
         },
         python_requires=">=3.8",
         classifiers=[


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description

Update the optional PaddleFleet dependency on `release/1.3` from `paddlefleet==0.4.0.post20260801+83b700a4fb9` to `paddlefleet==0.4.0.post20260808+054c7a9b0a8`.

Merge sequencing: PaddleFormers develop PR [#4854](https://github.com/PaddlePaddle/PaddleFormers/pull/4854) was created in parallel and must merge first; this release PR must remain blocked until then.

The new nightly wheel was built from PaddleFleet [`release/0.4` commit `054c7a9b0a870c7dd23cf4014d20e653cc6c01c0`](https://github.com/PaddlePaddle/PaddleFleet/commit/054c7a9b0a870c7dd23cf4014d20e653cc6c01c0), the protected authoritative branch head after [PaddleFleet #1676](https://github.com/PaddlePaddle/PaddleFleet/pull/1676) actually merged. The corresponding develop dependency update [PaddleFleet #1677](https://github.com/PaddlePaddle/PaddleFleet/pull/1677) merged first.

The matching [official CUDA 12.9 index wheel](https://paddle-whl.bj.bcebos.com/nightly/cu129/paddlefleet/paddlefleet-0.4.0.post20260808+054c7a9b0a8-py3-none-any.whl) has SHA-256 `a4b040b9d7eee83e4209bd0383b15eab4ff81f4d70e0b76bae9e085614d08179`. Its `METADATA` reports version `0.4.0.post20260808+054c7a9b0a8` and requires the verified Paddle artifact `paddlepaddle-gpu==3.4.0.post20260808+733f3454aa0`; generated `_version.py` records the full Fleet commit. A fresh CPython 3.12 virtual environment installed the exact wheel with `--no-index --no-deps --no-cache-dir`, and installed metadata/commit were re-checked without importing PaddleFleet. The exact wheel is indexed on the official `cu126`, `cu129`, `cu130`, and `cu132` nightly indexes.

No source compatibility adjustment is needed; the existing dependency format and CI commit parser support this release-wheel convention.

### Validation

- Confirmed PaddleFleet #1677 and #1676 are actually merged in develop-first order.
- Confirmed protected PaddleFleet `release/0.4` resolves to `054c7a9b0a870c7dd23cf4014d20e653cc6c01c0`.
- Confirmed official wheel `METADATA`, generated full commit, exact Paddle dependency, SHA-256, and clean installation.
- `python3 -m py_compile setup.py scripts/ci_utils/get_fleet_commit.py`
- `python3 scripts/ci_utils/get_fleet_commit.py` → `054c7a9b0a8`
- AST parsing, exact one-file/one-line delta review, and `git diff --check` pass.
