### PR TITLE
feat: support gradient metric finalization for internal medicine monitors

### DIFF
--- a/paddleformers/trainer/trainer_callback.py
+++ b/paddleformers/trainer/trainer_callback.py
@@ -1045,6 +1045,15 @@ class InternalMedicineCallback(TrainerCallback):
             if collect is not None:
                 collect()
 
+    def on_optimizer_begin(self, args, state, control, scaler=None, **kwargs):
+        if not self._setup_done:
+            return
+
+        for monitor in self._monitor_dict.values():
+            finalize = getattr(monitor, "finalize_scaled_grad_metrics", None)
+            if finalize is not None:
+                finalize(scaler)
+
     def on_step_end(self, args, state, control, **kwargs):
         if not self._setup_done:
             return


### PR DESCRIPTION
### PR types

New features

### PR changes

Others

### Description

This PR adds optimizer-step integration for Internal Medicine gradient monitors.

Before the optimizer updates model parameters, `TrainerCallback` now calls `finalize_scaled_grad_metrics()` on registered monitors when the method is available. The current AMP `GradScaler` is passed to the monitor so that gradient metrics collected from autograd hooks, such as `h_res_logits_grad_min` and `h_res_logits_grad_max`, can be converted back to their unscaled values before being flushed.

The callback uses capability detection to remain backward-compatible with monitors that do not implement `finalize_scaled_grad_metrics()`.

This change does not modify model gradients or optimizer behavior. It only affects the values reported by Internal Medicine monitoring.