### PR TITLE
fix: finalize mHC composite metrics on substep end

### DIFF
--- a/paddleformers/trainer/trainer_callback.py
+++ b/paddleformers/trainer/trainer_callback.py
@@ -1054,6 +1054,15 @@ class InternalMedicineCallback(TrainerCallback):
             if finalize is not None:
                 finalize(scaler)
 
+    def on_substep_end(self, args, state, control, **kwargs):
+        if not self._setup_done:
+            return
+
+        for monitor in self._monitor_dict.values():
+            finalize = getattr(monitor, "finalize_composite_microbatch", None)
+            if finalize is not None:
+                finalize()
+
     def on_step_end(self, args, state, control, **kwargs):
         if not self._setup_done:
             return


### PR DESCRIPTION
### PR types

Others

### PR changes

Integrate Internal Medicine monitor finalization with optimizer and accumulation callbacks.

### Description

This PR adds callback integration for Internal Medicine monitors:

- Passes the current AMP `GradScaler` to `finalize_scaled_grad_metrics()` before the optimizer step, allowing autograd-hook gradient metrics to be restored to unscaled values;
- Calls `finalize_composite_microbatch()` at `on_substep_end`, preventing mHC composite snapshots from being overwritten during gradient accumulation;
- Uses capability detection to preserve compatibility with monitors that do not implement these optional methods.

The change only affects metric finalization and does not modify model gradients, optimizer behavior, or training semantics.