### PR TITLE
optimize ema accmulate

### DIFF
--- a/paddleformers/trainer/utils/zero_cost_checkpoint.py
+++ b/paddleformers/trainer/utils/zero_cost_checkpoint.py
@@ -313,7 +313,7 @@ class ZeroCostCheckpointEMAProcessor:
     def __init__(self, optimizer_fusion_storage_helper, param_fusion_storage_helper, ema_coef):
         self.optimizer_fusion_storage_helper = optimizer_fusion_storage_helper
         self.param_fusion_storage_helper = param_fusion_storage_helper
-        self.ema_coef = ema_coef
+        self.ema_coef = None if ema_coef is None else float(ema_coef)
         (
             self.ema_buffer,
             self.ema_buffer_model_params,

--- a/paddleformers/trainer/utils/zero_cost_checkpoint.py
+++ b/paddleformers/trainer/utils/zero_cost_checkpoint.py
@@ -14,6 +14,7 @@
 
 import atexit
 import copy
+import ctypes
 import functools
 import hashlib
 import json
@@ -295,6 +296,14 @@ def get_fused_param_mappings(optimizer, manipulated_state_dict):
     return param_mappings, ipc_meta_mappings
 
 
+def pin2cpu_zero_copy_fp32(t):
+    lt = t.get_tensor()
+    arr = np.ctypeslib.as_array(ctypes.cast(lt._ptr(), ctypes.POINTER(ctypes.c_float)), shape=(t._numel(),))
+    alias = core.eager.Tensor(value=arr, place=core.CPUPlace(), zero_copy=True)
+    alias._keep_alive = (t, arr)
+    return alias
+
+
 class ZeroCostCheckpointEMAProcessor:
     """
     生活在 ZCC Worker 里面的 EMA 处理模块.
@@ -357,11 +366,19 @@ class ZeroCostCheckpointEMAProcessor:
         # do update: ema = alpha * ema + (1-alpha) * model
         logger.info(f"[ZCC EMA] accumulating, buffer type:{self.ema_buffer.place} {self.ema_buffer.dtype}")
         with device_guard("cpu"):
-            cpu_master_weights = self.optimizer_fusion_storage_helper.cpu_buffer._slice(
-                self.master_min_offset, self.master_max_offset
-            ).cpu()
+            cpu_buffer = self.optimizer_fusion_storage_helper.cpu_buffer
+            if (
+                cpu_buffer.place.is_cuda_pinned_place()
+                and cpu_buffer.dtype == paddle.float32
+                and cpu_buffer.is_contiguous()
+            ):
+                cpu_master_weights = pin2cpu_zero_copy_fp32(cpu_buffer)._slice(
+                    self.master_min_offset, self.master_max_offset
+                )
+            else:
+                cpu_master_weights = cpu_buffer._slice(self.master_min_offset, self.master_max_offset).cpu()
             if zcc_ema_loss_threshold is None or loss < zcc_ema_loss_threshold:
-                self.ema_buffer = self.ema_coef * self.ema_buffer + (1 - self.ema_coef) * cpu_master_weights
+                self.ema_buffer.lerp_(cpu_master_weights, 1 - self.ema_coef)
                 for index, ema_buf in self.ema_buffer_model_params.items():
                     _, cpu_buf = self.param_fusion_storage_helper.inited_buffers[index]
                     updated_ema = self.ema_coef * ema_buf + (1 - self.ema_coef) * cpu_buf


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
优化了在开启zcc机制后在cpu侧的ema计算性能。
原先的计算瓶颈主要集中在两点：
1. 计算数据存储在pinned memory上，由于paddle目前将该内存归类到cuda类别中，导致需要再将数据拷贝一份到cpu
2. ema使用cpu进行数据计算，时间消费较大

**优化方案：** 
1. 创建一个cpu的tensor指针，指向pinned memory，欺骗内存该tensor在cpu上，以此消除拷贝时间
2. 使用paddle的lerp_函数，该函数对插值的计算进行了优化，能有效提升计算速度。

**优化表现：** 对numel为5456678784的fp32元素进行计算：
优化前：
<img width="1948" height="284" alt="image" src="https://github.com/user-attachments/assets/00ca66a3-d602-45d3-ad0a-cfe2893e00ec" />
cpu拷贝时间为图中.cpu所示，花费14.307s，ema更新总花费时间共67.281s，减去拷贝时间后计算时间为59.274s
优化后：
<img width="2444" height="268" alt="image" src="https://github.com/user-attachments/assets/55db2461-f553-4d63-9cab-c1cc5656c996" />
cpu拷贝时间为330.868us，ema总花费时间6.360s
优化后相比优化前提升10倍性能

**精度测试：**
在代码中内嵌针对两种计算方式进行精度的比较得到：

| Step | Max Abs Error | Mean Abs Error |
|---:|---:|---:|
| 3 | 0.000000e+00 | 0.000000e+00 |
| 6 | 4.656613e-10 | 2.978864e-13 |
| 9 | 9.313226e-10 | 4.579713e-13 |
| 12 | 9.313226e-10 | 5.904473e-13 |
| 15 | 1.862645e-09 | 6.756184e-13 |
| 18 | 1.862645e-09 | 9.256782e-13 |
| 21 | 1.862645e-09 | 1.170150e-12 |
| 24 | 1.862645e-09 | 1.178951e-12 |
| 27 | 1.862645e-09 | 1.240131e-12 |
| 30 | 3.725290e-09 | 1.378937e-12 |
| 33 | 3.725290e-09 | 1.621817e-12 |
| 36 | 3.725290e-09 | 1.938548e-12 |

精度误差在10-8数量级别左右，误差较小。可以看到最大误差在进行阶跃性的跳跃，这主要是因为ema_buffer中的值正在平滑变大，这导致误差值变大。等待权重值稳定后将会保持稳定的误差。

查看lerp源码得到该方案的实现为：
```
  eigen_out.device(place) =
      (eigen_x.broadcast(x_bcast_dims).template cast<MPType>() +
       eigen_w.broadcast(w_bcast_dims).template cast<MPType>() *
           (eigen_y.broadcast(y_bcast_dims).template cast<MPType>() -
            eigen_x.broadcast(x_bcast_dims).template cast<MPType>()))
          .template cast<T>();
}
```
原本的计算公式为out = w * x + (1 - w) * y ；lerp的计算公式为out = x + w * (y - x)

从而产生两项误差：
1. w和（1-w）的出现会存在误差，两者相加可能不为1，产生误差
2. 计算次数和位置顺序不同产生误差

两个区别说明误差是由两种计算方式的差异导致的，lerp的精度相对于原本的实现方式会更加高。

**内存泄漏**
通过测试无内存泄漏问题