### PR TITLE
[release/1.3] cherry-pick: finalize gradient & mHC composite metrics for internal medicine monitors (#4870)(#4871)

### DIFF
--- a/paddleformers/trainer/trainer_callback.py
+++ b/paddleformers/trainer/trainer_callback.py
@@ -1026,6 +1026,15 @@ class InternalMedicineCallback(TrainerCallback):
             if finalize is not None:
                 finalize(scaler)
 
+    def on_substep_end(self, args, state, control, **kwargs):
+        if not self._setup_done:
+            return
+
+        for monitor in self._monitor_dict.values():
+            finalize = getattr(monitor, "finalize_composite_microbatch", None)
+            if finalize is not None:
+                finalize()
+
     def on_step_end(self, args, state, control, **kwargs):
         if not self._setup_done:
             return

--- a/paddleformers/trainer/trainer_callback.py
+++ b/paddleformers/trainer/trainer_callback.py
@@ -1017,6 +1017,15 @@ class InternalMedicineCallback(TrainerCallback):
             if collect is not None:
                 collect()
 
+    def on_optimizer_begin(self, args, state, control, scaler=None, **kwargs):
+        if not self._setup_done:
+            return
+
+        for monitor in self._monitor_dict.values():
+            finalize = getattr(monitor, "finalize_scaled_grad_metrics", None)
+            if finalize is not None:
+                finalize(scaler)
+
     def on_step_end(self, args, state, control, **kwargs):
         if not self._setup_done:
             return


### PR DESCRIPTION
Merged in dev: #4870
Merged in dev: #4871
### PR types
Bug fixes

### PR changes
Others

### Description

Cherry-pick #4870 and #4871 to `release/1.3`.

- #4870 `feat: support gradient metric finalization for internal medicine monitors`
  - Adds `InternalMedicineCallback.on_optimizer_begin`, which calls each monitor's `finalize_scaled_grad_metrics(scaler)` so gradient metrics are unscaled/finalized before the optimizer step.
- #4871 `fix: finalize mHC composite metrics on substep end`
  - Adds `InternalMedicineCallback.on_substep_end`, which calls each monitor's `finalize_composite_microbatch()` so composite mHC metrics are settled per microbatch instead of only at step end.

Both hooks early-return when `self._setup_done` is False, and use `getattr(..., None)` so monitors without these methods are unaffected.

Scope: `paddleformers/trainer/trainer_callback.py` only, +18 lines, no behavior change for users who don't enable the internal medicine monitors. Clean cherry-pick, no conflicts.