### PR TITLE
update internal medicine args set of paddleformers side

### DIFF
--- a/paddleformers/cli/hparams/finetuning_args.py
+++ b/paddleformers/cli/hparams/finetuning_args.py
@@ -127,11 +127,10 @@ class PreTrainingArguments(TrainingArguments):
 
     def __post_init__(self):
         super().__post_init__()
-        if (
-            self.internal_medicine_monitors
-            and (self.internal_medicine_monitor_interval or 0) > 0
-            and not self.internal_medicine_log_dir
-        ):
+        # Keep the internal-medicine jsonl in its own subdirectory instead of the
+        # output_dir root, so it is not mistaken for a checkpoint artifact. Mirrors
+        # the eb pretrain path (ernie5/src/trainers/pretraining_trainer.py:1646).
+        if self.internal_medicine_monitors and (self.internal_medicine_monitor_interval or 0) > 0:
             self.internal_medicine_log_dir = os.path.join(self.output_dir, "internal_medicine")
 
     @property

--- a/paddleformers/cli/hparams/finetuning_args.py
+++ b/paddleformers/cli/hparams/finetuning_args.py
@@ -127,9 +127,6 @@ class PreTrainingArguments(TrainingArguments):
 
     def __post_init__(self):
         super().__post_init__()
-        # Keep the internal-medicine jsonl in its own subdirectory instead of the
-        # output_dir root, so it is not mistaken for a checkpoint artifact. Mirrors
-        # the eb pretrain path (ernie5/src/trainers/pretraining_trainer.py:1646).
         if self.internal_medicine_monitors and (self.internal_medicine_monitor_interval or 0) > 0:
             self.internal_medicine_log_dir = os.path.join(self.output_dir, "internal_medicine")
 

--- a/paddleformers/cli/hparams/finetuning_args.py
+++ b/paddleformers/cli/hparams/finetuning_args.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
@@ -72,17 +73,21 @@ class PreTrainingArguments(TrainingArguments):
         metadata={"help": "the logging interval of global_training_logs"},
     )
     internal_medicine_monitors: Optional[str] = field(
-        default="",
+        default="qk_stats,moe_health,massive_act,mhc_health,vha_health",
         metadata={
-            "help": "Comma-separated list of internal medicine monitors. Options: qk_stats,moe_health,massive_act,all"
+            "help": "Comma-separated list of internal medicine monitors. Options: "
+            "qk_stats,moe_health,massive_act,mhc_health,vha_health,all. Defaults to all five. "
+            "mhc_health is a hard no-op on models without HyperConnectionTransformerLayer, "
+            "vha_health likewise on models without VHA postmix. "
+            "To disable monitoring entirely, set internal_medicine_monitor_interval to 0."
         },
     )
     internal_medicine_monitor_interval: int = field(
         default=0,
         metadata={
             "help": "Step interval for internal medicine monitors. "
-            "0 (default) disables monitoring (no collection, no viewer). "
-            "Positive integer is the sampling interval."
+            "0 = disabled (default; no collection, no viewer). "
+            "Positive integer = enable monitoring with that sampling interval."
         },
     )
     internal_medicine_qk_row_stride: int = field(
@@ -91,14 +96,6 @@ class PreTrainingArguments(TrainingArguments):
             "help": "qk_stats query-row subsampling stride. 1 = exact full pass. "
             "Larger values (e.g. 16/32) subsample query rows to cut the O(S^2) cost "
             "on long sequences; mean/entropy/sink stay unbiased, max is a lower bound."
-        },
-    )
-    internal_medicine_log_dir: str = field(
-        default="",
-        metadata={
-            "help": "Directory for the per-step JSONL produced by the internal-medicine "
-            "callback (rank 0 only). File name is fixed to 'internal_medicine.jsonl'. "
-            "Empty -> use output_dir. Consumed by tools/internal_medicine/server.py."
         },
     )
     num_consecutive: int = field(
@@ -127,6 +124,15 @@ class PreTrainingArguments(TrainingArguments):
         default=False,
         metadata={"help": "shuffle num_consecutive or not"},
     )
+
+    def __post_init__(self):
+        super().__post_init__()
+        if (
+            self.internal_medicine_monitors
+            and (self.internal_medicine_monitor_interval or 0) > 0
+            and not self.internal_medicine_log_dir
+        ):
+            self.internal_medicine_log_dir = os.path.join(self.output_dir, "internal_medicine")
 
     @property
     def need_data(self):

--- a/paddleformers/trainer/trainer_callback.py
+++ b/paddleformers/trainer/trainer_callback.py
@@ -22,6 +22,7 @@ import dataclasses
 import json
 import os
 import random
+import sys
 import time
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Union
@@ -1006,14 +1007,27 @@ class InternalMedicineCallback(TrainerCallback):
 
         self._maybe_truncate_on_resume(state)
 
+        # internal_medicine declares requires-python >= 3.10.
+        if sys.version_info < (3, 10):
+            logger.warning(
+                "[InternalMedicine/pfleet] internal_medicine requires Python >= 3.10 but this "
+                "interpreter is %d.%d; skipping monitor setup. Disable internal_medicine_monitors "
+                "to silence this warning.",
+                sys.version_info[0],
+                sys.version_info[1],
+            )
+            return
+
         try:
             from internal_medicine.backends.paddlefleet import setup_monitors
             from internal_medicine.core.training_logs import training_logs
-        except ImportError:
+        except (ImportError, TypeError, SyntaxError) as exc:
             logger.warning(
                 "[InternalMedicine/pfleet] internal_medicine_monitors is enabled, but the optional "
                 "internal_medicine package is not importable. Add third_party/llm-internal-medicine/src "
-                "to PYTHONPATH or disable internal_medicine_monitors."
+                "to PYTHONPATH or disable internal_medicine_monitors. (%s: %s)",
+                type(exc).__name__,
+                exc,
             )
             return
 

--- a/paddleformers/trainer/trainer_callback.py
+++ b/paddleformers/trainer/trainer_callback.py
@@ -1010,7 +1010,7 @@ class InternalMedicineCallback(TrainerCallback):
             from internal_medicine.backends.paddlefleet import setup_monitors
             from internal_medicine.core.training_logs import training_logs
         except ImportError:
-            logger.exception(
+            logger.warning(
                 "[InternalMedicine/pfleet] internal_medicine_monitors is enabled, but the optional "
                 "internal_medicine package is not importable. Add third_party/llm-internal-medicine/src "
                 "to PYTHONPATH or disable internal_medicine_monitors."
@@ -1180,7 +1180,7 @@ class InternalMedicineCallback(TrainerCallback):
                 f.write(json.dumps(record, ensure_ascii=False) + "\n")
         except Exception:
             # Never let logging IO crash training.
-            logger.exception("[InternalMedicine] failed to append jsonl record")
+            logger.warning("[InternalMedicine] failed to append jsonl record")
 
 
 class EMAStateAssemblerCallback(TrainerCallback):


### PR DESCRIPTION
### PR types

- [x] Others

### PR changes

1. Update the default value and help message of `internal_medicine_monitors`.
   - Enable the five available monitors by default when monitoring is enabled:
     `qk_stats`, `moe_health`, `massive_act`, `mhc_health`, and `vha_health`.
   - Clarify the behavior of `all` and model-specific no-op monitors.

2. Clarify `internal_medicine_monitor_interval` behavior.
   - `0` disables monitoring.
   - A positive value enables monitoring with the specified sampling interval.

3. Set the default internal medicine log directory to:
   `<output_dir>/internal_medicine`
   when monitoring is enabled and no log directory is specified.

4. Remove the redundant `internal_medicine_log_dir` argument definition from this file.

The changes are limited to argument definition and default-value handling. No model computation logic is changed.