### PR TITLE
[Deps] Update PaddleFleet to 66a8168b7b3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,7 @@ try:
         install_requires=REQUIRED_PACKAGES,
         entry_points={"console_scripts": get_console_scripts()},
         extras_require={
-            "paddlefleet": ["paddlefleet==0.4.0.post20260808+054c7a9b0a8"],
+            "paddlefleet": ["paddlefleet==0.4.0.post20260814+66a8168b7b3"],
         },
         python_requires=">=3.8",
         classifiers=[


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description

Update the optional PaddleFleet dependency from `paddlefleet==0.4.0.post20260808+054c7a9b0a8` to `paddlefleet==0.4.0.post20260814+66a8168b7b3`.

The new nightly wheel was built from PaddleFleet [`release/0.4` commit `66a8168b7b38e16bd00d833955d9a251f18b499b`](https://github.com/PaddlePaddle/PaddleFleet/commit/66a8168b7b38e16bd00d833955d9a251f18b499b), the authoritative branch head after [PaddleFleet #1748](https://github.com/PaddlePaddle/PaddleFleet/pull/1748) merged.

The matching [official CUDA 12.9 index wheel](https://paddle-whl.bj.bcebos.com/nightly/cu129/paddlefleet/paddlefleet-0.4.0.post20260814+66a8168b7b3-py3-none-any.whl) has SHA-256 `00d10ce769a2d66c08dfdbe09a881a48458dc15bf86b4e8e20c03c5555c51820`. Its `METADATA` reports version `0.4.0.post20260814+66a8168b7b3` and requires `paddlepaddle-gpu==3.4.0.post20260812+a136cd3594a`; generated `_version.py` records the full Fleet commit. The exact wheel is available on the official `cu126`, `cu129`, `cu130`, and `cu132` nightly indexes.

No source compatibility adjustment is needed; the existing dependency format and CI commit parser support this release-wheel convention.

### Validation

- Confirmed PaddleFleet #1748 is merged and PaddleFleet `release/0.4` resolves to `66a8168b7b38e16bd00d833955d9a251f18b499b` via both Git and GitHub API.
- Confirmed official wheel `METADATA`, generated full commit, exact Paddle dependency, SHA-256, and availability on all four nightly indexes.
- `python3 -m py_compile setup.py scripts/ci_utils/get_fleet_commit.py`
- `python3 scripts/ci_utils/get_fleet_commit.py` → `66a8168b7b3`
- AST parsing, exact one-file/one-line delta review, and `git diff --check` pass.
