### PR TITLE
del .clone() & override FusionStorageHelper

### DIFF
--- a/paddleformers/trainer/utils/zero_cost_checkpoint.py
+++ b/paddleformers/trainer/utils/zero_cost_checkpoint.py
@@ -405,7 +405,7 @@ class ZeroCostCheckpointEMAProcessor:
                     continue  # non fp32 has no `self.ema_buffer_model_params`
                 if buffer_index.startswith("unshard_"):
                     # unshard_ type tensors use the entire buffer directly
-                    tensor = self.ema_buffer_model_params[buffer_index].clone()
+                    tensor = self.ema_buffer_model_params[buffer_index]
                     tensor.get_tensor()._set_dims(shape)
                     tensor.name = name
                     ema_state_dict[k] = tensor
@@ -413,7 +413,7 @@ class ZeroCostCheckpointEMAProcessor:
                 start = tensor_meta["start"]
                 end = tensor_meta["end"]
                 cpu_buffer = self.ema_buffer_model_params[buffer_index]
-                tensor = cpu_buffer._slice(start, end).clone()  # slice 出来的 tensor 在执行`paddle.save`会异常慢，此处必须clone
+                tensor = cpu_buffer._slice(start, end)
                 tensor.get_tensor()._set_dims(shape)
                 tensor.name = name
                 ema_state_dict[k] = tensor
@@ -421,7 +421,7 @@ class ZeroCostCheckpointEMAProcessor:
             for k, meta in self.optimizer_fusion_storage_helper.master_weights_meta.items():
                 s = meta["start"] - self.master_min_offset
                 e = meta["end"] - self.master_min_offset
-                t = self.ema_buffer._slice(s, e).clone()
+                t = self.ema_buffer._slice(s, e)
                 t.get_tensor()._set_dims(meta["shape"])
                 t.name = meta["name"]
                 ema_state_dict_master_weights[k] = t

--- a/paddleformers/trainer/utils/zero_cost_checkpoint.py
+++ b/paddleformers/trainer/utils/zero_cost_checkpoint.py
@@ -454,6 +454,40 @@ class ZeroCostCheckpointEMAProcessor:
                 self.ema_buffer[s:e] = ema_master[k].flatten()
 
 
+class OptFusionStorageHelper(FusionStorageHelper):
+    def __init__(
+        self,
+        accumulators_meta,
+        master_weights_meta,
+        merged_model_params_meta,
+        buffer_ipc_meta,
+    ):
+        super().__init__(
+            accumulators_meta,
+            master_weights_meta,
+            merged_model_params_meta,
+            buffer_ipc_meta,
+        )
+
+    @imperative_base.no_grad()
+    def restore_tensor_from_meta(self, tensor_meta):
+        shape = tensor_meta["shape"]
+        name = tensor_meta["name"]
+        start = tensor_meta["start"]
+        end = tensor_meta["end"]
+        if (
+            self.cpu_buffer.place.is_cuda_pinned_place()
+            and self.cpu_buffer.dtype == paddle.float32
+            and self.cpu_buffer.is_contiguous()
+        ):
+            tensor = pin2cpu_zero_copy_fp32(self.cpu_buffer)._slice(start, end)
+        else:
+            tensor = self.cpu_buffer._slice(start, end)
+        tensor.get_tensor()._set_dims(shape)
+        tensor.name = name
+        return tensor
+
+
 class ParamFusionStorageHelper:
     def __init__(
         self,
@@ -1432,7 +1466,7 @@ class ZeroCostCheckpointWorker:
             buffer_ipc_meta,
         ) = optimizer_states_meta
         if self.optimizer_fusion_storage_helper is None:
-            self.optimizer_fusion_storage_helper = FusionStorageHelper(
+            self.optimizer_fusion_storage_helper = OptFusionStorageHelper(
                 accumulators_meta,
                 master_weights_meta,
                 merged_model_params_meta,

--- a/paddleformers/trainer/utils/zero_cost_checkpoint.py
+++ b/paddleformers/trainer/utils/zero_cost_checkpoint.py
@@ -455,19 +455,15 @@ class ZeroCostCheckpointEMAProcessor:
 
 
 class OptFusionStorageHelper(FusionStorageHelper):
-    def __init__(
-        self,
-        accumulators_meta,
-        master_weights_meta,
-        merged_model_params_meta,
-        buffer_ipc_meta,
-    ):
-        super().__init__(
-            accumulators_meta,
-            master_weights_meta,
-            merged_model_params_meta,
-            buffer_ipc_meta,
-        )
+    """
+    A zero-copy variant of FusionStorageHelper whose `state_dict` returns
+    zero-copy views of its cpu_buffer (in pinned memory) instead of independent
+    copies.
+
+    Note: the caller MUST fully consume or persist the returned state_dict (e.g.
+    finish `paddle.save`) before starting the next `sync_param`, otherwise it
+    may silently corrupt the content in state_dict.
+    """
 
     @imperative_base.no_grad()
     def restore_tensor_from_meta(self, tensor_meta):


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
处理两个问题：
1. clone将导致性能显著下降，由于张量已经在内存上了，所以不需要拷贝可以直接使用。修改代码的注释提到的paddle.save性能问题可以是历史遗留问题，没有复现出性能下降问题。修改后的性能显著提升，原先拷贝需要数秒，现在该时间已经消除且对后续的save也不会产生影响
2. 创建OptFusionStorageHelper类，原先的类restore_tensor_from_meta因为数据存储在pinned memory中使用slice会进行copy，消费多余时间。现使用OptFusionStorageHelper覆盖原本的restore_tensor_from_meta方法从而实现零拷贝节省时间