### PR TITLE
optimize hf_checkpoint's wait time

### DIFF
--- a/paddleformers/transformers/model_utils.py
+++ b/paddleformers/transformers/model_utils.py
@@ -4035,7 +4035,7 @@ def save_full_param(
             f"Params: {len(current_shard_state_dict)}, "
             f"Path: {save_path}"
         )
-
+        paddle.device.synchronize()
         save_file(current_shard_state_dict, save_path)
 
         # Reset for the next shard
@@ -4048,14 +4048,17 @@ def save_full_param(
     total_size = 0
 
     for i, (param_key, param) in enumerate(itr):
-        param_size_bytes = param.numel() * param.element_size()
-        total_size += param_size_bytes.item()
+        param_size_bytes = int(np.prod(param.shape)) * param.element_size()
+        total_size += param_size_bytes
         if i % num_saver_ranks == rank:
             logger.info(f"[Rank {rank}/{moe_sharding_world_size}] Assigned to store parameter {param_key}")
             if current_shard_size_bytes > 0 and (current_shard_size_bytes + param_size_bytes > max_shard_size_bytes):
                 _save_current_shard()
-            # Move tensor to CPU since we only need to save it, not compute with it
-            current_shard_state_dict[param_key] = param.cpu()
+            # Non-blocking D2H into pinned (page-locked) host memory so the copy can
+            # overlap with subsequent tensor assembly instead of blocking the host per
+            # tensor. Completion is forced by paddle.device.synchronize() in
+            # _save_current_shard() before save_file reads the data.
+            current_shard_state_dict[param_key] = param._copy_to(paddle.CUDAPinnedPlace(), False)
             current_shard_size_bytes += param_size_bytes
 
             if current_shard_size_bytes >= max_shard_size_bytes:

--- a/paddleformers/transformers/model_utils.py
+++ b/paddleformers/transformers/model_utils.py
@@ -4036,7 +4036,8 @@ def save_full_param(
             f"Params: {len(current_shard_state_dict)}, "
             f"Path: {save_path}"
         )
-        paddle.device.synchronize()
+        if is_gpu:
+            paddle.device.cuda.synchronize()
         save_file(current_shard_state_dict, save_path)
 
         # Reset for the next shard
@@ -4047,7 +4048,7 @@ def save_full_param(
     logger.info(f"[Rank {rank}/{moe_sharding_world_size}] Starting to process the weight iterator...")
 
     total_size = 0
-
+    is_gpu = paddle.device.get_device().startswith("gpu")
     for i, (param_key, param) in enumerate(itr):
         param_size_bytes = math.prod(param.shape) * param.element_size()
         total_size += param_size_bytes
@@ -4055,11 +4056,15 @@ def save_full_param(
             logger.info(f"[Rank {rank}/{moe_sharding_world_size}] Assigned to store parameter {param_key}")
             if current_shard_size_bytes > 0 and (current_shard_size_bytes + param_size_bytes > max_shard_size_bytes):
                 _save_current_shard()
-            # Non-blocking D2H into pinned (page-locked) host memory so the copy can
-            # overlap with subsequent tensor assembly instead of blocking the host per
-            # tensor. Completion is forced by paddle.device.synchronize() in
-            # _save_current_shard() before save_file reads the data.
-            current_shard_state_dict[param_key] = param._copy_to(paddle.CUDAPinnedPlace(), False)
+            # CUDA: non-blocking D2H into pinned (page-locked) host memory so the
+            # copy can overlap with subsequent tensor assembly instead of blocking
+            # the host per tensor. Completion is forced by the single
+            # paddle.device.cuda.synchronize() in _save_current_shard() before
+            # save_file reads the data. XPU/CPU fall back to a blocking .cpu().
+            if is_gpu:
+                current_shard_state_dict[param_key] = param._copy_to(paddle.CUDAPinnedPlace(), False)
+            else:
+                current_shard_state_dict[param_key] = param.cpu()
             current_shard_size_bytes += param_size_bytes
 
             if current_shard_size_bytes >= max_shard_size_bytes:

--- a/paddleformers/transformers/model_utils.py
+++ b/paddleformers/transformers/model_utils.py
@@ -19,6 +19,7 @@ import copy
 import gc
 import inspect
 import json
+import math
 import os
 import re
 import sys
@@ -4048,7 +4049,7 @@ def save_full_param(
     total_size = 0
 
     for i, (param_key, param) in enumerate(itr):
-        param_size_bytes = int(np.prod(param.shape)) * param.element_size()
+        param_size_bytes = math.prod(param.shape) * param.element_size()
         total_size += param_size_bytes
         if i % num_saver_ranks == rank:
             logger.info(f"[Rank {rank}/{moe_sharding_world_size}] Assigned to store parameter {param_key}")

--- a/paddleformers/transformers/model_utils.py
+++ b/paddleformers/transformers/model_utils.py
@@ -4037,7 +4037,7 @@ def save_full_param(
             f"Path: {save_path}"
         )
         if is_gpu:
-            paddle.device.cuda.synchronize()
+            paddle.device.cuda.current_stream().synchronize()
         save_file(current_shard_state_dict, save_path)
 
         # Reset for the next shard


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
优化 save_full_param checkpoint 写盘路径：消除逐 tensor 的 D2H 同步阻塞
save_full_param 的保存循环中，每个 tensor 都会触发一次 host 阻塞的 GPU→CPU 同步，成为写盘路径的瓶颈。具体有两处：
1. size 计算触发隐式同步：原先用 param.numel().item() 计算 tensor 字节数。Paddle 中 numel() 返回的是 GPU 上的 0-D tensor，.item() 会强制一次 D2H 拷贝 + cudaStreamSynchronize
2. param.cpu() 逐 tensor 同步阻塞：每个待保存 tensor 都做一次同步 D2H 拷贝，host 必须等拷贝落地才能继续处理下一个 tensor，无法与后续 tensor 的 assembly 重叠。
通过代码改动消除逐tensor的同步，将同步时间统一落在存盘之前，减少阻塞。

性能优化结果：
对于Size: 5526.04 MB, Params: 631的数据，save_full_param时间由原先27.583s（9.142s写盘时间）降低到12s（9.146s写盘时间）。

内存显存泄漏检测：
显存无泄漏