### PR TITLE
fix(auto): route Gemma3 text checkpoints to text modeling

### DIFF
--- a/paddleformers/transformers/auto/modeling.py
+++ b/paddleformers/transformers/auto/modeling.py
@@ -98,6 +98,14 @@ MAPPING_NAMES = OrderedDict(
 )
 
 MAPPING_SPACIAL_KEY = OrderedDict([("Gemma3", "Gemma3"), ("Ernie4_5_VLMoe", "Ernie4_5_VLMoeForConditionalGeneration")])
+MAPPING_TASK_SPECIFIC_KEY = OrderedDict(
+    [
+        (("Gemma3Text", "ForCausalLM"), "Gemma3ForCausalLM"),
+        (("Gemma3Text", "ForCausalLMPipe"), "Gemma3ForCausalLMPipe"),
+    ]
+)
+# Text checkpoints use Gemma3ForCausalLM, whose prefix otherwise selects the multimodal Gemma3 module.
+MODEL_TYPE_TO_MODEL_NAME = OrderedDict([("gemma3_text", "Gemma3TextModel")])
 CONFIGURATION_MODEL_MAPPING = OrderedDict([((), "Gemma3ForConditionalGeneration")])
 
 MAPPING_TASKS = OrderedDict(
@@ -137,7 +145,9 @@ def get_name_mapping(task="Model"):
     """
     NAME_MAPPING = OrderedDict()
     for key, value in MAPPING_NAMES.items():
-        if key in MAPPING_SPACIAL_KEY and task == "Model":
+        if (key, task) in MAPPING_TASK_SPECIFIC_KEY:
+            import_class = MAPPING_TASK_SPECIFIC_KEY[(key, task)]
+        elif key in MAPPING_SPACIAL_KEY and task == "Model":
             import_class = MAPPING_SPACIAL_KEY[key] + task
         else:
             import_class = key + task
@@ -196,7 +206,9 @@ class _BaseAutoModelClass:
         # Sort the MAPPING_NAMES to reorder the model class names with longest-first rule
         # thus the names with same prefix can be correctly inferred
         # such as QWen and QWen2MOE, QWen2MOE is the longest prefix of QWen2MOEModel
-        model_name = "MiniCPM4_1Model" if resolved_model_type == "minicpm4_1" else None
+        model_name = MODEL_TYPE_TO_MODEL_NAME.get(config.get("model_type"))
+        if model_name is None and resolved_model_type == "minicpm4_1":
+            model_name = "MiniCPM4_1Model"
         SORTED_MAPPING_NAMES = dict(sorted(MAPPING_NAMES.items(), key=lambda x: len(x[0]), reverse=True))
         if model_name is None and init_class:
             for model_flag, name in SORTED_MAPPING_NAMES.items():

--- a/tests/transformers/gemma3/test_modeling.py
+++ b/tests/transformers/gemma3/test_modeling.py
@@ -25,6 +25,7 @@ import paddle
 import paddleformers.transformers as transformers_module
 from paddleformers.transformers import (
     AutoModel,
+    AutoModelForCausalLM,
     AutoModelForConditionalGeneration,
     Gemma3Config,
     Gemma3ForCausalLM,
@@ -180,11 +181,14 @@ class Gemma3ModelTest(unittest.TestCase):
             num_key_value_heads=2,
             head_dim=8,
             max_position_embeddings=64,
+            architectures=["Gemma3ForCausalLM"],
         )
 
         text_model = AutoModel.from_config(text_config)
+        text_causal_model = AutoModelForCausalLM.from_config(text_config)
 
         self.assertEqual(type(text_model).__name__, "Gemma3TextModel")
+        self.assertIsInstance(text_causal_model, Gemma3ForCausalLM)
 
     def test_top_level_exports_resolve_to_upstream_gemma3_text(self):
         self.assertEqual(transformers_module._class_to_module["Gemma3Config"], "gemma3.configuration")


### PR DESCRIPTION
#### Before submitting

- [x] Add regression coverage in the tests folder.

### PR types

Bug fixes

### PR changes

Models, APIs

### Description

- Route `gemma3_text` checkpoints to `Gemma3TextModel` during auto-model resolution.
- Map Gemma3 text causal LM tasks to `Gemma3ForCausalLM` and `Gemma3ForCausalLMPipe`.
- Cover architecture-based Gemma3 text loading with a regression test.

### Test Plan

- Gemma3 model tests: 14 passed.
- Python compilation check for both changed files.
- `git diff --check`.