### PR TITLE
[Deps] Update PaddleFleet to 33c2b9a2178

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,7 @@ try:
         install_requires=REQUIRED_PACKAGES,
         entry_points={"console_scripts": get_console_scripts()},
         extras_require={
-            "paddlefleet": ["paddlefleet==0.4.0.post20260814+66a8168b7b3"],
+            "paddlefleet": ["paddlefleet==0.4.0.post20260819+33c2b9a2178"],
         },
         python_requires=">=3.8",
         classifiers=[


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description

Update the optional PaddleFleet dependency from `paddlefleet==0.4.0.post20260814+66a8168b7b3` to `paddlefleet==0.4.0.post20260819+33c2b9a2178`.

The new nightly wheel was built from PaddleFleet [`release/0.4` commit `33c2b9a21780046e901e6603182d4bd6d6206b94`](https://github.com/PaddlePaddle/PaddleFleet/commit/33c2b9a21780046e901e6603182d4bd6d6206b94), which is the current authoritative branch head.

The matching [official CUDA 12.9 index wheel](https://paddle-whl.bj.bcebos.com/nightly/cu129/paddlefleet/paddlefleet-0.4.0.post20260819+33c2b9a2178-py3-none-any.whl) has SHA-256 `fb26ca8779d7bcad325e9cc3c424b9212ae971c7d5592fee3e5d1f7f1cca04d6`. Its `METADATA` reports version `0.4.0.post20260819+33c2b9a2178` and requires `paddlepaddle-gpu==3.4.0.post20260812+a136cd3594a`; generated `_version.py` records the full Fleet commit. The exact wheel is available on the official `cu126`, `cu129`, `cu130`, and `cu132` nightly indexes.

No source compatibility adjustment is needed; the existing dependency format and CI commit parser support this release-wheel convention.

### Validation

- Confirmed PaddleFleet `release/0.4` resolves to `33c2b9a21780046e901e6603182d4bd6d6206b94` via the remote ref.
- Confirmed official wheel `METADATA`, generated full commit, exact Paddle dependency, SHA-256, and availability on all four nightly indexes.
- `pre-commit run --files setup.py`
- `python3 -m py_compile setup.py scripts/ci_utils/get_fleet_commit.py`
- `python3 scripts/ci_utils/get_fleet_commit.py` → `33c2b9a2178`
- AST parsing, exact one-file/one-line delta review, and `git diff --check` pass.
