### PR TITLE
[CI] sync submodules after branch checkout in ce-build-whl

### DIFF
--- a/.github/workflows/ce-build-whl.yml
+++ b/.github/workflows/ce-build-whl.yml
@@ -69,6 +69,7 @@ jobs:
           echo "Checking out ${BRANCH}..."
           git fetch upstream ${BRANCH}:${BRANCH}
           git checkout ${BRANCH}
+          git submodule update --init --recursive --force
           git log --pretty=oneline -10
           '
 


### PR DESCRIPTION
## 改动内容

`.github/workflows/ce-build-whl.yml`：在 `git checkout ${BRANCH}` 之后补一次 submodule 同步。

```yaml
          git fetch upstream ${BRANCH}:${BRANCH}
          git checkout ${BRANCH}
          git submodule update --init --recursive --force
          git log --pretty=oneline -10
```

原先只在 `git pull` 之后同步过 submodule，切换到目标分支后 submodule 指针可能与该分支不一致，补一次 `--force` 同步。

## 测试

YAML 语法校验通过。
