### PR TITLE
[Benchmark] Add KimiK2 PT config

### DIFF
--- a/tests/config/benchmark/config/pt/Kimi-K2.yaml
+++ b/tests/config/benchmark/config/pt/Kimi-K2.yaml
@@ -1,0 +1,94 @@
+### data
+train_dataset_type: erniekit
+eval_dataset_type: erniekit
+train_dataset_path: ./dataset/data/pt_data/train.jsonl
+train_dataset_prob: "1.0"
+eval_dataset_path: ./dataset/data/pt_data/eval.jsonl
+eval_dataset_prob: "1.0"
+packing: true
+truncate_packing: true
+max_seq_len: 8192
+mix_strategy: concat
+dataloader_shuffle: false
+dataloader_num_workers: 24
+prefetch_factor: 24
+
+### model
+model_name_or_path: ./huggingface/Kimi-K2
+
+### finetuning
+# base
+stage: PT
+fine_tuning: full
+seed: 23
+do_train: true
+do_eval: false
+per_device_eval_batch_size: 1
+per_device_train_batch_size: 1
+num_train_epochs: 1
+max_steps: 50
+eval_iters: 10000
+eval_steps: 10000
+evaluation_strategy: steps
+save_steps: 200
+save_strategy: steps
+logging_steps: 1
+global_batch_size: 32
+gradient_accumulation_steps: 16
+logging_dir: ./vdl_log
+output_dir: ./checkpoints/kimik2-pt
+disable_tqdm: true
+eval_accumulation_steps: 1
+
+# args
+router_aux_loss_coef: 0.0001
+num_nextn_predict_layers: 1
+moe_router_force_load_balancing: true
+
+# train
+warmup_steps: 20
+learning_rate: 1.0e-5
+min_lr: 1.0e-6
+lr_scheduler_type: cosine
+weight_decay: 0.1
+adam_beta2: 0.95
+
+# parallel
+tensor_model_parallel_size: 1
+sequence_parallel: false
+use_expert_parallel: true
+expert_model_parallel_size: 8
+pipeline_model_parallel_size: 4
+
+# performance
+recompute_granularity: full
+recompute_method: block
+recompute_num_layers: 11
+
+moe_expert_fusion: true
+apply_rope_fusion: true
+moe_deep_gemm: false
+fp32_residual_connection: false
+
+# sharding
+split_param: true
+sharding: stage1
+stage1_overlap: true
+
+# pp
+overlap_p2p_comm: true
+variable_seq_lengths: true
+best_unbalanced_scheduler: true
+pp_release_grads: true
+
+amp_master_grad: true
+bf16: true
+fp16_opt_level: O2
+
+save_checkpoint_format: flex_checkpoint
+load_checkpoint_format: flex_checkpoint
+continue_training: true
+
+tensorwise_offload_optimizer: true
+
+skip_profile_timer: false

--- a/tests/config/benchmark/config/pt/run_kimik2.sh
+++ b/tests/config/benchmark/config/pt/run_kimik2.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# KimiK2 PaddleFleet 多机训练脚本
+# 参考: run_glm45_4nodes_128k.sh
+
+set -e
+
+# 清理分布式环境变量
+for name in `env | grep -E 'PADDLE|ENDPOINT' | awk -F'=' '{print $1}'`; do
+    unset ${name}
+done
+unset http_proxy https_proxy
+
+# 激活 PaddleFleet 环境
+if [ -f '/root/paddlejob/share-storage/gpfs/system-public/liyamei/PaddleFleet/.venv/bin/activate' ]; then
+    source /root/paddlejob/share-storage/gpfs/system-public/liyamei/PaddleFleet/.venv/bin/activate
+    echo "activate PaddleFleet env"
+fi
+
+export root_dir=/root/paddlejob/share-storage/gpfs/system-public/liyamei/PaddleFormers
+cd $root_dir
+
+# 多机配置
+# START_RANK/END_RANK: 根据实际机器分配调整
+START_RANK=${START_RANK:-0}
+END_RANK=${END_RANK:-4}
+nnodes=$(($END_RANK-$START_RANK))
+
+# 从 hostfile 获取 master 地址（根据 START_RANK 确定主节点）
+hostfile_path="/root/paddlejob/share-storage/gpfs/system-public/liyamei/hostfile"
+if [ -f "$hostfile_path" ]; then
+    master=$(cat $hostfile_path | head -n $(($START_RANK+1)) | tail -n 1 | awk '{print $1}')
+else
+    master=$(hostname -i)
+fi
+port=${MASTER_PORT:-36677}
+
+# 获取当前 rank
+current_rank=${PADDLE_TRAINER_ID:-0}
+rank=$(($current_rank-$START_RANK))
+
+# 环境变量
+export FLAGS_cudnn_deterministic=1
+export FLAGS_embedding_deterministic=1
+export PADDLEFORMERS_DIST_LOG=./kimik2_dist_log
+export PADDLE_DUMP_DIR=/root/paddlejob/share-storage/gpfs/system-public/liyamei/kimik2_dump
+
+# 清理残留进程
+ps aux | grep paddleformers-cli | grep -v grep | awk '{print $2}' | xargs kill -9 2>/dev/null || true
+rm -rf core.* 2>/dev/null || true
+
+# 配置文件
+config_yaml=$root_dir/tests/config/benchmark/config/pt/Kimi-K2.yaml
+log_dir=$root_dir/kimik2_output
+mkdir -p $log_dir
+log_file=$log_dir/train.log
+
+echo "=========================================="
+echo "KimiK2 PT Benchmark Training"
+echo "Config: $config_yaml"
+echo "NNODES: $nnodes"
+echo "MASTER_ADDR: $master"
+echo "MASTER_PORT: $port"
+echo "RANK: $rank"
+echo "Log: $log_file"
+echo "=========================================="
+
+# 启动训练
+NNODES=$nnodes MASTER_ADDR=$master MASTER_PORT=$port RANK=$rank \
+    paddleformers-cli train $config_yaml 2>&1 | tee $log_file
+
+echo "Training completed. Log saved to $log_file"


### PR DESCRIPTION
参考 #4716（GLM-4.5-Air PT benchmark），新增 KimiK2 预训练性能提测配置。

### PR types
Others

### PR changes
Others

### Description
- 新增 `tests/config/benchmark/config/pt/Kimi-K2.yaml`：stage=PT（通用 run_sft 路径），max_seq_len=8192，erniekit 打包数据，TP=1/EP=8/PP=4，bf16 + flex_checkpoint，含 KimiK2/MoE 特有项（num_nextn_predict_layers、router_aux_loss_coef、moe_router_force_load_balancing 等）。
- 新增 `tests/config/benchmark/config/pt/run_kimik2.sh`：参考 run_glm45_4nodes_128k.sh 的多机启动脚本。

仅新增文件，未改动现有代码。