### PR TITLE
optimize hf_checkpoint 

### DIFF
--- a/paddleformers/transformers/model_utils.py
+++ b/paddleformers/transformers/model_utils.py
@@ -20,7 +20,6 @@ import ctypes
 import gc
 import inspect
 import json
-import math
 import os
 import re
 import sys
@@ -3997,8 +3996,10 @@ def _get_pinned_arena(nbytes):
     """
     global _PINNED_ARENA, _PINNED_ARENA_CAPACITY, _ASYNC_LOADER
     if _PINNED_ARENA is None or _PINNED_ARENA_CAPACITY < nbytes:
-        _host_buf = np.empty(nbytes, dtype=np.uint8)
-        _PINNED_ARENA = paddle.to_tensor(_host_buf, place=paddle.CUDAPinnedPlace())
+        arena = core.eager.Tensor()
+        arena.get_tensor()._set_dims([nbytes])
+        arena.get_tensor()._mutable_data(paddle.CUDAPinnedPlace(), core.VarDesc.VarType.UINT8)
+        _PINNED_ARENA = arena
         _PINNED_ARENA_CAPACITY = nbytes
     if _ASYNC_LOADER is None:
         _ASYNC_LOADER = create_async_load()
@@ -4120,15 +4121,14 @@ def save_full_param(
     total_size = 0
 
     for i, (param_key, param) in enumerate(itr):
-        param_size_bytes = math.prod(param.shape) * param.element_size()
+        param_size_bytes = param.size * param.itemsize
         total_size += param_size_bytes
         if i % num_saver_ranks == rank:
             logger.info(f"[Rank {rank}/{moe_sharding_world_size}] Assigned to store parameter {param_key}")
-            nbytes = int(param_size_bytes)
-            if current_shard_size_bytes > 0 and (current_shard_size_bytes + nbytes > max_shard_size_bytes):
+            if current_shard_size_bytes > 0 and (current_shard_size_bytes + param_size_bytes > max_shard_size_bytes):
                 _save_current_shard()
 
-            if not use_pinned_arena or nbytes > max_shard_size_bytes:
+            if not use_pinned_arena or param_size_bytes > max_shard_size_bytes:
                 # Non-GPU device, or a single param larger than the arena: synchronous copy.
                 current_shard_state_dict[param_key] = param.cpu()
             else:
@@ -4139,15 +4139,17 @@ def save_full_param(
                     dst_tensor=arena_cpu,
                     src_offset=0,
                     dst_offset=arena_offset,
-                    offload_size=nbytes,
+                    offload_size=param_size_bytes,
                     async_loader=async_loader,
                 )
                 shard_tasks.append(task)
                 shard_src_refs.append(src)
-                current_shard_state_dict[param_key] = get_param(arena_offset, nbytes, param.dtype, list(param.shape))
-                arena_offset += nbytes
+                current_shard_state_dict[param_key] = get_param(
+                    arena_offset, param_size_bytes, param.dtype, list(param.shape)
+                )
+                arena_offset += param_size_bytes
 
-            current_shard_size_bytes += nbytes
+            current_shard_size_bytes += param_size_bytes
 
             if current_shard_size_bytes >= max_shard_size_bytes:
                 _save_current_shard()

--- a/paddleformers/transformers/model_utils.py
+++ b/paddleformers/transformers/model_utils.py
@@ -16,14 +16,14 @@ from __future__ import annotations
 import concurrent.futures
 import contextlib
 import copy
+import ctypes
 import gc
 import inspect
 import json
+import math
 import os
 import re
 import sys
-import math
-import ctypes
 import tempfile
 import warnings
 from collections.abc import Iterator
@@ -48,19 +48,20 @@ from huggingface_hub import (
 )
 from huggingface_hub.utils import EntryNotFoundError
 from paddle import Tensor
+from paddle.base import core
 from paddle.distributed.fleet.meta_parallel import LocalSharedLayerDesc
 from paddle.distributed.fleet.meta_parallel.parallel_layers import (
     PipelineLayer,
     SharedLayerDesc,
 )
-from paddle.nn import Embedding, Layer
-from paddle.base import core
 
 # TODO(fangzeyang) Temporary fix and replace by paddle framework downloader later
 from paddle.incubate.tensor.manipulation import (
     async_offload_with_offset,
     create_async_load,
 )
+from paddle.nn import Embedding, Layer
+
 # TODO(fangzeyang) Temporary fix and replace by paddle framework downloader later
 from paddle.utils.download import is_url as is_remote_url
 from safetensors.paddle import save_file
@@ -3985,6 +3986,7 @@ _PINNED_ARENA = None
 _PINNED_ARENA_CAPACITY = 0
 _ASYNC_LOADER = None
 
+
 def _get_pinned_arena(nbytes):
     """Return a process-level (per-rank) pinned uint8 arena of at least ``nbytes`` and a
     shared async loader, both reused across checkpoints.
@@ -4002,6 +4004,7 @@ def _get_pinned_arena(nbytes):
     if _ASYNC_LOADER is None:
         _ASYNC_LOADER = create_async_load()
     return _PINNED_ARENA, _ASYNC_LOADER
+
 
 def save_full_param(
     itr: Iterator[tuple[str, Tensor]],
@@ -4070,15 +4073,12 @@ def save_full_param(
         # Wrap the pinned arena bytes as a CPUPlace zero-copy alias so save_file
         # sees is_cpu_place()==True and skips its internal per-param .cpu().
         base_ptr = arena_cpu.get_tensor()._ptr() + byte_start
-        np_u8 = np.ctypeslib.as_array(
-            ctypes.cast(base_ptr, ctypes.POINTER(ctypes.c_ubyte)), shape=(nbytes,)
-        )
+        np_u8 = np.ctypeslib.as_array(ctypes.cast(base_ptr, ctypes.POINTER(ctypes.c_ubyte)), shape=(nbytes,))
         alias_u8 = core.eager.Tensor(value=np_u8, place=core.CPUPlace(), zero_copy=True)
         alias = alias_u8.view(dtype)
         alias.get_tensor()._set_dims(shape)
         alias._keep_alive = (arena_cpu, np_u8, alias_u8)
         return alias
-
 
     def _save_current_shard():
         nonlocal sub_shard_index, current_shard_state_dict, current_shard_size_bytes
@@ -4145,9 +4145,7 @@ def save_full_param(
                 )
                 shard_tasks.append(task)
                 shard_src_refs.append(src)
-                current_shard_state_dict[param_key] = get_param(
-                    arena_offset, nbytes, param.dtype, list(param.shape)
-                )
+                current_shard_state_dict[param_key] = get_param(arena_offset, nbytes, param.dtype, list(param.shape))
                 arena_offset += nbytes
 
             current_shard_size_bytes += nbytes

--- a/paddleformers/transformers/model_utils.py
+++ b/paddleformers/transformers/model_utils.py
@@ -22,6 +22,8 @@ import json
 import os
 import re
 import sys
+import math
+import ctypes
 import tempfile
 import warnings
 from collections.abc import Iterator
@@ -52,7 +54,13 @@ from paddle.distributed.fleet.meta_parallel.parallel_layers import (
     SharedLayerDesc,
 )
 from paddle.nn import Embedding, Layer
+from paddle.base import core
 
+# TODO(fangzeyang) Temporary fix and replace by paddle framework downloader later
+from paddle.incubate.tensor.manipulation import (
+    async_offload_with_offset,
+    create_async_load,
+)
 # TODO(fangzeyang) Temporary fix and replace by paddle framework downloader later
 from paddle.utils.download import is_url as is_remote_url
 from safetensors.paddle import save_file
@@ -3973,6 +3981,28 @@ def clean_model_class_name(class_name, suffixes_to_strip: Union[str, List[str]] 
     return re.sub(pattern, "", class_name)
 
 
+_PINNED_ARENA = None
+_PINNED_ARENA_CAPACITY = 0
+_ASYNC_LOADER = None
+
+def _get_pinned_arena(nbytes):
+    """Return a process-level (per-rank) pinned uint8 arena of at least ``nbytes`` and a
+    shared async loader, both reused across checkpoints.
+
+    NOTE: The arena is a single shared buffer. Checkpoint saves that use it MUST NOT
+    overlap in time -- if two saves run concurrently they will write into the same
+    arena region and corrupt each other's data. Callers rely on checkpoints being
+    serialized (one save fully finishes, including the final cpu_wait + save_file,
+    before the next begins) so the buffer can be safely reused.
+    """
+    global _PINNED_ARENA, _PINNED_ARENA_CAPACITY, _ASYNC_LOADER
+    if _PINNED_ARENA is None or _PINNED_ARENA_CAPACITY < nbytes:
+        _PINNED_ARENA = paddle.empty(nbytes, dtype=paddle.uint8, pin_memory=True)
+        _PINNED_ARENA_CAPACITY = nbytes
+    if _ASYNC_LOADER is None:
+        _ASYNC_LOADER = create_async_load()
+    return _PINNED_ARENA, _ASYNC_LOADER
+
 def save_full_param(
     itr: Iterator[tuple[str, Tensor]],
     save_dir: str,
@@ -3984,6 +4014,14 @@ def save_full_param(
     """
     Saves model weights from an iterator into shards, supporting max shard size
     and a limited number of saver ranks.
+
+    On GPU, weights are offloaded asynchronously via a reused pinned-memory arena:
+    each param is DMA-copied D2H into a byte offset of a page-locked buffer on a
+    dedicated loader stream (no per-param host sync), a zero-copy alias into that
+    buffer is handed to save_file, and the shard waits once (cpu_wait on the last
+    copy) before writing to disk. This overlaps the copies and avoids the slow
+    synchronous pageable path. On non-GPU devices (XPU/CPU) the arena is skipped
+    and every param falls back to a synchronous param.cpu() copy.
 
     Only ranks less than `num_saver_ranks` will perform disk I/O. All other ranks
     will iterate through the data to maintain synchronization but will not save.
@@ -4015,14 +4053,46 @@ def save_full_param(
 
     os.makedirs(save_dir, exist_ok=True)
 
+    use_pinned_arena = paddle.get_device().startswith("gpu")
+    if use_pinned_arena:
+        arena_cpu, async_loader = _get_pinned_arena(max_shard_size_bytes)
+    else:
+        arena_cpu, async_loader = None, None
+
     current_shard_state_dict = {}
     current_shard_size_bytes = 0
     sub_shard_index = 0
+    arena_offset = 0
+    shard_tasks = []
+    shard_src_refs = []
+
+    def get_param(byte_start, nbytes, dtype, shape):
+        # Wrap the pinned arena bytes as a CPUPlace zero-copy alias so save_file
+        # sees is_cpu_place()==True and skips its internal per-param .cpu().
+        base_ptr = arena_cpu.get_tensor()._ptr() + byte_start
+        np_u8 = np.ctypeslib.as_array(
+            ctypes.cast(base_ptr, ctypes.POINTER(ctypes.c_ubyte)), shape=(nbytes,)
+        )
+        alias_u8 = core.eager.Tensor(value=np_u8, place=core.CPUPlace(), zero_copy=True)
+        alias = alias_u8.view(dtype)
+        alias.get_tensor()._set_dims(shape)
+        alias._keep_alive = (arena_cpu, np_u8, alias_u8)
+        return alias
+
 
     def _save_current_shard():
         nonlocal sub_shard_index, current_shard_state_dict, current_shard_size_bytes
+        nonlocal arena_offset, shard_tasks, shard_src_refs
         if not current_shard_state_dict:
             return
+
+        # Wait for all async D2H copies of this shard to land in the arena.
+        # cuda_wait for all but the last, cpu_wait on the last (same ordered stream).
+        if shard_tasks:
+            last_task = shard_tasks.pop(-1)
+            for task in shard_tasks:
+                task.cuda_wait()
+            last_task.cpu_wait()
 
         # Filename includes the main shard number (rank) and the sub-shard index
         cur_rank = paddle.distributed.get_rank()
@@ -4042,21 +4112,45 @@ def save_full_param(
         sub_shard_index += 1
         current_shard_state_dict = {}
         current_shard_size_bytes = 0
+        arena_offset = 0
+        shard_tasks = []
+        shard_src_refs = []
 
     logger.info(f"[Rank {rank}/{moe_sharding_world_size}] Starting to process the weight iterator...")
 
     total_size = 0
 
     for i, (param_key, param) in enumerate(itr):
-        param_size_bytes = param.numel() * param.element_size()
-        total_size += param_size_bytes.item()
+        param_size_bytes = math.prod(param.shape) * param.element_size()
+        total_size += param_size_bytes
         if i % num_saver_ranks == rank:
             logger.info(f"[Rank {rank}/{moe_sharding_world_size}] Assigned to store parameter {param_key}")
-            if current_shard_size_bytes > 0 and (current_shard_size_bytes + param_size_bytes > max_shard_size_bytes):
+            nbytes = int(param_size_bytes)
+            if current_shard_size_bytes > 0 and (current_shard_size_bytes + nbytes > max_shard_size_bytes):
                 _save_current_shard()
-            # Move tensor to CPU since we only need to save it, not compute with it
-            current_shard_state_dict[param_key] = param.cpu()
-            current_shard_size_bytes += param_size_bytes
+
+            if not use_pinned_arena or nbytes > max_shard_size_bytes:
+                # Non-GPU device, or a single param larger than the arena: synchronous copy.
+                current_shard_state_dict[param_key] = param.cpu()
+            else:
+                # Async D2H copy into the arena, plus a zero-copy alias for save_file.
+                src = param.flatten().view(paddle.uint8)
+                task = async_offload_with_offset(
+                    src_tensor=src,
+                    dst_tensor=arena_cpu,
+                    src_offset=0,
+                    dst_offset=arena_offset,
+                    offload_size=nbytes,
+                    async_loader=async_loader,
+                )
+                shard_tasks.append(task)
+                shard_src_refs.append(src)
+                current_shard_state_dict[param_key] = get_param(
+                    arena_offset, nbytes, param.dtype, list(param.shape)
+                )
+                arena_offset += nbytes
+
+            current_shard_size_bytes += nbytes
 
             if current_shard_size_bytes >= max_shard_size_bytes:
                 _save_current_shard()

--- a/paddleformers/transformers/model_utils.py
+++ b/paddleformers/transformers/model_utils.py
@@ -54,8 +54,6 @@ from paddle.distributed.fleet.meta_parallel.parallel_layers import (
     PipelineLayer,
     SharedLayerDesc,
 )
-
-# TODO(fangzeyang) Temporary fix and replace by paddle framework downloader later
 from paddle.incubate.tensor.manipulation import (
     async_offload_with_offset,
     create_async_load,

--- a/paddleformers/transformers/model_utils.py
+++ b/paddleformers/transformers/model_utils.py
@@ -3997,7 +3997,8 @@ def _get_pinned_arena(nbytes):
     """
     global _PINNED_ARENA, _PINNED_ARENA_CAPACITY, _ASYNC_LOADER
     if _PINNED_ARENA is None or _PINNED_ARENA_CAPACITY < nbytes:
-        _PINNED_ARENA = paddle.empty(nbytes, dtype=paddle.uint8, pin_memory=True)
+        _host_buf = np.empty(nbytes, dtype=np.uint8)
+        _PINNED_ARENA = paddle.to_tensor(_host_buf, place=paddle.CUDAPinnedPlace())
         _PINNED_ARENA_CAPACITY = nbytes
     if _ASYNC_LOADER is None:
         _ASYNC_LOADER = create_async_load()


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
优化 save_full_param checkpoint 写盘路径
save_full_param 的保存循环中，所有rank之间会先进行broadcast和scatter_all的nccl通信来逐tensor的同步，每个rank拿到自己要写盘的tensor后就触发一次 host 阻塞的 GPU→CPU 同步。在获得一定量的tensor后开始落盘。该操作过程的瓶颈主要为：
param.cpu() 逐 tensor 同步阻塞：每个待保存 tensor 都做一次同步 D2H 拷贝，host 必须等拷贝落地才能继续处理下一个 tensor。其次，由于nccl通信前所有rank需要对齐，导致不需要搬运张量到cpu的rank也要统一等待需要搬运张量到cpu的rank。

**代码改动：**
1. 声明pinned_memory，GPU数据异步搬运到pinned_memory,各rank之间不进行阻塞，等到统一落盘时再进行同步落盘
2. numel放cpu计算，不影响GPU

**性能优化结果：**
<img width="2286" height="228" alt="image" src="https://github.com/user-attachments/assets/d6dbf1ce-be92-42d3-b690-181808483217" />
<img width="2352" height="200" alt="image" src="https://github.com/user-attachments/assets/3aa92a3e-531f-4e16-93ec-98f54287ac46" />
在1机8卡上，对于Size: 5526.04 MB, Params: 631的数据，save_full_param时间由原先26.165s（3.793s写盘时间）降低到10.149s（5.248s写盘时间）。

如果可以后面再补一个多机测试，感觉效果可能会更好

**精度对比结果：** 对前后输出的hf_checkpoint读取并对比，无精度误差

**内存显存泄漏检测：**
- 显存无泄漏
- 内存开辟了一个大小（默认16G/卡）的pinned memory缓冲区，后续所有的hf_checkpoint存储均使用该缓冲区（包括ema hf_checkpoint)

**潜在问题：**
1. 在第一次启动hf_checkpoint时，创建pinned memory缓冲区需要时间（16G约7s）
3. pinned memory的写盘速度远落后于pageable memory的写盘速度，实际测试慢4倍左右。但是考虑到大规模机器的通信等待时间较长，在多机下每个机器实际落盘数据量很小这个提升应该还是划算的
4. max_shard_size_bytes是不是设置的太大了，不知道开这么大的pinned memory会不会有影响