### PR TITLE
fix pdc resume bug

### DIFF
--- a/paddleformers/trainer/argparser.py
+++ b/paddleformers/trainer/argparser.py
@@ -436,6 +436,12 @@ class PdArgumentParser(ArgumentParser):
                         logger.info(
                             f"init_step == 0 and user has defined resume_from_checkpoint: {user_defined_resume_from_checkpoint}"
                         )
+                        if args.get("load_from_hf", False) and not args.get("ignore_load_lr_and_optim", False):
+                            args["ignore_load_lr_and_optim"] = True
+                            logger.warning(
+                                "load_from_hf is True, will not load lr and optim state dict. "
+                                "Set ignore_load_lr_and_optim=True"
+                            )
                         return user_defined_resume_from_checkpoint
                 else:
                     # pdc_init_step > 0
@@ -452,15 +458,6 @@ class PdArgumentParser(ArgumentParser):
                     return resume_checkpoint
 
         args["resume_from_checkpoint"] = get_resume_checkpoint_path(args)
-        if (
-            args.get("load_from_hf", False)
-            and args["resume_from_checkpoint"] is not None
-            and not args.get("ignore_load_lr_and_optim", False)
-        ):
-            args["ignore_load_lr_and_optim"] = True
-            logger.warning(
-                "load_from_hf is True, will not load lr and optim state dict. Set ignore_load_lr_and_optim=True"
-            )
         args_for_json = to_regular_dict(args)
 
         json_filename = args_for_json.get("args_output_to_local")

--- a/paddleformers/trainer/argparser.py
+++ b/paddleformers/trainer/argparser.py
@@ -441,6 +441,10 @@ class PdArgumentParser(ArgumentParser):
                     # pdc_init_step > 0
                     logger.info(f"resume training process by pdc longjob with resume step: {pdc_init_step}")
                     resume_checkpoint = os.path.join(args.get("output_dir", None), f"checkpoint-{pdc_init_step}")
+                    # resuming from output_dir/checkpoint-N, which is always saved in paddle format
+                    if args.get("load_from_hf", False):
+                        args["load_from_hf"] = False
+                        logger.warning(f"resume from {resume_checkpoint} by pdc longjob, set load_from_hf=False")
                     if user_defined_resume_from_checkpoint is not None:
                         logger.warning(
                             f"pdc_init_step:{pdc_init_step} and resume_ckpt:{user_defined_resume_from_checkpoint} exist together, use resume_checkpoint:{resume_checkpoint}"
@@ -448,6 +452,15 @@ class PdArgumentParser(ArgumentParser):
                     return resume_checkpoint
 
         args["resume_from_checkpoint"] = get_resume_checkpoint_path(args)
+        if (
+            args.get("load_from_hf", False)
+            and args["resume_from_checkpoint"] is not None
+            and not args.get("ignore_load_lr_and_optim", False)
+        ):
+            args["ignore_load_lr_and_optim"] = True
+            logger.warning(
+                "load_from_hf is True, will not load lr and optim state dict. Set ignore_load_lr_and_optim=True"
+            )
         args_for_json = to_regular_dict(args)
 
         json_filename = args_for_json.get("args_output_to_local")

--- a/paddleformers/trainer/argparser.py
+++ b/paddleformers/trainer/argparser.py
@@ -436,21 +436,18 @@ class PdArgumentParser(ArgumentParser):
                         logger.info(
                             f"init_step == 0 and user has defined resume_from_checkpoint: {user_defined_resume_from_checkpoint}"
                         )
-                        if args.get("load_from_hf", False) and not args.get("ignore_load_lr_and_optim", False):
-                            args["ignore_load_lr_and_optim"] = True
-                            logger.warning(
-                                "load_from_hf is True, will not load lr and optim state dict. "
-                                "Set ignore_load_lr_and_optim=True"
-                            )
                         return user_defined_resume_from_checkpoint
                 else:
                     # pdc_init_step > 0
                     logger.info(f"resume training process by pdc longjob with resume step: {pdc_init_step}")
                     resume_checkpoint = os.path.join(args.get("output_dir", None), f"checkpoint-{pdc_init_step}")
                     # resuming from output_dir/checkpoint-N, which is always saved in paddle format
-                    if args.get("load_from_hf", False):
+                    if os.getenv("NORMAL_RESUME", "").lower() == "true":
                         args["load_from_hf"] = False
-                        logger.warning(f"resume from {resume_checkpoint} by pdc longjob, set load_from_hf=False")
+                        args["ignore_load_lr_and_optim"] = False
+                        logger.warning(
+                            "NORMAL_RESUME is set, force load_from_hf=False & ignore_load_lr_and_optim=False"
+                        )
                     if user_defined_resume_from_checkpoint is not None:
                         logger.warning(
                             f"pdc_init_step:{pdc_init_step} and resume_ckpt:{user_defined_resume_from_checkpoint} exist together, use resume_checkpoint:{resume_checkpoint}"


### PR DESCRIPTION
### PR types
Others 

### PR changes
Others

### Description
当前容错重启的时候需要手动修改yaml
开始训练需要设置
```
load_from_hf: True
ignore_load_lr_and_optim: True
```
开启容错续训的时候又需要：
```
load_from_hf: False
ignore_load_lr_and_optim: False
```

为了降低使用成本做此修改。ignore_load_lr_and_optim 这个开关用户根据实际续训需要设置为True或False，load_from_hf在续训的时候会自动设为False避免报错