### PR TITLE
Do not offload tensors with a shape of 0/1.

### DIFF
--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -1375,6 +1375,8 @@ class Trainer:
             if self.args.tensorwise_offload_optimizer:
                 logger.info("Offloading optimizer state for FC...")
                 for k, v in optimizer_sharded_state_dict.items():
+                    if v.local_tensor.numel() <= 1:
+                        continue
                     offload(v.local_tensor)
                 del opt_states, master_weights, optimizer_sharded_state_dict
 


### PR DESCRIPTION
### PR types
Bug fixes 

### PR changes
APIs 

### Description

tensorwise_offload_optimize 断点续训报错
<img width="3656" height="1520" alt="cfba2c225715e572a7f05c3df7d8e95d" src="https://github.com/user-attachments/assets/5fc3c673-7cf4-498b-8d14-1520781e5ddd" />

怀疑_share_data_with 对极小的 scalar tensor无法正常使用
Merged in dev: #4895 