### PR TITLE
[Deps] Update PaddleFleet to cc7ea038f82

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,7 @@ try:
         install_requires=REQUIRED_PACKAGES,
         entry_points={"console_scripts": get_console_scripts()},
         extras_require={
-            "paddlefleet": ["paddlefleet==0.4.0.post20260814+66a8168b7b3"],
+            "paddlefleet": ["paddlefleet==0.4.0.post20260821+cc7ea038f82"],
         },
         python_requires=">=3.8",
         classifiers=[


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description

Update the optional PaddleFleet dependency on `develop` from `paddlefleet==0.4.0.post20260814+66a8168b7b3` to `paddlefleet==0.4.0.post20260821+cc7ea038f82`.

The new wheel was built from PaddleFleet [`release/0.4` commit `cc7ea038f82a734dc92c32517b974856f29df9cd`](https://github.com/PaddlePaddle/PaddleFleet/commit/cc7ea038f82a734dc92c32517b974856f29df9cd), the current real-time release branch head.

The matching official CUDA 12.9 nightly wheel is [`paddlefleet-0.4.0.post20260821+cc7ea038f82-py3-none-any.whl`](https://paddle-whl.bj.bcebos.com/nightly/cu129/paddlefleet/paddlefleet-0.4.0.post20260821%2Bcc7ea038f82-py3-none-any.whl), with SHA-256 `daf40019f214667ad9e3c4b10c177997a27b3747476aaaf7f63b2b064fc18e53`. Its `METADATA` reports version `0.4.0.post20260821+cc7ea038f82` and the generated `_version.py` records the full Fleet commit. The exact wheel is available on the official `cu126`, `cu129`, `cu130`, and `cu132` nightly indexes.

No source compatibility adjustment is needed; this keeps the existing `setup.py` `extras_require.paddlefleet` single-line convention.

### Validation

- Confirmed PaddleFleet `release/0.4` resolves to `cc7ea038f82a734dc92c32517b974856f29df9cd` via live remote refs and GitHub API.
- Confirmed the official CUDA 12.9 wheel HTTP 200, metadata version, embedded full commit, SHA-256, and availability on all four nightly indexes.
- `python3 -m py_compile setup.py scripts/ci_utils/get_fleet_commit.py`
- `python3 scripts/ci_utils/get_fleet_commit.py` -> `cc7ea038f82`
- Exact one-file/one-line delta review and `git diff --check` pass.
