### PR TITLE
[release/1.3][Deps] Update PaddleFleet to 4ba2429256b

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,7 @@ try:
         install_requires=REQUIRED_PACKAGES,
         entry_points={"console_scripts": get_console_scripts()},
         extras_require={
-            "paddlefleet": ["paddlefleet==0.4.0.post20260814+66a8168b7b3"],
+            "paddlefleet": ["paddlefleet==0.4.0.post20260821+4ba2429256b"],
         },
         python_requires=">=3.8",
         classifiers=[


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description

Update the optional PaddleFleet dependency on `release/1.3` from `paddlefleet==0.4.0.post20260814+66a8168b7b3` to `paddlefleet==0.4.0.post20260821+4ba2429256b`.

The paired develop update is [#4906](https://github.com/PaddlePaddle/PaddleFormers/pull/4906); this PR is independently based on the latest `release/1.3` branch.

The new nightly wheel was built from PaddleFleet [`release/0.4` commit `4ba2429256beb01c47022610a6bbf050f6738948`](https://github.com/PaddlePaddle/PaddleFleet/commit/4ba2429256beb01c47022610a6bbf050f6738948).

The matching [official CUDA 12.9 index wheel](https://paddle-whl.bj.bcebos.com/nightly/cu129/paddlefleet/paddlefleet-0.4.0.post20260821+4ba2429256b-py3-none-any.whl) has SHA-256 `0bcb1c374c2677fa356e4b58f3f5019c4cd07edaaf01670e3580df0809b5fefd`. Its `METADATA` reports version `0.4.0.post20260821+4ba2429256b`, and generated `_version.py` records the full Fleet commit.

### Validation

- Confirmed PaddleFleet `release/0.4` resolves to `4ba2429256beb01c47022610a6bbf050f6738948` via Git and GitHub API.
- Downloaded and installed the exact wheel from the official CUDA 12.9 nightly index with `--no-deps`; verified its metadata and embedded full commit.
- `pre-commit run --files setup.py`
- `python -m py_compile setup.py`
- `python scripts/ci_utils/get_fleet_commit.py` -> `4ba2429256b`
- AST requirement parsing and `git diff --check` pass.
