### PR TITLE
Fix AutoConfig import without optional PaddleFleet ops

### DIFF
--- a/paddleformers/transformers/auto/configuration.py
+++ b/paddleformers/transformers/auto/configuration.py
@@ -25,7 +25,6 @@ from ...utils.download import resolve_file_path
 from ...utils.import_utils import import_module
 from ...utils.log import logger
 from ..configuration_utils import PretrainedConfig
-from ..model_utils import PretrainedModel
 
 __all__ = [
     "AutoConfig",
@@ -332,6 +331,8 @@ class AutoConfig(PretrainedConfig):
                 if config_class is not PretrainedConfig:
                     model_config_class = config_class
                     return model_config_class
+
+        from ..model_utils import PretrainedModel
 
         assert inspect.isclass(model_class) and issubclass(
             model_class, PretrainedModel

--- a/tests/transformers/auto/test_configuration.py
+++ b/tests/transformers/auto/test_configuration.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import json
 import os
 import random
+import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -30,6 +32,24 @@ from ...utils.test_module.custom_configuration import CustomConfig
 
 
 class AutoConfigTest(unittest.TestCase):
+    def test_import_does_not_eagerly_load_model_utils(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import sys; "
+                    "from paddleformers.transformers import AutoConfig; "
+                    "assert AutoConfig.__name__ == 'AutoConfig'; "
+                    "assert 'paddleformers.transformers.model_utils' not in sys.modules"
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
     def test_built_in_model_class_config(self):
         config = AutoConfig.from_pretrained("PaddleFormers/tiny-random-qwen3", download_hub="aistudio")
         number = random.randint(0, 10000)


### PR DESCRIPTION
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.
- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types

Bug fixes

### PR changes

APIs

### Description

Fixes #4778.

Importing `AutoConfig` currently imports `PretrainedModel` at module load time. That pulls in `model_utils`, then the quantization stack. When the PaddleFleet package is installed but its separately distributed `paddlefleet_ops` package is unavailable, the indirect import chain fails before a configuration object can be used:

```text
AutoConfig -> model_utils -> quantization_utils
           -> paddlefleet.parallel_state -> paddlefleet.context_parallel_utils
           -> paddlefleet_ops
```

A configuration-only API should not require model implementations or optional CUDA operators. This change moves the `PretrainedModel` import into `_get_config_class_from_config`, immediately before the legacy custom-model `issubclass` check that actually needs it. Standard `AutoConfig` imports and `model_type`-based configuration loading therefore stay independent of the model/quantization stack, while the legacy validation path keeps the same behavior.

The regression test starts a clean Python subprocess and verifies that importing `AutoConfig` does not load `paddleformers.transformers.model_utils`.

Validation:

- PaddleFormers pre-commit hooks matching the changed Python files: Black, isort, flake8, copyright checker, merge-conflict check, and private-key detection passed
- `python -m compileall -q paddleformers/transformers/auto/configuration.py tests/transformers/auto/test_configuration.py`
- structural regression verifies there is no module-level `model_utils` import and exactly one function-local import in the legacy path
- `git diff --check`