### PR TITLE
[release/1.3][Deps] Update PaddleFleet to 4543a00b5ab

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,7 @@ try:
         install_requires=REQUIRED_PACKAGES,
         entry_points={"console_scripts": get_console_scripts()},
         extras_require={
-            "paddlefleet": ["paddlefleet==0.4.0.post20260821+4ba2429256b"],
+            "paddlefleet": ["paddlefleet==0.4.0.post20260824+4543a00b5ab"],
         },
         python_requires=">=3.8",
         classifiers=[


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [x] Lint code. `pre-commit run --file setup.py` passed.
- [ ] Add test cases into `tests` folder. This dependency-only change does not add runtime logic.

### PR types

Others

### PR changes

Others

### Description

Update the PaddleFleet extra dependency on `release/1.3` to the exact artifact built from commit `4543a00b5ab745184eb74f003db88027bfaedc1c`.

Target package: `paddlefleet==0.4.0.post20260824+4543a00b5ab`

Develop PR: [#4917](https://github.com/PaddlePaddle/PaddleFormers/pull/4917)

Validation: `pre-commit run --file setup.py` and `git diff --check`.
