### PR TITLE
Add_idefics3_model

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,15 @@ PaddleFormers 是基于百度深度学习框架 PaddlePaddle 搭建的 Transform
     </tr>
     <!-- VLM 分类 - 跨行合并开始 -->
     <tr>
-      <td rowspan="4" style="vertical-align: top;">VLM</td>
+      <td rowspan="5" style="vertical-align: top;">VLM</td>
       <td>🏛️ERNIE-4.5-VL</td>
       <td>baidu/ERNIE-4.5-VL-28B-A3B-Base-PT、baidu/ERNIE-4.5-VL-28B-A3B-PT、baidu/ERNIE-4.5-VL-424B-A47B-Base-PT、baidu/ERNIE-4.5-VL-424B-A47B-PT、baidu/ERNIE-4.5-VL-28B-A3B-Thinking</td>
       <td>ernie_vl、ernie_vl_nothink</td>
+    </tr>
+    <tr>
+      <td>Idefics3</td>
+      <td>HuggingFaceM4/Idefics3-8B-Llama3</td>
+      <td>idefics3</td>
     </tr>
     <tr>
       <td>🏛️PaddleOCR-VL</td>

--- a/docs/zh/model_capability.md
+++ b/docs/zh/model_capability.md
@@ -14,6 +14,7 @@
 |Qwen3|✓|✓|✓|✓|✓|
 |Qwen3-Next|✓|✓|✓|✓|✓|
 |🏛️ERNIE-4.5-VL|x|✓|✓|x|x|
+|Idefics3|x|✓|✓|x|x|
 |🏛️PaddleOCR-VL|x|✓|✓|x|x|
 |Qwen2.5-VL|x|✓|✓|x|x|
 |Qwen3-VL|x|✓|✓|x|x|
@@ -34,6 +35,7 @@
 |Qwen3|✓|✓|✓|✓|✓|✓|
 |Qwen3-Next|✓|✓|✓|x|✓|✓|
 |🏛️ERNIE-4.5-VL|✓|✓|✓|x|✓|✓|
+|Idefics3|x|x|-|x|✓|✓|
 |🏛️PaddleOCR-VL|x|x|-|x|✓|✓|
 |Qwen2.5-VL|✓|x|-|x|✓|✓|
 |Qwen3-VL|x|x|✓|x|✓|✓|

--- a/paddleformers/cli/utils/llm_utils.py
+++ b/paddleformers/cli/utils/llm_utils.py
@@ -387,6 +387,26 @@ def get_lora_target_modules(model):
             ".*resampler_model.*temporal_linear.0.*",
             ".*resampler_model.*temporal_linear.2.*",
         ]
+    elif model.config.model_type == "idefics3":
+        target_modules = [
+            # Language Model
+            "model.text_model.*q_proj.*",
+            "model.text_model.*k_proj.*",
+            "model.text_model.*v_proj.*",
+            "model.text_model.*o_proj.*",
+            "model.text_model.*gate_proj.*",
+            "model.text_model.*up_proj.*",
+            "model.text_model.*down_proj.*",
+            # Vision Encoder
+            "model.vision_model.*q_proj.*",
+            "model.vision_model.*k_proj.*",
+            "model.vision_model.*v_proj.*",
+            "model.vision_model.*out_proj.*",
+            "model.vision_model.*fc1.*",
+            "model.vision_model.*fc2.*",
+            # Projector
+            "model.connector.*proj.*",
+        ]
     elif model.config.model_type == "paddleocr_vl":
         target_modules = [
             # Language Model

--- a/paddleformers/cli/utils/mllm_utils.py
+++ b/paddleformers/cli/utils/mllm_utils.py
@@ -32,6 +32,7 @@ class MLLMModelMapping:
     paddleocr_vl = "paddleocr_vl"
     ernie4_5_moe_vl = "ernie4_5_moe_vl"
     glm4v_moe = "glm4v_moe"
+    idefics3 = "idefics3"
 
 
 @dataclass
@@ -256,5 +257,14 @@ register_multimodel_keys(
         aligner="model.visual.merger",
         llm=["model.language_model", "lm_head"],
         vision="model.visual",
+    )
+)
+
+register_multimodel_keys(
+    MultiModelKeys(
+        model_dtype=MLLMModelMapping.idefics3,
+        aligner="model.connector",
+        llm=["model.text_model", "lm_head"],
+        vision="model.vision_model",
     )
 )

--- a/paddleformers/datasets/template/mm_plugin.py
+++ b/paddleformers/datasets/template/mm_plugin.py
@@ -393,6 +393,91 @@ class BasePlugin(MMPluginMixin):
 
 
 @dataclass
+class Idefics3Plugin(BasePlugin):
+    fake_image_token: str = "<fake_token_around_image>"
+    global_image_token: str = "<global-img>"
+
+    # Idefics3 uses a unique placeholder internally because its model image_token
+    # ("<image>") collides with the dataset IMAGE_PLACEHOLDER ("<image>").
+    _IDEFICS3_IMG_PLACEHOLDER: str = "<idefics3_image>"
+
+    @override
+    def process_messages(
+        self,
+        messages,
+        images,
+        videos,
+        audios,
+        mm_inputs,
+        processor,
+    ):
+        self._validate_input(processor, images, videos, audios)
+        num_image_tokens = 0
+        messages = deepcopy(messages)
+        image_seq_len = getattr(processor, "image_seq_len", 169)
+
+        # Pre-compute per-image tile counts
+        image_processor = getattr(processor, "image_processor", None)
+        do_split = getattr(image_processor, "do_image_splitting", True)
+        per_image_tiles = []
+        if self.expand_mm_tokens and do_split:
+            for img in images:
+                h, w = self._get_image_size(img)
+                _, rows, cols = image_processor.get_number_of_image_patches(h, w, {})
+                per_image_tiles.append(rows * cols + 1 if rows > 0 else 1)
+        else:
+            per_image_tiles = [1] * len(images)
+
+        for message in messages:
+            content = message.get("content", "")
+            if not isinstance(content, str) or IMAGE_PLACEHOLDER not in content:
+                continue
+
+            # Step 1: <image> → safe temp placeholder (IMAGE_PLACEHOLDER == self.image_token)
+            for tiles in per_image_tiles:
+                content = content.replace(IMAGE_PLACEHOLDER, self._IDEFICS3_IMG_PLACEHOLDER, 1)
+
+            # Step 2: while loop over temp placeholder, standard pattern
+            while self._IDEFICS3_IMG_PLACEHOLDER in content:
+                tiles = per_image_tiles[num_image_tokens]
+                image_seqlen = tiles * image_seq_len if self.expand_mm_tokens else 1
+                content = content.replace(
+                    self._IDEFICS3_IMG_PLACEHOLDER,
+                    self.image_token * image_seqlen,
+                    1,
+                )
+                num_image_tokens += 1
+
+            message["content"] = content
+
+        self.masked_tokens = [
+            self.image_token,
+            self.fake_image_token,
+            self.global_image_token,
+            *[f"<row_{row}_col_{col}>" for row in range(1, 7) for col in range(1, 7)],
+        ]
+        return messages
+
+    @staticmethod
+    def _get_image_size(img):
+        """Get (height, width) from various image representations."""
+        if isinstance(img, str):
+            try:
+                from PIL import Image as PILImage
+
+                with PILImage.open(img) as pil:
+                    return pil.height, pil.width
+            except Exception:
+                return 364, 364
+        if hasattr(img, "size"):
+            w, h = img.size
+            return h, w
+        if hasattr(img, "height") and hasattr(img, "width"):
+            return img.height, img.width
+        return 364, 364
+
+
+@dataclass
 class PaddleOCRVLPlugin(BasePlugin):
     image_bos_token: str = "<|IMAGE_START|>"
     image_eos_token: str = "<|IMAGE_END|>"
@@ -1602,6 +1687,7 @@ class KimiK3Plugin(BasePlugin):
 
 PLUGINS = {
     "base": BasePlugin,
+    "idefics3": Idefics3Plugin,
     "ernie_vl": ErnieVLPlugin,
     "qwen2_vl": Qwen2VLPlugin,
     "paddleocr_vl": PaddleOCRVLPlugin,

--- a/paddleformers/datasets/template/template.py
+++ b/paddleformers/datasets/template/template.py
@@ -956,6 +956,42 @@ register_template(
 )
 
 
+# Idefics3: matches vLLM tokenizer_config.json chat_template exactly.
+# Key differences from llama3 template:
+#   1. suffix=["<|eot_id|>"] 鈥?model learns to output it (vLLM behavior), appended via SFTDataset
+#   2. chat_sep="<|eot_id|>" — matches Swift chat_sep, added between turns
+#   3. mm_plugin=idefics3 鈥?Idefics3Plugin masks visual structure tokens in loss
+# Image token expansion (<row_X_col_Y>, <global-img>, etc.) is handled by Idefics3Processor
+# internally (replace_image_token).
+register_template(
+    name="idefics3",
+    format_user=StringFormatter(
+        slots=[
+            (
+                "<|start_header_id|>user<|end_header_id|>\n\n{{content}}<|eot_id|>"
+                "<|start_header_id|>assistant<|end_header_id|>\n\n"
+            )
+        ]
+    ),
+    format_assistant=StringFormatter(slots=["{{content}}"]),
+    format_system=StringFormatter(slots=["<|start_header_id|>system<|end_header_id|>\n\n{{content}}<|eot_id|>"]),
+    format_function=FunctionFormatter(slots=["{{content}}<|eot_id|>"], tool_format="llama3"),
+    format_observation=StringFormatter(
+        slots=[
+            (
+                "<|start_header_id|>tool<|end_header_id|>\n\n{{content}}<|eot_id|>"
+                "<|start_header_id|>assistant<|end_header_id|>\n\n"
+            )
+        ]
+    ),
+    format_tools=ToolFormatter(tool_format="llama3"),
+    format_prefix=EmptyFormatter(slots=[{"bos_token"}]),
+    suffix=["<|eot_id|>"],
+    chat_sep="<|eot_id|>",
+    mm_plugin=get_mm_plugin(name="idefics3", image_token="<image>"),
+)
+
+
 # copied from gemma template
 register_template(
     name="gemma",

--- a/paddleformers/transformers/__init__.py
+++ b/paddleformers/transformers/__init__.py
@@ -421,6 +421,16 @@ import_structure = {
     ],
     "glm_ocr.processor": ["Glm46VProcessor"],
     "glm_ocr.image_processor": ["Glm46VImageProcessor"],
+    "idefics3.configuration": ["Idefics3Config", "Idefics3VisionConfig"],
+    "idefics3.modeling": [
+        "Idefics3ForConditionalGeneration",
+        "Idefics3Model",
+        "Idefics3PreTrainedModel",
+        "Idefics3VisionTransformer",
+    ],
+    "idefics3.processor": ["Idefics3Processor"],
+    "idefics3.image_processor": ["Idefics3ImageProcessor"],
+    "idefics3": [],
     "olmo2.configuration": ["Olmo2Config"],
     "olmo2.modeling": ["Olmo2DecoderLayer", "Olmo2Model", "Olmo2ForCausalLM", "Olmo2ForCausalLMPipe"],
     "olmo2": [],
@@ -551,6 +561,7 @@ if TYPE_CHECKING:
     from .intern_lm2 import InternLM2Tokenizer
     from .gemma4_moe import *
     from .phi4 import *
+    from .idefics3 import *
 else:
     sys.modules[__name__] = _LazyModule(
         __name__,

--- a/paddleformers/transformers/auto/configuration.py
+++ b/paddleformers/transformers/auto/configuration.py
@@ -71,6 +71,8 @@ CONFIG_MAPPING_NAMES = OrderedDict(
         ("shieldgemma2", "ShieldGemma2Config"),
         ("glm4v_moe", "Glm4vMoeConfig"),
         ("glm_ocr", "GlmOcrConfig"),
+        ("idefics3", "Idefics3Config"),
+        ("idefics3_vision", "Idefics3VisionConfig"),
         ("qwen3_5", "Qwen3_5Config"),
         ("qwen3_5_moe", "Qwen3_5MoEConfig"),
         ("olmo2", "Olmo2Config"),
@@ -117,6 +119,7 @@ MODEL_NAMES_MAPPING = OrderedDict(
         ("gemma3", "Gemma3ForConditionalGeneration"),
         ("gemma3_text", "Gemma3TextModel"),
         ("shieldgemma2", "ShieldGemma2ForImageClassification"),
+        ("idefics3", "Idefics3ForConditionalGeneration"),
         ("qwen3_5_moe", "Qwen3_5MoEForConditionalGeneration"),
         ("qwen3_5", "Qwen3_5ForConditionalGeneration"),
         ("minicpm3", "MiniCPM3Model"),
@@ -149,6 +152,7 @@ SPECIAL_MODEL_TYPE_TO_MODULE_NAME = OrderedDict(
         ("gemma4_text", "gemma4_moe"),
         ("gemma4", "gemma4_moe"),
         ("phi4flash", "phi4"),
+        ("idefics3_vision", "idefics3"),
     ]
 )
 

--- a/paddleformers/transformers/auto/image_processing.py
+++ b/paddleformers/transformers/auto/image_processing.py
@@ -62,6 +62,7 @@ IMAGE_PROCESSOR_MAPPING_NAMES.update(
         "qwen3_vl": ("Qwen3VLImageProcessor", "Qwen3VLImageProcessorFast"),
         "glm_ocr": ("Glm46VImageProcessor"),
         "paligemma": ("PaliGemmaImageProcessor"),
+        "idefics3": ("Idefics3ImageProcessor"),
     }
 )
 

--- a/paddleformers/transformers/auto/modeling.py
+++ b/paddleformers/transformers/auto/modeling.py
@@ -94,6 +94,7 @@ MAPPING_NAMES = OrderedDict(
         ("Olmo2", "olmo2"),
         ("InternLM3", "intern_lm3"),
         ("InternLM2", "intern"),
+        ("Idefics3", "idefics3"),
     ]
 )
 

--- a/paddleformers/transformers/auto/processing.py
+++ b/paddleformers/transformers/auto/processing.py
@@ -61,6 +61,7 @@ PROCESSOR_MAPPING_NAMES = OrderedDict(
         ("glm4v_moe", "Glm4vProcessor"),
         ("glm_ocr", "Glm46VProcessor"),
         ("paligemma2", "PaliGemmaProcessor"),
+        ("idefics3", "Idefics3Processor"),
     ]
 )
 

--- a/paddleformers/transformers/idefics3/__init__.py
+++ b/paddleformers/transformers/idefics3/__init__.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 
 from ...utils.lazy_import import _LazyModule
 
-
 import_structure = {
     "configuration": ["Idefics3Config", "Idefics3VisionConfig"],
     "image_processor": ["Idefics3ImageProcessor"],

--- a/paddleformers/transformers/idefics3/__init__.py
+++ b/paddleformers/transformers/idefics3/__init__.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+
+import sys
+from typing import TYPE_CHECKING
+
+from ...utils.lazy_import import _LazyModule
+
+
+import_structure = {
+    "configuration": ["Idefics3Config", "Idefics3VisionConfig"],
+    "image_processor": ["Idefics3ImageProcessor"],
+    "processor": ["Idefics3Processor"],
+    "modeling": [
+        "Idefics3ForConditionalGeneration",
+        "Idefics3Model",
+        "Idefics3PreTrainedModel",
+        "Idefics3VisionTransformer",
+    ],
+}
+
+if TYPE_CHECKING:
+    from .configuration import *
+    from .image_processor import *
+    from .modeling import *
+    from .processor import *
+else:
+    sys.modules[__name__] = _LazyModule(
+        __name__,
+        globals()["__file__"],
+        import_structure,
+        module_spec=__spec__,
+    )

--- a/paddleformers/transformers/idefics3/configuration.py
+++ b/paddleformers/transformers/idefics3/configuration.py
@@ -70,9 +70,7 @@ class Idefics3Config(PretrainedConfig):
             text_config["model_type"] = text_config.get("model_type", "llama")
             self.text_config = CONFIG_MAPPING[text_config["model_type"]](**text_config)
         elif text_config is None:
-            self.text_config = CONFIG_MAPPING["llama"](
-                vocab_size=128258, rms_norm_eps=1e-5, pad_token_id=pad_token_id
-            )
+            self.text_config = CONFIG_MAPPING["llama"](vocab_size=128258, rms_norm_eps=1e-5, pad_token_id=pad_token_id)
         else:
             self.text_config = text_config
 

--- a/paddleformers/transformers/idefics3/configuration.py
+++ b/paddleformers/transformers/idefics3/configuration.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+"""Idefics3 model configuration."""
+
+from ..auto.configuration import CONFIG_MAPPING
+from ..configuration_utils import PretrainedConfig
+
+
+class Idefics3VisionConfig(PretrainedConfig):
+    model_type = "idefics3_vision"
+    base_config_key = "vision_config"
+
+    def __init__(
+        self,
+        hidden_size=1152,
+        intermediate_size=3072,
+        num_hidden_layers=12,
+        num_attention_heads=16,
+        num_channels=3,
+        image_size=224,
+        patch_size=32,
+        hidden_act="gelu_pytorch_tanh",
+        layer_norm_eps=1e-6,
+        attention_dropout=0.0,
+        initializer_range=0.02,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_channels = num_channels
+        self.image_size = image_size
+        self.patch_size = patch_size
+        self.hidden_act = hidden_act
+        self.layer_norm_eps = layer_norm_eps
+        self.attention_dropout = attention_dropout
+        self.initializer_range = initializer_range
+
+
+class Idefics3Config(PretrainedConfig):
+    model_type = "idefics3"
+    sub_configs = {"vision_config": Idefics3VisionConfig, "text_config": CONFIG_MAPPING}
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        text_config=None,
+        vision_config=None,
+        use_cache=True,
+        image_token_id=128257,
+        tie_word_embeddings=False,
+        scale_factor=2,
+        pad_token_id=128002,
+        **kwargs,
+    ):
+        super().__init__(pad_token_id=pad_token_id, tie_word_embeddings=tie_word_embeddings, **kwargs)
+
+        if isinstance(vision_config, dict):
+            self.vision_config = Idefics3VisionConfig(**vision_config)
+        elif vision_config is None:
+            self.vision_config = Idefics3VisionConfig()
+        else:
+            self.vision_config = vision_config
+
+        if isinstance(text_config, dict):
+            text_config = text_config.copy()
+            text_config["model_type"] = text_config.get("model_type", "llama")
+            self.text_config = CONFIG_MAPPING[text_config["model_type"]](**text_config)
+        elif text_config is None:
+            self.text_config = CONFIG_MAPPING["llama"](
+                vocab_size=128258, rms_norm_eps=1e-5, pad_token_id=pad_token_id
+            )
+        else:
+            self.text_config = text_config
+
+        self.use_cache = use_cache
+        self.image_token_id = image_token_id
+        self.scale_factor = scale_factor
+        if "_attn_implementation" in kwargs:
+            self.vision_config._attn_implementation = kwargs["_attn_implementation"]
+            self.text_config._attn_implementation = kwargs["_attn_implementation"]
+
+    def __setattr__(self, key, value):
+        if (
+            (text_config := super().__getattribute__("__dict__").get("text_config")) is not None
+            and key not in ["_name_or_path", "model_type", "dtype", "_attn_implementation_internal"]
+            and key in text_config.__dict__
+        ):
+            setattr(text_config, key, value)
+        else:
+            super().__setattr__(key, value)
+
+    def __getattribute__(self, key):
+        if "text_config" in super().__getattribute__("__dict__") and key not in [
+            "_name_or_path",
+            "model_type",
+            "dtype",
+            "_attn_implementation_internal",
+        ]:
+            text_config = super().__getattribute__("text_config")
+            if key in text_config.__dict__:
+                # Check self first: attributes explicitly set on Idefics3Config
+                # (e.g. tie_word_embeddings) take priority over text_config defaults.
+                self_dict = super().__getattribute__("__dict__")
+                if key in self_dict:
+                    return self_dict[key]
+                return getattr(text_config, key)
+        return super().__getattribute__(key)
+
+
+__all__ = ["Idefics3Config", "Idefics3VisionConfig"]

--- a/paddleformers/transformers/idefics3/image_processor.py
+++ b/paddleformers/transformers/idefics3/image_processor.py
@@ -1,0 +1,259 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+"""Paddle Idefics3 image processor."""
+
+from __future__ import annotations
+
+import math
+from io import BytesIO
+from urllib.request import urlopen
+
+import numpy as np
+from PIL import Image, ImageOps
+
+from ..feature_extraction_utils import BatchFeature
+from ..image_processing_utils import BaseImageProcessor
+
+IMAGENET_STANDARD_MEAN = [0.485, 0.456, 0.406]
+IMAGENET_STANDARD_STD = [0.229, 0.224, 0.225]
+MAX_IMAGE_SIZE = 1456
+
+
+def _to_pil(image) -> Image.Image:
+    if isinstance(image, str):
+        with urlopen(image) as response:
+            image = Image.open(BytesIO(response.read()))
+    if isinstance(image, Image.Image):
+        return ImageOps.exif_transpose(image).convert("RGB")
+    if hasattr(image, "numpy"):
+        image = image.numpy()
+    array = np.asarray(image)
+    if array.ndim == 3 and array.shape[0] == 3 and array.shape[-1] != 3:
+        array = array.transpose(1, 2, 0)
+    if array.ndim != 3 or array.shape[-1] != 3:
+        raise ValueError("Idefics3ImageProcessor expects RGB images with shape [H, W, 3].")
+    if array.dtype != np.uint8:
+        if array.max() <= 1.0:
+            array = array * 255
+        array = array.astype(np.uint8)
+    return Image.fromarray(array).convert("RGB")
+
+
+def _make_nested_images(images):
+    if images is None:
+        return None
+    if isinstance(images, (str, Image.Image)) or not isinstance(images, (list, tuple)):
+        return [[images]]
+    if len(images) == 0:
+        return [[]]
+    if isinstance(images[0], (list, tuple)):
+        return [list(sample) for sample in images]
+    return [list(images)]
+
+
+def _longest_edge(size):
+    if isinstance(size, dict):
+        return size.get("longest_edge") or max(size.get("height"), size.get("width"))
+    return size
+
+
+def _resize_to_longest_edge(image: Image.Image, longest_edge: int, resample) -> Image.Image:
+    width, height = image.size
+    if max(width, height) == longest_edge:
+        return image
+    scale = longest_edge / max(width, height)
+    new_width = max(1, int(round(width * scale)))
+    new_height = max(1, int(round(height * scale)))
+    return image.resize((new_width, new_height), resample=resample)
+
+
+def _resize_to_multiple_for_vision(image: Image.Image, max_size: int, resample) -> Image.Image:
+    width, height = image.size
+    aspect_ratio = width / height
+    if width >= height:
+        new_width = math.ceil(width / max_size) * max_size
+        new_height = int(new_width / aspect_ratio)
+        new_height = math.ceil(new_height / max_size) * max_size
+    else:
+        new_height = math.ceil(height / max_size) * max_size
+        new_width = int(new_height * aspect_ratio)
+        new_width = math.ceil(new_width / max_size) * max_size
+    return image.resize((new_width, new_height), resample=resample)
+
+
+def _normalize(image: Image.Image, image_mean, image_std, do_rescale, do_normalize):
+    array = np.asarray(image).astype("float32")
+    if do_rescale:
+        array = array / 255.0
+    if do_normalize:
+        array = (array - np.asarray(image_mean, dtype="float32")) / np.asarray(image_std, dtype="float32")
+    return array.transpose(2, 0, 1)
+
+
+def _resize_output_size_rescale_to_max_len(height, width, max_len):
+    scale = max_len / max(height, width)
+    return int(round(height * scale)), int(round(width * scale))
+
+
+def _resize_output_size_scale_below_upper_bound(height, width, max_len):
+    if max(height, width) <= max_len:
+        return height, width
+    scale = max_len / max(height, width)
+    return int(round(height * scale)), int(round(width * scale))
+
+
+class Idefics3ImageProcessor(BaseImageProcessor):
+    model_input_names = ["pixel_values", "pixel_attention_mask"]
+
+    def __init__(
+        self,
+        size=None,
+        max_image_size=None,
+        image_mean=None,
+        image_std=None,
+        do_resize=True,
+        do_rescale=True,
+        do_normalize=True,
+        do_convert_rgb=True,
+        do_image_splitting=True,
+        do_pad=True,
+        return_row_col_info=False,
+        resample=None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.size = size or {"longest_edge": 4 * 364}
+        self.max_image_size = max_image_size or {"longest_edge": 364}
+        self.image_mean = image_mean or IMAGENET_STANDARD_MEAN
+        self.image_std = image_std or IMAGENET_STANDARD_STD
+        self.do_resize = do_resize
+        self.do_rescale = do_rescale
+        self.do_normalize = do_normalize
+        self.do_convert_rgb = do_convert_rgb
+        self.do_image_splitting = do_image_splitting
+        self.do_pad = do_pad
+        self.return_row_col_info = return_row_col_info
+        self.resample = resample or Image.Resampling.LANCZOS
+
+    def fetch_images(self, images):
+        if isinstance(images, str):
+            return _to_pil(images)
+        if isinstance(images, (list, tuple)):
+            return [self.fetch_images(image) for image in images]
+        return images
+
+    def split_image(self, image: Image.Image, max_image_size: dict, resample):
+        max_size = _longest_edge(max_image_size)
+        width, height = image.size
+        if height > max_size or width > max_size:
+            rows = math.ceil(height / max_size)
+            cols = math.ceil(width / max_size)
+            padded = Image.new("RGB", (cols * max_size, rows * max_size))
+            padded.paste(image, (0, 0))
+            frames = []
+            for row in range(rows):
+                for col in range(cols):
+                    left = col * max_size
+                    top = row * max_size
+                    frames.append(padded.crop((left, top, left + max_size, top + max_size)))
+            frames.append(image.resize((max_size, max_size), resample=resample))
+            return frames, rows, cols
+        return [image], 0, 0
+
+    def preprocess(self, images, return_tensors=None, **kwargs):
+        if images is None:
+            return BatchFeature(data={}, tensor_type=return_tensors)
+
+        nested_images = _make_nested_images(self.fetch_images(images))
+        do_resize = kwargs.get("do_resize", self.do_resize)
+        do_rescale = kwargs.get("do_rescale", self.do_rescale)
+        do_normalize = kwargs.get("do_normalize", self.do_normalize)
+        do_image_splitting = kwargs.get("do_image_splitting", self.do_image_splitting)
+        do_pad = kwargs.get("do_pad", self.do_pad)
+        return_row_col_info = kwargs.get("return_row_col_info", self.return_row_col_info)
+        size = kwargs.get("size", self.size)
+        max_image_size = kwargs.get("max_image_size", self.max_image_size)
+        image_mean = kwargs.get("image_mean", self.image_mean)
+        image_std = kwargs.get("image_std", self.image_std)
+        resample = kwargs.get("resample", self.resample)
+
+        processed_samples = []
+        rows, cols = [], []
+        for sample in nested_images:
+            sample_images = []
+            sample_rows, sample_cols = [], []
+            for image in sample:
+                image = _to_pil(image)
+                if do_resize:
+                    image = _resize_to_longest_edge(image, _longest_edge(size), resample)
+                if do_image_splitting:
+                    image = _resize_to_multiple_for_vision(image, _longest_edge(max_image_size), resample)
+                    frames, image_rows, image_cols = self.split_image(image, max_image_size, resample)
+                else:
+                    side = _longest_edge(max_image_size)
+                    frames, image_rows, image_cols = [image.resize((side, side), resample=resample)], 0, 0
+                sample_images.extend(
+                    _normalize(frame, image_mean, image_std, do_rescale, do_normalize) for frame in frames
+                )
+                sample_rows.append(image_rows)
+                sample_cols.append(image_cols)
+            processed_samples.append(sample_images)
+            rows.append(sample_rows)
+            cols.append(sample_cols)
+
+        if do_pad:
+            max_num_images = max(max(len(sample), 1) for sample in processed_samples)
+            max_height = max((image.shape[-2] for sample in processed_samples for image in sample), default=1)
+            max_width = max((image.shape[-1] for sample in processed_samples for image in sample), default=1)
+            pixel_values = np.zeros((len(processed_samples), max_num_images, 3, max_height, max_width), dtype="float32")
+            pixel_attention_mask = np.zeros((len(processed_samples), max_num_images, max_height, max_width), dtype="int64")
+            for sample_idx, sample in enumerate(processed_samples):
+                for image_idx, image in enumerate(sample):
+                    _, height, width = image.shape
+                    pixel_values[sample_idx, image_idx, :, :height, :width] = image
+                    pixel_attention_mask[sample_idx, image_idx, :height, :width] = 1
+            data = {"pixel_values": pixel_values, "pixel_attention_mask": pixel_attention_mask}
+        else:
+            data = {"pixel_values": processed_samples}
+
+        if return_row_col_info:
+            data["rows"] = rows
+            data["cols"] = cols
+        return BatchFeature(data=data, tensor_type=return_tensors)
+
+    def __call__(self, images, return_tensors=None, **kwargs):
+        return self.preprocess(images, return_tensors=return_tensors, **kwargs)
+
+    def to_dict(self):
+        output = super().to_dict()
+        output.pop("_valid_processor_keys", None)
+        output.pop("return_row_col_info", None)
+        return output
+
+    def get_number_of_image_patches(self, height: int, width: int, images_kwargs: dict):
+        do_image_splitting = images_kwargs.get("do_image_splitting", self.do_image_splitting)
+        max_image_size = images_kwargs.get("max_image_size", self.max_image_size)
+        size = images_kwargs.get("size", self.size)
+        num_patches = num_rows = num_cols = 0
+        if do_image_splitting:
+            height, width = _resize_output_size_rescale_to_max_len(height, width, max_len=_longest_edge(size))
+            height, width = _resize_output_size_scale_below_upper_bound(height, width, max_len=MAX_IMAGE_SIZE)
+            aspect_ratio = width / height
+            max_size = _longest_edge(max_image_size)
+            if width >= height:
+                resized_width = math.ceil(width / max_size) * max_size
+                resized_height = int(width / aspect_ratio)
+                resized_height = math.ceil(height / max_size) * max_size
+            else:
+                resized_height = math.ceil(height / max_size) * max_size
+                resized_width = int(height * aspect_ratio)
+                resized_width = math.ceil(width / max_size) * max_size
+            if resized_height > max_size or resized_width > max_size:
+                num_rows = math.ceil(resized_height / max_size)
+                num_cols = math.ceil(resized_width / max_size)
+                num_patches = num_rows * num_cols + 1
+        return num_patches, num_rows, num_cols
+
+
+__all__ = ["Idefics3ImageProcessor"]

--- a/paddleformers/transformers/idefics3/image_processor.py
+++ b/paddleformers/transformers/idefics3/image_processor.py
@@ -206,8 +206,12 @@ class Idefics3ImageProcessor(BaseImageProcessor):
             max_num_images = max(max(len(sample), 1) for sample in processed_samples)
             max_height = max((image.shape[-2] for sample in processed_samples for image in sample), default=1)
             max_width = max((image.shape[-1] for sample in processed_samples for image in sample), default=1)
-            pixel_values = np.zeros((len(processed_samples), max_num_images, 3, max_height, max_width), dtype="float32")
-            pixel_attention_mask = np.zeros((len(processed_samples), max_num_images, max_height, max_width), dtype="int64")
+            pixel_values = np.zeros(
+                (len(processed_samples), max_num_images, 3, max_height, max_width), dtype="float32"
+            )
+            pixel_attention_mask = np.zeros(
+                (len(processed_samples), max_num_images, max_height, max_width), dtype="int64"
+            )
             for sample_idx, sample in enumerate(processed_samples):
                 for image_idx, image in enumerate(sample):
                     _, height, width = image.shape

--- a/paddleformers/transformers/idefics3/modeling.py
+++ b/paddleformers/transformers/idefics3/modeling.py
@@ -1,0 +1,641 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+"""Paddle Idefics3 model."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Optional, Tuple, Union
+
+import paddle
+import paddle.nn as nn
+import paddle.nn.functional as F
+
+from ...generation import GenerationMixin
+from ...nn.criterion.interface import CriterionLayer
+from ...nn.lm_head import LMHead as GeneralLMHead
+from ..activations import ACT2FN
+from ..auto.modeling import AutoModel
+from ..llama.modeling import LlamaModel
+from ..model_outputs import (
+    BaseModelOutput,
+    BaseModelOutputWithPast,
+    BaseModelOutputWithPooling,
+    CausalLMOutputWithPast,
+    ModelOutput,
+)
+from ..model_utils import PretrainedModel, register_base_model
+from .configuration import Idefics3Config, Idefics3VisionConfig
+
+@dataclass
+class Idefics3BaseModelOutputWithPast(ModelOutput):
+    last_hidden_state: Optional[paddle.Tensor] = None
+    past_key_values: Optional[Tuple[Tuple[paddle.Tensor]]] = None
+    hidden_states: Optional[Tuple[paddle.Tensor]] = None
+    attentions: Optional[Tuple[paddle.Tensor]] = None
+    image_hidden_states: Optional[paddle.Tensor] = None
+
+
+@dataclass
+class Idefics3CausalLMOutputWithPast(CausalLMOutputWithPast):
+    image_hidden_states: Optional[paddle.Tensor] = None
+
+
+def _bucketize_right(values: paddle.Tensor, boundaries: paddle.Tensor) -> paddle.Tensor:
+    flat_values = values.reshape([-1])
+    bucket_ids = paddle.searchsorted(boundaries, flat_values, right=True)
+    return bucket_ids.reshape(values.shape)
+
+
+class Idefics3VisionEmbeddings(nn.Layer):
+    def __init__(self, config: Idefics3VisionConfig):
+        super().__init__()
+        self.embed_dim = config.hidden_size
+        self.image_size = config.image_size
+        self.patch_size = config.patch_size
+        self.patch_embedding = nn.Conv2D(
+            in_channels=config.num_channels,
+            out_channels=self.embed_dim,
+            kernel_size=self.patch_size,
+            stride=self.patch_size,
+        )
+        self.num_patches_per_side = self.image_size // self.patch_size
+        self.num_positions = self.num_patches_per_side**2
+        self.position_embedding = nn.Embedding(self.num_positions, self.embed_dim)
+
+    def forward(self, pixel_values: paddle.Tensor, patch_attention_mask: paddle.Tensor) -> paddle.Tensor:
+        batch_size, _, height, width = pixel_values.shape
+        patch_embeds = self.patch_embedding(pixel_values)
+        embeddings = patch_embeds.flatten(2).transpose([0, 2, 1])
+
+        max_patches_h = height // self.patch_size
+        max_patches_w = width // self.patch_size
+
+        boundaries = paddle.arange(
+            1 / self.num_patches_per_side, 1.0, 1 / self.num_patches_per_side
+        )  # default float32, matching HF
+        position_ids = paddle.zeros(
+            [batch_size, max_patches_h * max_patches_w], dtype="int64"
+        )
+
+        # Per-image position-id computation 鈥?matches the installed HF
+        # implementation which loops over batch elements individually.
+        for batch_idx, p_attn_mask in enumerate(patch_attention_mask):
+            nb_patches_h = p_attn_mask[:, 0].sum()
+            nb_patches_w = p_attn_mask[0].sum()
+
+            h_indices = paddle.arange(nb_patches_h, dtype=pixel_values.dtype)
+            w_indices = paddle.arange(nb_patches_w, dtype=pixel_values.dtype)
+
+            fractional_h = h_indices / nb_patches_h * (1 - 1e-6)
+            fractional_w = w_indices / nb_patches_w * (1 - 1e-6)
+
+            bucket_h = _bucketize_right(fractional_h, boundaries)
+            bucket_w = _bucketize_right(fractional_w, boundaries)
+
+            pos_ids = (bucket_h.unsqueeze(1) * self.num_patches_per_side + bucket_w.unsqueeze(0)).flatten()
+            position_ids[batch_idx][p_attn_mask.reshape([-1])] = pos_ids
+
+        return embeddings + self.position_embedding(position_ids)
+
+
+class Idefics3VisionAttention(nn.Layer):
+    def __init__(self, config: Idefics3VisionConfig):
+        super().__init__()
+        self.embed_dim = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = self.embed_dim // self.num_heads
+        if self.head_dim * self.num_heads != self.embed_dim:
+            raise ValueError(
+                f"hidden_size must be divisible by num_attention_heads, got {self.embed_dim} and {self.num_heads}."
+            )
+        self.scale = self.head_dim**-0.5
+        self.dropout = config.attention_dropout
+        self.q_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.k_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.v_proj = nn.Linear(self.embed_dim, self.embed_dim)
+        self.out_proj = nn.Linear(self.embed_dim, self.embed_dim)
+
+    def _shape(self, tensor, batch_size, seq_len):
+        return tensor.reshape([batch_size, seq_len, self.num_heads, self.head_dim]).transpose([0, 2, 1, 3])
+
+    def forward(self, hidden_states: paddle.Tensor, attention_mask: Optional[paddle.Tensor] = None):
+        batch_size, seq_len, _ = hidden_states.shape
+        query = self._shape(self.q_proj(hidden_states), batch_size, seq_len)
+        key = self._shape(self.k_proj(hidden_states), batch_size, seq_len)
+        value = self._shape(self.v_proj(hidden_states), batch_size, seq_len)
+        attn_weights = paddle.matmul(query, key, transpose_y=True) * self.scale
+        if attention_mask is not None:
+            attn_weights = attn_weights + attention_mask
+        attn_weights = F.softmax(attn_weights.astype("float32"), axis=-1).astype(query.dtype)
+        attn_weights = F.dropout(attn_weights, p=self.dropout, training=self.training)
+        attn_output = paddle.matmul(attn_weights, value)
+        attn_output = attn_output.transpose([0, 2, 1, 3]).reshape([batch_size, seq_len, self.embed_dim])
+        return self.out_proj(attn_output), attn_weights
+
+
+class Idefics3VisionMLP(nn.Layer):
+    def __init__(self, config: Idefics3VisionConfig):
+        super().__init__()
+        self.activation_fn = ACT2FN[config.hidden_act]
+        self.fc1 = nn.Linear(config.hidden_size, config.intermediate_size)
+        self.fc2 = nn.Linear(config.intermediate_size, config.hidden_size)
+
+    def forward(self, hidden_states):
+        return self.fc2(self.activation_fn(self.fc1(hidden_states)))
+
+
+class Idefics3EncoderLayer(nn.Layer):
+    def __init__(self, config: Idefics3VisionConfig):
+        super().__init__()
+        self.self_attn = Idefics3VisionAttention(config)
+        self.layer_norm1 = nn.LayerNorm(config.hidden_size, epsilon=config.layer_norm_eps)
+        self.mlp = Idefics3VisionMLP(config)
+        self.layer_norm2 = nn.LayerNorm(config.hidden_size, epsilon=config.layer_norm_eps)
+
+    def forward(self, hidden_states: paddle.Tensor, attention_mask: Optional[paddle.Tensor] = None):
+        residual = hidden_states
+        hidden_states, _ = self.self_attn(self.layer_norm1(hidden_states), attention_mask=attention_mask)
+        hidden_states = residual + hidden_states
+        residual = hidden_states
+        hidden_states = self.mlp(self.layer_norm2(hidden_states))
+        return residual + hidden_states
+
+
+class Idefics3Encoder(nn.Layer):
+    def __init__(self, config: Idefics3VisionConfig):
+        super().__init__()
+        self.layers = nn.LayerList([Idefics3EncoderLayer(config) for _ in range(config.num_hidden_layers)])
+
+    def forward(self, inputs_embeds, attention_mask=None):
+        hidden_states = inputs_embeds
+        for layer in self.layers:
+            hidden_states = layer(hidden_states, attention_mask=attention_mask)
+        return BaseModelOutput(last_hidden_state=hidden_states)
+
+
+class Idefics3SimpleMLP(nn.Layer):
+    def __init__(self, config: Idefics3Config):
+        super().__init__()
+        input_size = config.vision_config.hidden_size * (config.scale_factor**2)
+        output_size = config.text_config.hidden_size
+        self.proj = nn.Linear(input_size, output_size, bias_attr=False)
+
+    def forward(self, x):
+        return self.proj(x)
+
+
+class Idefics3Connector(nn.Layer):
+    def __init__(self, config: Idefics3Config):
+        super().__init__()
+        self.scale_factor = config.scale_factor
+        self.modality_projection = Idefics3SimpleMLP(config)
+
+    def pixel_shuffle(self, x, scale_factor=2):
+        batch_size, seq_len, embed_dim = x.shape
+        height = width = int(math.sqrt(seq_len))
+        if height * width != seq_len:
+            raise ValueError(f"Idefics3 connector expects square image sequence, got sequence length {seq_len}.")
+        x = x.reshape([batch_size, height, width, embed_dim])
+        x = x.reshape([batch_size, height, width // scale_factor, embed_dim * scale_factor])
+        x = x.transpose([0, 2, 1, 3])
+        x = x.reshape([batch_size, width // scale_factor, height // scale_factor, embed_dim * scale_factor**2])
+        x = x.transpose([0, 2, 1, 3])
+        return x.reshape([batch_size, seq_len // scale_factor**2, embed_dim * scale_factor**2])
+
+    def forward(self, image_hidden_states):
+        return self.modality_projection(self.pixel_shuffle(image_hidden_states, self.scale_factor))
+
+
+class Idefics3PreTrainedModel(PretrainedModel):
+    config_class = Idefics3Config
+    base_model_prefix = "model"
+    input_modalities = ["image", "text"]
+    supports_gradient_checkpointing = True
+    _no_split_modules = ["Idefics3VisionAttention", "Idefics3EncoderLayer"]
+    _keys_to_ignore_on_load_unexpected = [r"rotary_emb\.inv_freq"]
+    transpose_weight_keys = [
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "out_proj",
+        "fc1",
+        "fc2",
+        "proj",
+        # Note: lm_head is GeneralLMHead (weight [vocab, hidden]) 閳?no transpose needed
+    ]
+
+    @classmethod
+    def _gen_aoa_config(cls, config):
+        prefix = cls.base_model_prefix + "." if cls != cls.base_model_class else ""
+        # HF weight paths use "model.text_model.*" directly (no intermediate "model")
+        text_src = "model.text_model"
+        text_dst = f"{prefix}text_model"
+        text_layers = getattr(config.text_config, "num_hidden_layers", 0)
+
+        statements = [
+            # --- lm_head (GeneralLMHead weight [vocab, hidden], same as HF 鈫?no ^T) ---
+            "lm_head.weight -> lm_head.weight",
+            # --- connector ---
+            f"model.connector.modality_projection.proj.weight^T -> {prefix}connector.modality_projection.proj.weight",
+            # --- vision_model ---
+            f"model.vision_model.embeddings.patch_embedding.weight -> {prefix}vision_model.embeddings.patch_embedding.weight",
+            f"model.vision_model.embeddings.patch_embedding.bias -> {prefix}vision_model.embeddings.patch_embedding.bias",
+            f"model.vision_model.embeddings.position_embedding.weight -> {prefix}vision_model.embeddings.position_embedding.weight",
+            f"model.vision_model.post_layernorm.weight -> {prefix}vision_model.post_layernorm.weight",
+            f"model.vision_model.post_layernorm.bias -> {prefix}vision_model.post_layernorm.bias",
+            # --- text_model: embedding + final norm (no transpose needed) ---
+            f"{text_src}.embed_tokens.weight -> {text_dst}.embed_tokens.weight",
+            f"{text_src}.norm.weight -> {text_dst}.norm.weight",
+        ]
+
+        # --- vision encoder layers ---
+        for layer_id in range(config.vision_config.num_hidden_layers):
+            src = f"model.vision_model.encoder.layers.{layer_id}"
+            dst = f"{prefix}vision_model.encoder.layers.{layer_id}"
+            statements.extend(
+                [
+                    f"{src}.self_attn.q_proj.weight^T -> {dst}.self_attn.q_proj.weight",
+                    f"{src}.self_attn.q_proj.bias -> {dst}.self_attn.q_proj.bias",
+                    f"{src}.self_attn.k_proj.weight^T -> {dst}.self_attn.k_proj.weight",
+                    f"{src}.self_attn.k_proj.bias -> {dst}.self_attn.k_proj.bias",
+                    f"{src}.self_attn.v_proj.weight^T -> {dst}.self_attn.v_proj.weight",
+                    f"{src}.self_attn.v_proj.bias -> {dst}.self_attn.v_proj.bias",
+                    f"{src}.self_attn.out_proj.weight^T -> {dst}.self_attn.out_proj.weight",
+                    f"{src}.self_attn.out_proj.bias -> {dst}.self_attn.out_proj.bias",
+                    f"{src}.layer_norm1.weight -> {dst}.layer_norm1.weight",
+                    f"{src}.layer_norm1.bias -> {dst}.layer_norm1.bias",
+                    f"{src}.mlp.fc1.weight^T -> {dst}.mlp.fc1.weight",
+                    f"{src}.mlp.fc1.bias -> {dst}.mlp.fc1.bias",
+                    f"{src}.mlp.fc2.weight^T -> {dst}.mlp.fc2.weight",
+                    f"{src}.mlp.fc2.bias -> {dst}.mlp.fc2.bias",
+                    f"{src}.layer_norm2.weight -> {dst}.layer_norm2.weight",
+                    f"{src}.layer_norm2.bias -> {dst}.layer_norm2.bias",
+                ]
+            )
+
+        # --- text_model transformer layers (Linear weights need ^T for HF鈫扨addle) ---
+        for layer_id in range(text_layers):
+            src_l = f"{text_src}.layers.{layer_id}"
+            dst_l = f"{text_dst}.layers.{layer_id}"
+            statements.extend(
+                [
+                    # Attention: Q/K/V/O projections
+                    f"{src_l}.self_attn.q_proj.weight^T -> {dst_l}.self_attn.q_proj.weight",
+                    f"{src_l}.self_attn.k_proj.weight^T -> {dst_l}.self_attn.k_proj.weight",
+                    f"{src_l}.self_attn.v_proj.weight^T -> {dst_l}.self_attn.v_proj.weight",
+                    f"{src_l}.self_attn.o_proj.weight^T -> {dst_l}.self_attn.o_proj.weight",
+                    # RMSNorm (1D, no transpose)
+                    f"{src_l}.input_layernorm.weight -> {dst_l}.input_layernorm.weight",
+                    f"{src_l}.post_attention_layernorm.weight -> {dst_l}.post_attention_layernorm.weight",
+                    # MLP: gate/up/down projections
+                    f"{src_l}.mlp.gate_proj.weight^T -> {dst_l}.mlp.gate_proj.weight",
+                    f"{src_l}.mlp.up_proj.weight^T -> {dst_l}.mlp.up_proj.weight",
+                    f"{src_l}.mlp.down_proj.weight^T -> {dst_l}.mlp.down_proj.weight",
+                ]
+            )
+
+        return {"aoa_statements": statements}
+
+    def _init_weights(self, layer):
+        std = getattr(self.config, "initializer_range", None) or getattr(self.config.vision_config, "initializer_range", 0.02)
+        if isinstance(layer, (nn.Linear, nn.Conv2D)):
+            layer.weight.set_value(paddle.normal(mean=0.0, std=std, shape=layer.weight.shape))
+            if getattr(layer, "bias", None) is not None:
+                layer.bias.set_value(paddle.zeros_like(layer.bias))
+        elif isinstance(layer, nn.Embedding):
+            layer.weight.set_value(paddle.normal(mean=0.0, std=std, shape=layer.weight.shape))
+
+
+class Idefics3VisionTransformer(Idefics3PreTrainedModel):
+    config_class = Idefics3VisionConfig
+
+    def __init__(self, config: Idefics3VisionConfig):
+        super().__init__(config)
+        self.embeddings = Idefics3VisionEmbeddings(config)
+        self.encoder = Idefics3Encoder(config)
+        self.patch_size = config.patch_size
+        self.post_layernorm = nn.LayerNorm(config.hidden_size, epsilon=config.layer_norm_eps)
+
+    def get_input_embeddings(self):
+        return self.embeddings
+
+    def set_input_embeddings(self, value):
+        self.embeddings = value
+
+    def forward(self, pixel_values, patch_attention_mask=None, return_dict=True, **kwargs):
+        batch_size = pixel_values.shape[0]
+        if patch_attention_mask is None:
+            patch_attention_mask = paddle.ones(
+                [batch_size, pixel_values.shape[2] // self.patch_size, pixel_values.shape[3] // self.patch_size],
+                dtype="bool",
+            )
+        else:
+            patch_attention_mask = patch_attention_mask.astype("bool")
+        hidden_states = self.embeddings(pixel_values=pixel_values, patch_attention_mask=patch_attention_mask)
+        flat_mask = patch_attention_mask.reshape([batch_size, -1]).astype("bool")
+        min_value = paddle.finfo(hidden_states.dtype).min
+        attention_mask = paddle.where(
+            flat_mask[:, None, None, :],
+            paddle.zeros([1], dtype=hidden_states.dtype),
+            paddle.full([1], min_value, dtype=hidden_states.dtype),
+        )
+        encoder_outputs = self.encoder(inputs_embeds=hidden_states, attention_mask=attention_mask)
+        last_hidden_state = self.post_layernorm(encoder_outputs.last_hidden_state)
+        if not return_dict:
+            return (last_hidden_state,)
+        return BaseModelOutput(last_hidden_state=last_hidden_state)
+
+
+@register_base_model
+class Idefics3Model(Idefics3PreTrainedModel):
+    def __init__(self, config: Idefics3Config):
+        super().__init__(config)
+        self.vision_model = Idefics3VisionTransformer(config.vision_config)
+        self.connector = Idefics3Connector(config)
+        if getattr(config.text_config, "model_type", None) == "llama":
+            self.text_model = LlamaModel(config.text_config)
+        else:
+            self.text_model = AutoModel.from_config(config.text_config)
+        self.image_token_id = config.image_token_id
+        self.image_seq_len = int(
+            ((config.vision_config.image_size // config.vision_config.patch_size) ** 2) / (config.scale_factor**2)
+        )
+
+    def get_input_embeddings(self):
+        return self.text_model.get_input_embeddings()
+
+    def set_input_embeddings(self, value):
+        self.text_model.set_input_embeddings(value)
+
+    def inputs_merger(self, input_ids, inputs_embeds, image_hidden_states):
+        if input_ids is None:
+            special_image_mask = (
+                inputs_embeds
+                == self.get_input_embeddings()(paddle.to_tensor(self.config.image_token_id, dtype="int64"))
+            ).all(axis=-1)
+        else:
+            special_image_mask = input_ids == self.config.image_token_id
+
+        # Count image tokens BEFORE expand_as (bool mask integrity)
+        n_image_tokens = special_image_mask.sum()
+
+        special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds)
+        if inputs_embeds[special_image_mask].numel() != image_hidden_states.numel():
+            raise ValueError(
+                f"Image features and image tokens do not match: "
+                f"n_image_tokens={n_image_tokens.item()}, "
+                f"image_hidden_states.shape={image_hidden_states.shape}, "
+                f"numel={image_hidden_states.numel()}"
+            )
+        return inputs_embeds.masked_scatter(special_image_mask, image_hidden_states.astype(inputs_embeds.dtype))
+
+    def get_image_features(self, pixel_values, pixel_attention_mask=None, **kwargs):
+        if len(pixel_values.shape) != 5:
+            raise ValueError("`pixel_values` must have shape [batch, num_images, channels, height, width].")
+        batch_size, num_images = pixel_values.shape[:2]
+        flat_pixel_values = pixel_values.reshape([batch_size * num_images, *pixel_values.shape[2:]])
+        nb_values_per_image = math.prod(flat_pixel_values.shape[1:])
+        real_images = (flat_pixel_values == 0.0).sum(axis=[1, 2, 3]) != nb_values_per_image
+        real_indices = paddle.nonzero(real_images).flatten()
+        if real_indices.numel() == 0:
+            empty_shape = [0, self.image_seq_len, self.config.text_config.hidden_size]
+            return BaseModelOutputWithPooling(pooler_output=paddle.empty(empty_shape, dtype=flat_pixel_values.dtype))
+
+        flat_pixel_values = paddle.gather(flat_pixel_values, real_indices, axis=0)
+        if pixel_attention_mask is None:
+            pixel_attention_mask = paddle.ones(
+                [flat_pixel_values.shape[0], flat_pixel_values.shape[2], flat_pixel_values.shape[3]], dtype="bool"
+            )
+        else:
+            if pixel_attention_mask.shape[:2] != pixel_values.shape[:2]:
+                raise ValueError("`pixel_attention_mask` batch and num_images dimensions must match `pixel_values`.")
+            pixel_attention_mask = pixel_attention_mask.reshape([batch_size * num_images, *pixel_attention_mask.shape[2:]])
+            pixel_attention_mask = paddle.gather(pixel_attention_mask, real_indices, axis=0).astype("bool")
+
+        patch_size = self.config.vision_config.patch_size
+        valid_h = (pixel_attention_mask.shape[1] // patch_size) * patch_size
+        valid_w = (pixel_attention_mask.shape[2] // patch_size) * patch_size
+        pixel_attention_mask = pixel_attention_mask[:, :valid_h, :valid_w]
+        patch_attention_mask = pixel_attention_mask.reshape(
+            [pixel_attention_mask.shape[0], valid_h // patch_size, patch_size, valid_w // patch_size, patch_size]
+        ).sum(axis=[2, 4]) > 0
+        image_outputs = self.vision_model(
+            pixel_values=flat_pixel_values, patch_attention_mask=patch_attention_mask, return_dict=True
+        )
+        image_features = self.connector(image_outputs.last_hidden_state)
+        return BaseModelOutputWithPooling(
+            last_hidden_state=image_outputs.last_hidden_state,
+            pooler_output=image_features,
+        )
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        position_ids=None,
+        past_key_values=None,
+        inputs_embeds=None,
+        pixel_values=None,
+        pixel_attention_mask=None,
+        image_hidden_states=None,
+        use_cache=None,
+        output_hidden_states=None,
+        output_attentions=None,
+        return_dict=True,
+        cache_position=None,
+        **kwargs,
+    ):
+        if input_ids is None and inputs_embeds is None:
+            raise ValueError("You have to specify either input_ids or inputs_embeds.")
+        if inputs_embeds is None:
+            inputs_embeds = self.get_input_embeddings()(input_ids)
+        if pixel_values is not None and image_hidden_states is not None:
+            raise ValueError("You cannot specify both pixel_values and image_hidden_states at the same time.")
+        if pixel_values is not None:
+            image_hidden_states = self.get_image_features(pixel_values, pixel_attention_mask).pooler_output
+        if image_hidden_states is not None:
+            inputs_embeds = self.inputs_merger(input_ids, inputs_embeds, image_hidden_states)
+
+        text_outputs = self.text_model(
+            input_ids=None,
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            output_hidden_states=output_hidden_states,
+            return_dict=True,
+        )
+        if not return_dict:
+            return (text_outputs.last_hidden_state, text_outputs.past_key_values, text_outputs.hidden_states, None, image_hidden_states)
+        return Idefics3BaseModelOutputWithPast(
+            last_hidden_state=text_outputs.last_hidden_state,
+            past_key_values=text_outputs.past_key_values,
+            hidden_states=text_outputs.hidden_states,
+            attentions=getattr(text_outputs, "attentions", None),
+            image_hidden_states=image_hidden_states,
+        )
+
+
+class Idefics3ForConditionalGeneration(Idefics3PreTrainedModel, GenerationMixin):
+    _tied_weights_keys = {"lm_head.weight": "model.text_model.embed_tokens.weight"}
+
+    def __init__(self, config: Idefics3Config):
+        super().__init__(config)
+        self.model = Idefics3Model(config)
+        self.image_token_id = config.image_token_id
+        # Use GeneralLMHead (weight [vocab, hidden]) for compatibility with
+        # nn.Embedding weight tie. nn.Linear stores weight as [in, out] in
+        # Paddle, which requires transposition when tied to embedding weights.
+        self.lm_head = GeneralLMHead(config.text_config)
+        self.vocab_size = config.text_config.vocab_size
+        self.criterion = CriterionLayer(config.text_config)
+        self.tie_weights()
+
+    def get_input_embeddings(self):
+        return self.model.get_input_embeddings()
+
+    def set_input_embeddings(self, value):
+        self.model.set_input_embeddings(value)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, value):
+        self.lm_head = value
+
+    def get_image_features(self, pixel_values, pixel_attention_mask=None, **kwargs):
+        return self.model.get_image_features(pixel_values=pixel_values, pixel_attention_mask=pixel_attention_mask, **kwargs)
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        position_ids=None,
+        past_key_values=None,
+        inputs_embeds=None,
+        pixel_values=None,
+        pixel_attention_mask=None,
+        image_hidden_states=None,
+        labels=None,
+        use_cache=None,
+        output_attentions=None,
+        output_hidden_states=None,
+        return_dict=True,
+        logits_to_keep: Union[int, paddle.Tensor] = 0,
+        cache_position=None,
+        **kwargs,
+    ):
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            pixel_values=pixel_values,
+            pixel_attention_mask=pixel_attention_mask,
+            image_hidden_states=image_hidden_states,
+            use_cache=use_cache,
+            output_hidden_states=output_hidden_states,
+            output_attentions=output_attentions,
+            return_dict=True,
+            cache_position=cache_position,
+            **kwargs,
+        )
+        hidden_states = outputs.last_hidden_state
+        # logits_to_keep=None means keep all logits (same as 0)
+        if logits_to_keep is None or logits_to_keep == 0:
+            logits = self.lm_head(hidden_states)
+        elif isinstance(logits_to_keep, int):
+            logits = self.lm_head(hidden_states[:, -logits_to_keep:, :])
+        else:
+            logits = self.lm_head(hidden_states[:, logits_to_keep, :])
+
+        loss = None
+        if labels is not None:
+            if isinstance(logits_to_keep, int) and logits_to_keep != 0:
+                labels = labels[:, -logits.shape[1] :]
+            labels = paddle.where(labels == self.image_token_id, paddle.full_like(labels, -100), labels)
+            # NOTE: Labels are already pre-shifted by the data pipeline (SFTDataset._process_sft_sequence).
+            # The model MUST NOT shift here to avoid double-shifting.
+            # This aligns with qwen3's pattern: self.criterion(logits, labels) without manual shift.
+            loss, _ = self.criterion(logits, labels)
+
+        if not return_dict:
+            output = (logits, outputs.past_key_values, outputs.hidden_states, outputs.attentions, outputs.image_hidden_states)
+            return ((loss,) + output) if loss is not None else output
+        return Idefics3CausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+            image_hidden_states=outputs.image_hidden_states,
+        )
+
+    def prepare_inputs_for_generation(
+        self,
+        input_ids,
+        past_key_values=None,
+        attention_mask=None,
+        inputs_embeds=None,
+        cache_position=None,
+        position_ids=None,
+        use_cache=True,
+        pixel_values=None,
+        pixel_attention_mask=None,
+        image_hidden_states=None,
+        logits_to_keep=None,
+        **kwargs,
+    ):
+        if past_key_values is None:
+            cache_position = paddle.arange(input_ids.shape[1])
+        else:
+            cache_position = paddle.to_tensor([input_ids.shape[1] - 1])
+        model_inputs = super().prepare_inputs_for_generation(
+            input_ids,
+            past_key_values=past_key_values,
+            attention_mask=attention_mask,
+            inputs_embeds=inputs_embeds,
+            cache_position=cache_position,
+            position_ids=position_ids,
+            use_cache=use_cache,
+            pixel_values=pixel_values,
+            pixel_attention_mask=pixel_attention_mask,
+            image_hidden_states=image_hidden_states,
+            logits_to_keep=logits_to_keep,
+            **kwargs,
+        )
+        if image_hidden_states is not None or cache_position[0] != 0:
+            model_inputs["pixel_values"] = None
+            model_inputs["pixel_attention_mask"] = None
+        return model_inputs
+
+    def expand_inputs_for_generation(
+        self,
+        expand_size: int = 1,
+        is_encoder_decoder: bool = False,
+        input_ids: Optional[paddle.Tensor] = None,
+        **model_kwargs,
+    ):
+        if expand_size == 1:
+            return input_ids, model_kwargs
+        for key, value in list(model_kwargs.items()):
+            if value is None or not isinstance(value, paddle.Tensor):
+                continue
+            if key != "cache_position":
+                model_kwargs[key] = value.repeat_interleave(expand_size, axis=0)
+        if input_ids is not None:
+            input_ids = input_ids.repeat_interleave(expand_size, axis=0)
+        return input_ids, model_kwargs
+
+
+__all__ = [
+    "Idefics3ForConditionalGeneration",
+    "Idefics3Model",
+    "Idefics3PreTrainedModel",
+    "Idefics3VisionTransformer",
+]

--- a/paddleformers/transformers/idefics3/modeling.py
+++ b/paddleformers/transformers/idefics3/modeling.py
@@ -379,17 +379,16 @@ class Idefics3Model(Idefics3PreTrainedModel):
         else:
             special_image_mask = input_ids == self.config.image_token_id
 
-        # Count image tokens BEFORE expand_as (bool mask integrity)
-        n_image_tokens = special_image_mask.sum()
-
-        special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds)
-        if inputs_embeds[special_image_mask].numel() != image_hidden_states.numel():
+        n_image_tokens = int(special_image_mask.astype("int64").sum().item())
+        n_image_features = int(image_hidden_states.shape[0] * image_hidden_states.shape[1])
+        if n_image_tokens != n_image_features:
             raise ValueError(
                 f"Image features and image tokens do not match: "
-                f"n_image_tokens={n_image_tokens.item()}, "
+                f"n_image_tokens={n_image_tokens}, "
                 f"image_hidden_states.shape={image_hidden_states.shape}, "
                 f"numel={image_hidden_states.numel()}"
             )
+        special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds)
         return inputs_embeds.masked_scatter(special_image_mask, image_hidden_states.astype(inputs_embeds.dtype))
 
     def get_image_features(self, pixel_values, pixel_attention_mask=None, **kwargs):

--- a/paddleformers/transformers/idefics3/modeling.py
+++ b/paddleformers/transformers/idefics3/modeling.py
@@ -21,13 +21,13 @@ from ..auto.modeling import AutoModel
 from ..llama.modeling import LlamaModel
 from ..model_outputs import (
     BaseModelOutput,
-    BaseModelOutputWithPast,
     BaseModelOutputWithPooling,
     CausalLMOutputWithPast,
     ModelOutput,
 )
 from ..model_utils import PretrainedModel, register_base_model
 from .configuration import Idefics3Config, Idefics3VisionConfig
+
 
 @dataclass
 class Idefics3BaseModelOutputWithPast(ModelOutput):
@@ -76,9 +76,7 @@ class Idefics3VisionEmbeddings(nn.Layer):
         boundaries = paddle.arange(
             1 / self.num_patches_per_side, 1.0, 1 / self.num_patches_per_side
         )  # default float32, matching HF
-        position_ids = paddle.zeros(
-            [batch_size, max_patches_h * max_patches_w], dtype="int64"
-        )
+        position_ids = paddle.zeros([batch_size, max_patches_h * max_patches_w], dtype="int64")
 
         # Per-image position-id computation 鈥?matches the installed HF
         # implementation which loops over batch elements individually.
@@ -300,7 +298,9 @@ class Idefics3PreTrainedModel(PretrainedModel):
         return {"aoa_statements": statements}
 
     def _init_weights(self, layer):
-        std = getattr(self.config, "initializer_range", None) or getattr(self.config.vision_config, "initializer_range", 0.02)
+        std = getattr(self.config, "initializer_range", None) or getattr(
+            self.config.vision_config, "initializer_range", 0.02
+        )
         if isinstance(layer, (nn.Linear, nn.Conv2D)):
             layer.weight.set_value(paddle.normal(mean=0.0, std=std, shape=layer.weight.shape))
             if getattr(layer, "bias", None) is not None:
@@ -412,16 +412,21 @@ class Idefics3Model(Idefics3PreTrainedModel):
         else:
             if pixel_attention_mask.shape[:2] != pixel_values.shape[:2]:
                 raise ValueError("`pixel_attention_mask` batch and num_images dimensions must match `pixel_values`.")
-            pixel_attention_mask = pixel_attention_mask.reshape([batch_size * num_images, *pixel_attention_mask.shape[2:]])
+            pixel_attention_mask = pixel_attention_mask.reshape(
+                [batch_size * num_images, *pixel_attention_mask.shape[2:]]
+            )
             pixel_attention_mask = paddle.gather(pixel_attention_mask, real_indices, axis=0).astype("bool")
 
         patch_size = self.config.vision_config.patch_size
         valid_h = (pixel_attention_mask.shape[1] // patch_size) * patch_size
         valid_w = (pixel_attention_mask.shape[2] // patch_size) * patch_size
         pixel_attention_mask = pixel_attention_mask[:, :valid_h, :valid_w]
-        patch_attention_mask = pixel_attention_mask.reshape(
-            [pixel_attention_mask.shape[0], valid_h // patch_size, patch_size, valid_w // patch_size, patch_size]
-        ).sum(axis=[2, 4]) > 0
+        patch_attention_mask = (
+            pixel_attention_mask.reshape(
+                [pixel_attention_mask.shape[0], valid_h // patch_size, patch_size, valid_w // patch_size, patch_size]
+            ).sum(axis=[2, 4])
+            > 0
+        )
         image_outputs = self.vision_model(
             pixel_values=flat_pixel_values, patch_attention_mask=patch_attention_mask, return_dict=True
         )
@@ -442,12 +447,15 @@ class Idefics3Model(Idefics3PreTrainedModel):
         pixel_attention_mask=None,
         image_hidden_states=None,
         use_cache=None,
-        output_hidden_states=None,
         output_attentions=None,
+        output_hidden_states=None,
         return_dict=True,
         cache_position=None,
         **kwargs,
     ):
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
         if input_ids is None and inputs_embeds is None:
             raise ValueError("You have to specify either input_ids or inputs_embeds.")
         if inputs_embeds is None:
@@ -470,12 +478,18 @@ class Idefics3Model(Idefics3PreTrainedModel):
             return_dict=True,
         )
         if not return_dict:
-            return (text_outputs.last_hidden_state, text_outputs.past_key_values, text_outputs.hidden_states, None, image_hidden_states)
+            return (
+                text_outputs.last_hidden_state,
+                text_outputs.past_key_values,
+                text_outputs.hidden_states,
+                None,
+                image_hidden_states,
+            )
         return Idefics3BaseModelOutputWithPast(
             last_hidden_state=text_outputs.last_hidden_state,
             past_key_values=text_outputs.past_key_values,
             hidden_states=text_outputs.hidden_states,
-            attentions=getattr(text_outputs, "attentions", None),
+            attentions=None,
             image_hidden_states=image_hidden_states,
         )
 
@@ -508,7 +522,9 @@ class Idefics3ForConditionalGeneration(Idefics3PreTrainedModel, GenerationMixin)
         self.lm_head = value
 
     def get_image_features(self, pixel_values, pixel_attention_mask=None, **kwargs):
-        return self.model.get_image_features(pixel_values=pixel_values, pixel_attention_mask=pixel_attention_mask, **kwargs)
+        return self.model.get_image_features(
+            pixel_values=pixel_values, pixel_attention_mask=pixel_attention_mask, **kwargs
+        )
 
     def forward(
         self,
@@ -565,7 +581,13 @@ class Idefics3ForConditionalGeneration(Idefics3PreTrainedModel, GenerationMixin)
             loss, _ = self.criterion(logits, labels)
 
         if not return_dict:
-            output = (logits, outputs.past_key_values, outputs.hidden_states, outputs.attentions, outputs.image_hidden_states)
+            output = (
+                logits,
+                outputs.past_key_values,
+                outputs.hidden_states,
+                outputs.attentions,
+                outputs.image_hidden_states,
+            )
             return ((loss,) + output) if loss is not None else output
         return Idefics3CausalLMOutputWithPast(
             loss=loss,
@@ -612,22 +634,24 @@ class Idefics3ForConditionalGeneration(Idefics3PreTrainedModel, GenerationMixin)
         if image_hidden_states is not None or cache_position[0] != 0:
             model_inputs["pixel_values"] = None
             model_inputs["pixel_attention_mask"] = None
+        if cache_position[0] != 0:
+            model_inputs["image_hidden_states"] = None
         return model_inputs
 
-    def expand_inputs_for_generation(
-        self,
-        expand_size: int = 1,
-        is_encoder_decoder: bool = False,
-        input_ids: Optional[paddle.Tensor] = None,
-        **model_kwargs,
-    ):
+    def expand_inputs_for_generation(self, input_ids, expand_size, attention_mask=None, **model_kwargs):
         if expand_size == 1:
             return input_ids, model_kwargs
+        if attention_mask is not None:
+            model_kwargs["attention_mask"] = attention_mask.repeat_interleave(expand_size, axis=0)
         for key, value in list(model_kwargs.items()):
-            if value is None or not isinstance(value, paddle.Tensor):
+            if (
+                key == "attention_mask"
+                or key == "cache_position"
+                or value is None
+                or not isinstance(value, paddle.Tensor)
+            ):
                 continue
-            if key != "cache_position":
-                model_kwargs[key] = value.repeat_interleave(expand_size, axis=0)
+            model_kwargs[key] = value.repeat_interleave(expand_size, axis=0)
         if input_ids is not None:
             input_ids = input_ids.repeat_interleave(expand_size, axis=0)
         return input_ids, model_kwargs

--- a/paddleformers/transformers/idefics3/processor.py
+++ b/paddleformers/transformers/idefics3/processor.py
@@ -1,0 +1,257 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+"""Paddle Idefics3 processor."""
+
+from itertools import accumulate
+from typing import Optional, TypedDict, Union
+
+import numpy as np
+
+from ..feature_extraction_utils import BatchFeature
+from ..image_utils import ImageInput, is_valid_image
+from ..processing_utils import MultiModalData, ProcessingKwargs, ProcessorMixin, Unpack
+from ..tokenizer_utils import AddedToken
+from ..tokenizer_utils_base import PreTokenizedInput, TextInput
+
+
+class Idefics3ImageProcessorKwargs(TypedDict, total=False):
+    """Image processor kwargs for IDEfics3, including return_row_col_info."""
+
+    do_convert_rgb: bool
+    do_resize: bool
+    do_rescale: bool
+    do_normalize: bool
+    do_image_splitting: bool
+    do_pad: bool
+    return_row_col_info: bool
+    size: dict
+    max_image_size: dict
+    image_mean: list[float]
+    image_std: list[float]
+    resample: int
+    return_tensors: str
+
+
+class Idefics3ProcessorKwargs(ProcessingKwargs, total=False):
+    _defaults = {
+        "text_kwargs": {
+            "add_special_tokens": True,
+            "padding": False,
+            "is_split_into_words": False,
+            "return_mm_token_type_ids": False,
+        },
+        "images_kwargs": {
+            "return_row_col_info": True,
+        },
+    }
+    images_kwargs: Idefics3ImageProcessorKwargs
+
+
+class Idefics3Processor(ProcessorMixin):
+    attributes = ["image_processor", "tokenizer"]
+    image_processor_class = "AutoImageProcessor"
+    tokenizer_class = ("LlamaTokenizer", "LlamaTokenizerFast")
+
+    def __init__(self, image_processor=None, tokenizer=None, image_seq_len: int = 169, chat_template=None, **kwargs):
+        self.fake_image_token = AddedToken("<fake_token_around_image>", normalized=False, special=True).content
+        self.image_token = AddedToken("<image>", normalized=False, special=True).content
+        self.end_of_utterance_token = AddedToken("<end_of_utterance>", normalized=False, special=True).content
+        self.global_image_tag = "<global-img>"
+        self.image_seq_len = image_seq_len
+        self.image_token_id = tokenizer.convert_tokens_to_ids(self.image_token) if tokenizer is not None else None
+        self.fake_image_token_id = (
+            tokenizer.convert_tokens_to_ids(self.fake_image_token) if tokenizer is not None else None
+        )
+        self.global_image_token_id = (
+            tokenizer.convert_tokens_to_ids(self.global_image_tag) if tokenizer is not None else None
+        )
+        self.row_col_ids = (
+            [tokenizer.convert_tokens_to_ids(f"<row_{i + 1}_col_{j + 1}>") for i in range(6) for j in range(6)]
+            if tokenizer is not None
+            else []
+        )
+
+        if tokenizer is not None:
+            tokenizer.add_special_tokens(
+                {
+                    "additional_special_tokens": [
+                        self.fake_image_token,
+                        self.image_token,
+                        self.end_of_utterance_token,
+                    ]
+                }
+            )
+            self.image_token_id = tokenizer.convert_tokens_to_ids(self.image_token)
+            self.fake_image_token_id = tokenizer.convert_tokens_to_ids(self.fake_image_token)
+
+        super().__init__(image_processor, tokenizer, chat_template=chat_template, **kwargs)
+
+    def __call__(
+        self,
+        images: Optional[ImageInput] = None,
+        text: Union[TextInput, PreTokenizedInput, list[TextInput], list[PreTokenizedInput]] = None,
+        image_seq_len: Optional[int] = None,
+        **kwargs: Unpack[Idefics3ProcessorKwargs],
+    ) -> BatchFeature:
+        images, text = self.prepare_inputs_layout(images=images, text=text)
+        self.validate_inputs(images=images, text=text)
+
+        output_kwargs = self._merge_kwargs(
+            Idefics3ProcessorKwargs,
+            tokenizer_init_kwargs=self.tokenizer.init_kwargs,
+            **kwargs,
+        )
+
+        image_seq_len = image_seq_len if image_seq_len is not None else self.image_seq_len
+        return_tensors = output_kwargs["text_kwargs"].pop("return_tensors", None)
+        return_mm_token_type_ids = output_kwargs["text_kwargs"].pop("return_mm_token_type_ids", False)
+
+        image_inputs = {}
+        text_inputs = {}
+        if images is not None:
+            image_kwargs = output_kwargs["images_kwargs"].copy()
+            image_kwargs.pop("return_tensors", None)
+            image_inputs = self.image_processor(images, return_tensors=None, **image_kwargs)
+            images_replacements = [self.replace_image_token(image_inputs, idx, image_seq_len) for idx in range(sum(map(len, images)))]
+            image_inputs.pop("rows", None)
+            image_inputs.pop("cols", None)
+
+            if text is not None:
+                text = self.get_text_with_replacements(text, images_replacements)
+                text_inputs = self.tokenizer(text, return_tensors=None, **output_kwargs["text_kwargs"])
+                self._check_special_mm_tokens(text, text_inputs, modalities=["image"])
+            else:
+                text = images_replacements
+                text_inputs = self.tokenizer(text, return_tensors=None, **output_kwargs["text_kwargs"])
+        elif text is not None:
+            text_inputs = self.tokenizer(text=text, return_tensors=None, **output_kwargs["text_kwargs"])
+
+        if return_mm_token_type_ids and text_inputs:
+            text_inputs["mm_token_type_ids"] = self.create_mm_token_type_ids(text_inputs["input_ids"])
+
+        return BatchFeature(data={**text_inputs, **image_inputs}, tensor_type=return_tensors)
+
+    def prepare_inputs_layout(self, images=None, text=None):
+        if text is not None:
+            if isinstance(text, str):
+                text = [text]
+            else:
+                text = list(text)
+
+        if images is not None:
+            images = self.image_processor.fetch_images(images)
+            if is_valid_image(images):
+                images = [[images]]
+            elif isinstance(images, (list, tuple)) and images and is_valid_image(images[0]):
+                if text is not None:
+                    n_images_in_text = [sample.count(self.image_token) for sample in text]
+                    cumsum_images = [0] + list(accumulate(n_images_in_text))
+                    images = [images[cumsum_images[i] : cumsum_images[i + 1]] for i in range(len(n_images_in_text))]
+                else:
+                    images = [list(images)]
+            else:
+                images = [list(sample) for sample in images]
+        return images, text
+
+    def validate_inputs(self, images=None, text=None):
+        if text is None and images is None:
+            raise ValueError("You must provide either `text` or `images`.")
+        if text is not None:
+            n_images_in_text = [sample.count(self.image_token) for sample in text]
+            if images is not None:
+                n_images_in_images = [len(sample) for sample in images]
+                if n_images_in_text != n_images_in_images:
+                    raise ValueError(
+                        f"The total number of {self.image_token} tokens in the prompts should be the same as the "
+                        f"number of images passed. Found {n_images_in_text} tokens and {n_images_in_images} images."
+                    )
+            elif any(n_images_in_text):
+                raise ValueError(f"Found {sum(n_images_in_text)} {self.image_token} tokens but no images were passed.")
+
+    def replace_image_token(self, image_inputs: dict, image_idx: int, image_seq_len: int) -> str:
+        image_rows = [row for row_list in image_inputs["rows"] for row in row_list][image_idx]
+        image_cols = [col for col_list in image_inputs["cols"] for col in col_list][image_idx]
+        if image_rows == 0 and image_cols == 0:
+            return (
+                f"{self.fake_image_token}"
+                f"{self.global_image_tag}"
+                f"{self.image_token * image_seq_len}"
+                f"{self.fake_image_token}"
+            )
+
+        text_split_images = ""
+        for row in range(image_rows):
+            for col in range(image_cols):
+                text_split_images += (
+                    f"{self.fake_image_token}"
+                    f"<row_{row + 1}_col_{col + 1}>"
+                    f"{self.image_token * image_seq_len}"
+                )
+            text_split_images += "\n"
+        text_split_images += (
+            f"\n{self.fake_image_token}"
+            f"{self.global_image_tag}"
+            f"{self.image_token * image_seq_len}"
+            f"{self.fake_image_token}"
+        )
+        return text_split_images
+
+    def get_text_with_replacements(self, text, images_replacements):
+        image_idx = 0
+        replaced_text = []
+        for sample in text:
+            while self.image_token in sample:
+                sample = sample.replace(self.image_token, images_replacements[image_idx], 1)
+                image_idx += 1
+            replaced_text.append(sample)
+        return replaced_text
+
+    def create_mm_token_type_ids(self, input_ids):
+        mm_token_type_ids = []
+        for ids in input_ids:
+            array_ids = np.array(ids)
+            token_types = np.zeros_like(array_ids)
+            token_types[array_ids == self.image_token_id] = 1
+            mm_token_type_ids.append(token_types.tolist())
+        return mm_token_type_ids
+
+    def _get_num_multimodal_tokens(self, image_sizes=None, **kwargs):
+        vision_data = {}
+        if image_sizes is not None:
+            images_kwargs = Idefics3ProcessorKwargs._defaults.get("images_kwargs", {}).copy()
+            images_kwargs.update(kwargs)
+            base_image_length = self.image_seq_len + 3
+            col_length = self.image_seq_len + 2
+            extra_split_newline = len(self.tokenizer("\n\n", add_special_tokens=False)["input_ids"]) - 1
+            num_image_tokens = []
+            num_image_patches = []
+            for image_size in image_sizes:
+                num_patches, num_rows, num_cols = self.image_processor.get_number_of_image_patches(
+                    *image_size, images_kwargs
+                )
+                row_length = col_length * num_cols + 1
+                split_extra = extra_split_newline if num_rows > 0 else 0
+                num_image_tokens.append(base_image_length + split_extra + (row_length * num_rows))
+                num_image_patches.append(num_patches)
+            vision_data.update({"num_image_tokens": num_image_tokens, "num_image_patches": num_image_patches})
+        return MultiModalData(**vision_data)
+
+    def post_process_image_text_to_text(
+        self, generated_outputs, skip_special_tokens=True, clean_up_tokenization_spaces=False, **kwargs
+    ):
+        return self.tokenizer.batch_decode(
+            generated_outputs,
+            skip_special_tokens=skip_special_tokens,
+            clean_up_tokenization_spaces=clean_up_tokenization_spaces,
+            **kwargs,
+        )
+
+    @property
+    def model_input_names(self):
+        tokenizer_input_names = self.tokenizer.model_input_names
+        image_processor_input_names = self.image_processor.model_input_names
+        return list(dict.fromkeys(tokenizer_input_names + image_processor_input_names))
+
+
+__all__ = ["Idefics3Processor"]

--- a/paddleformers/transformers/idefics3/processor.py
+++ b/paddleformers/transformers/idefics3/processor.py
@@ -113,7 +113,9 @@ class Idefics3Processor(ProcessorMixin):
             image_kwargs = output_kwargs["images_kwargs"].copy()
             image_kwargs.pop("return_tensors", None)
             image_inputs = self.image_processor(images, return_tensors=None, **image_kwargs)
-            images_replacements = [self.replace_image_token(image_inputs, idx, image_seq_len) for idx in range(sum(map(len, images)))]
+            images_replacements = [
+                self.replace_image_token(image_inputs, idx, image_seq_len) for idx in range(sum(map(len, images)))
+            ]
             image_inputs.pop("rows", None)
             image_inputs.pop("cols", None)
 
@@ -184,9 +186,7 @@ class Idefics3Processor(ProcessorMixin):
         for row in range(image_rows):
             for col in range(image_cols):
                 text_split_images += (
-                    f"{self.fake_image_token}"
-                    f"<row_{row + 1}_col_{col + 1}>"
-                    f"{self.image_token * image_seq_len}"
+                    f"{self.fake_image_token}" f"<row_{row + 1}_col_{col + 1}>" f"{self.image_token * image_seq_len}"
                 )
             text_split_images += "\n"
         text_split_images += (
@@ -202,9 +202,13 @@ class Idefics3Processor(ProcessorMixin):
         replaced_text = []
         for sample in text:
             while self.image_token in sample:
+                if image_idx >= len(images_replacements):
+                    raise ValueError("The number of image tokens exceeds the available image replacements.")
                 sample = sample.replace(self.image_token, images_replacements[image_idx], 1)
                 image_idx += 1
             replaced_text.append(sample)
+        if image_idx != len(images_replacements):
+            raise ValueError("The number of image replacements does not match the number of image tokens.")
         return replaced_text
 
     def create_mm_token_type_ids(self, input_ids):

--- a/paddleformers/transformers/idefics3/processor.py
+++ b/paddleformers/transformers/idefics3/processor.py
@@ -201,12 +201,18 @@ class Idefics3Processor(ProcessorMixin):
         image_idx = 0
         replaced_text = []
         for sample in text:
-            while self.image_token in sample:
+            parts = sample.split(self.image_token)
+            num_image_tokens = len(parts) - 1
+            if image_idx + num_image_tokens > len(images_replacements):
+                raise ValueError("The number of image tokens exceeds the available image replacements.")
+
+            sample_with_replacements = parts[0]
+            for part in parts[1:]:
                 if image_idx >= len(images_replacements):
                     raise ValueError("The number of image tokens exceeds the available image replacements.")
-                sample = sample.replace(self.image_token, images_replacements[image_idx], 1)
+                sample_with_replacements += images_replacements[image_idx] + part
                 image_idx += 1
-            replaced_text.append(sample)
+            replaced_text.append(sample_with_replacements)
         if image_idx != len(images_replacements):
             raise ValueError("The number of image replacements does not match the number of image tokens.")
         return replaced_text

--- a/paddleformers/transformers/model_utils.py
+++ b/paddleformers/transformers/model_utils.py
@@ -105,6 +105,7 @@ from .utils import (  # convert_ndarray_dtype,
 )
 
 VLMS = [
+    "idefics3",
     "qwen2vl",
     "qwen2_5_vl",
 ]

--- a/tests/transformers/idefics3/__init__.py
+++ b/tests/transformers/idefics3/__init__.py
@@ -1,4 +1,13 @@
 # Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/transformers/idefics3/__init__.py
+++ b/tests/transformers/idefics3/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+

--- a/tests/transformers/idefics3/test_image_processor.py
+++ b/tests/transformers/idefics3/test_image_processor.py
@@ -10,9 +10,11 @@ import paddle
 from PIL import Image
 
 from paddleformers.transformers import AutoImageProcessor, Idefics3ImageProcessor
+from tests.testing_utils import gpu_device_initializer
 
 
 class Idefics3ImageProcessorTest(unittest.TestCase):
+    @gpu_device_initializer(log_prefix="Idefics3ImageProcessorTest", gpu_id=0)
     def setUp(self):
         self.image = Image.fromarray(np.full((8, 10, 3), 127, dtype=np.uint8))
         self.processor = Idefics3ImageProcessor(

--- a/tests/transformers/idefics3/test_image_processor.py
+++ b/tests/transformers/idefics3/test_image_processor.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+
+import tempfile
+import unittest
+
+import numpy as np
+import paddle
+from PIL import Image
+
+from paddleformers.transformers import AutoImageProcessor, Idefics3ImageProcessor
+
+
+class Idefics3ImageProcessorTest(unittest.TestCase):
+    def setUp(self):
+        self.image = Image.fromarray(np.full((8, 10, 3), 127, dtype=np.uint8))
+        self.processor = Idefics3ImageProcessor(
+            size={"longest_edge": 8},
+            max_image_size={"longest_edge": 8},
+            do_image_splitting=False,
+        )
+
+    def test_output_keys_and_shapes(self):
+        inputs = self.processor(self.image, return_tensors="pd")
+
+        self.assertIn("pixel_values", inputs)
+        self.assertIn("pixel_attention_mask", inputs)
+        self.assertEqual(inputs["pixel_values"].shape, [1, 1, 3, 8, 8])
+        self.assertEqual(inputs["pixel_attention_mask"].shape, [1, 1, 8, 8])
+        self.assertEqual(inputs["pixel_values"].dtype, paddle.float32)
+
+    def test_return_row_col_info(self):
+        inputs = self.processor(self.image, return_row_col_info=True)
+
+        self.assertEqual(inputs["rows"], [[0]])
+        self.assertEqual(inputs["cols"], [[0]])
+
+    def test_batch_padding(self):
+        large_image = Image.fromarray(np.full((8, 16, 3), 255, dtype=np.uint8))
+        processor = Idefics3ImageProcessor(
+            size={"longest_edge": 16},
+            max_image_size={"longest_edge": 8},
+            do_image_splitting=True,
+        )
+
+        inputs = processor([self.image, large_image], return_row_col_info=True, return_tensors="pd")
+
+        self.assertEqual(inputs["pixel_values"].shape[0], 1)
+        self.assertGreater(inputs["pixel_values"].shape[1], 2)
+        self.assertEqual(inputs["pixel_attention_mask"].shape[:2], inputs["pixel_values"].shape[:2])
+        self.assertEqual(inputs["rows"], [[2, 1]])
+        self.assertEqual(inputs["cols"], [[2, 2]])
+
+    def test_save_load_with_auto_image_processor(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.processor.save_pretrained(tmpdir)
+            reloaded = AutoImageProcessor.from_pretrained(tmpdir)
+
+        self.assertIsInstance(reloaded, Idefics3ImageProcessor)
+        inputs = reloaded(self.image, return_tensors="pd")
+        self.assertEqual(inputs["pixel_values"].shape, [1, 1, 3, 8, 8])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/transformers/idefics3/test_modeling.py
+++ b/tests/transformers/idefics3/test_modeling.py
@@ -159,7 +159,7 @@ class Idefics3ModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCa
                 expected = model(**self._prepare_for_class(inputs_dict, model_class))[0]
 
             with tempfile.TemporaryDirectory() as tmpdirname:
-                model.save_pretrained(tmpdirname, save_to_hf=False, save_checkpoint_format="")
+                model.save_pretrained(tmpdirname, save_safetensors=False, save_checkpoint_format="")
                 reloaded = model_class.from_pretrained(
                     tmpdirname,
                     convert_from_hf=False,

--- a/tests/transformers/idefics3/test_modeling.py
+++ b/tests/transformers/idefics3/test_modeling.py
@@ -3,6 +3,7 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 from __future__ import annotations
 
+import copy
 import tempfile
 import unittest
 
@@ -14,6 +15,7 @@ from paddleformers.transformers import (
     Idefics3ForConditionalGeneration,
     Idefics3Model,
 )
+from tests.testing_utils import gpu_device_initializer
 from tests.transformers.test_configuration_common import ConfigTester
 from tests.transformers.test_generation_utils import GenerationTesterMixin
 from tests.transformers.test_modeling_common import (
@@ -105,7 +107,9 @@ class Idefics3ModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCa
     max_new_tokens = 3
     has_attentions = False
 
+    @gpu_device_initializer(log_prefix="Idefics3ModelTest", gpu_id=0)
     def setUp(self):
+        super().setUp()
         self.model_tester = Idefics3ModelTester(self)
         self.config_tester = ConfigTester(self, config_class=Idefics3Config, has_text_modality=False)
 
@@ -155,7 +159,7 @@ class Idefics3ModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCa
                 expected = model(**self._prepare_for_class(inputs_dict, model_class))[0]
 
             with tempfile.TemporaryDirectory() as tmpdirname:
-                model.save_pretrained(tmpdirname, save_safetensors=False, save_checkpoint_format="")
+                model.save_pretrained(tmpdirname, save_to_hf=False, save_checkpoint_format="")
                 reloaded = model_class.from_pretrained(
                     tmpdirname,
                     convert_from_hf=False,
@@ -173,10 +177,11 @@ class Idefics3ModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCa
             self.assertLessEqual(np.max(np.abs(expected - actual)), 1e-5)
 
     def test_resize_tokens_embeddings(self):
-        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        original_config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         no_label_inputs = {k: v for k, v in inputs_dict.items() if k != "labels"}
 
         for model_class in self.all_model_classes:
+            config = copy.deepcopy(original_config)
             model = self._make_model_instance(config, model_class).eval()
             old_vocab_size = config.text_config.vocab_size
 
@@ -191,6 +196,9 @@ class Idefics3ModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCa
             model_embed = model.resize_token_embeddings(old_vocab_size - 15)
             self.assertEqual(model.config.text_config.vocab_size, old_vocab_size - 15)
             self.assertEqual(model_embed.weight.shape[0], old_vocab_size - 15)
+
+            # Input ids should be clamped to the maximum size of the reduced vocabulary
+            no_label_inputs["input_ids"] = paddle.clip(no_label_inputs["input_ids"], max=old_vocab_size - 15 - 1)
 
             with paddle.no_grad():
                 outputs = model(**self._prepare_for_class(no_label_inputs, model_class))

--- a/tests/transformers/idefics3/test_modeling.py
+++ b/tests/transformers/idefics3/test_modeling.py
@@ -1,0 +1,284 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+from __future__ import annotations
+
+import unittest
+
+import paddle
+
+from paddleformers.transformers import Idefics3Config, Idefics3ForConditionalGeneration, Idefics3Model
+from tests.transformers.test_configuration_common import ConfigTester
+from tests.transformers.test_generation_utils import GenerationTesterMixin
+from tests.transformers.test_modeling_common import ModelTesterMixin, ModelTesterPretrainedMixin
+
+
+class Idefics3ModelTester:
+    def __init__(
+        self,
+        parent,
+        batch_size=1,
+        seq_length=3,
+        image_token_id=4,
+        pad_token_id=0,
+        hidden_size=16,
+        vocab_size=32,
+    ):
+        self.parent = parent
+        self.batch_size = batch_size
+        self.seq_length = seq_length
+        self.image_token_id = image_token_id
+        self.pad_token_id = pad_token_id
+        self.hidden_size = hidden_size
+        self.vocab_size = vocab_size
+
+    def get_config(self):
+        return Idefics3Config(
+            image_token_id=self.image_token_id,
+            pad_token_id=self.pad_token_id,
+            scale_factor=2,
+            text_config={
+                "model_type": "llama",
+                "hidden_size": self.hidden_size,
+                "intermediate_size": 32,
+                "num_hidden_layers": 1,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "vocab_size": self.vocab_size,
+                "max_position_embeddings": 32,
+                "bos_token_id": 1,
+                "eos_token_id": 2,
+                "pad_token_id": self.pad_token_id,
+            },
+            vision_config={
+                "hidden_size": 8,
+                "intermediate_size": 16,
+                "num_hidden_layers": 1,
+                "num_attention_heads": 2,
+                "image_size": 8,
+                "patch_size": 4,
+            },
+        )
+
+    def prepare_config_and_inputs(self):
+        config = self.get_config()
+        image_hidden_states = paddle.zeros([self.batch_size, 1, config.text_config.hidden_size], dtype="float32")
+        return config, image_hidden_states
+
+    def prepare_config_and_inputs_for_common(self):
+        config, image_hidden_states = self.prepare_config_and_inputs()
+        input_ids = paddle.to_tensor([[1, self.image_token_id, 5]], dtype="int64").expand([self.batch_size, -1])
+        labels = paddle.to_tensor([[-100, -100, 5]], dtype="int64").expand([self.batch_size, -1])
+        attention_mask = paddle.ones(input_ids.shape, dtype="int64")
+
+        inputs_dict = {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "image_hidden_states": image_hidden_states,
+            "labels": labels,
+        }
+        return config, inputs_dict
+
+
+class Idefics3ModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase):
+    """
+    Model tester for `Idefics3ForConditionalGeneration`.
+    """
+
+    base_model_class = Idefics3Model
+    all_model_classes = (Idefics3Model, Idefics3ForConditionalGeneration)
+    all_generative_model_classes = {Idefics3ForConditionalGeneration: {Idefics3Model, "idefics3"}}
+    max_new_tokens = 3
+
+    def setUp(self):
+        self.model_tester = Idefics3ModelTester(self)
+        self.config_tester = ConfigTester(self, config_class=Idefics3Config, has_text_modality=False)
+
+    def _get_logits_processor_kwargs(self, do_sample=False, config=None):
+        logits_processor_kwargs = {
+            "bad_words_ids": [[1, 2]],
+            "repetition_penalty": 1.2,
+            "remove_invalid_values": True,
+        }
+        if do_sample:
+            logits_processor_kwargs.update(
+                {
+                    "top_k": 10,
+                    "top_p": 0.7,
+                    "temperature": 0.7,
+                }
+            )
+        if config is not None and config.image_token_id < config.text_config.vocab_size:
+            logits_processor_kwargs["bad_words_ids"].append([config.image_token_id])
+        return logits_processor_kwargs
+
+    def _greedy_generate(
+        self,
+        model,
+        inputs_dict,
+        output_scores=False,
+        output_logits=False,
+        output_attentions=False,
+        output_hidden_states=False,
+        return_dict_in_generate=False,
+        use_cache=True,
+    ):
+        logits_processor_kwargs = self._get_logits_processor_kwargs(do_sample=False, config=model.config)
+        return model.generate(
+            do_sample=False,
+            num_beams=1,
+            max_new_tokens=self.max_new_tokens,
+            min_new_tokens=self.max_new_tokens,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            output_scores=output_scores,
+            output_logits=output_logits,
+            return_dict_in_generate=return_dict_in_generate,
+            use_cache=use_cache,
+            trunc_input=False,
+            **logits_processor_kwargs,
+            **inputs_dict,
+        )
+
+    def _beam_search_generate(
+        self,
+        model,
+        inputs_dict,
+        beam_kwargs,
+        output_scores=False,
+        output_logits=False,
+        output_attentions=False,
+        output_hidden_states=False,
+        return_dict_in_generate=False,
+        use_cache=True,
+    ):
+        logits_processor_kwargs = self._get_logits_processor_kwargs(do_sample=False, config=model.config)
+        return model.generate(
+            do_sample=False,
+            max_new_tokens=self.max_new_tokens,
+            min_new_tokens=self.max_new_tokens,
+            output_scores=output_scores,
+            output_logits=output_logits,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict_in_generate=return_dict_in_generate,
+            use_cache=use_cache,
+            trunc_input=False,
+            **beam_kwargs,
+            **logits_processor_kwargs,
+            **inputs_dict,
+        )
+
+    def _sample_generate(
+        self,
+        model,
+        inputs_dict,
+        num_return_sequences,
+        output_scores=False,
+        output_logits=False,
+        output_attentions=False,
+        output_hidden_states=False,
+        return_dict_in_generate=False,
+        use_cache=True,
+    ):
+        paddle.seed(0)
+        logits_processor_kwargs = self._get_logits_processor_kwargs(do_sample=True, config=model.config)
+        return model.generate(
+            do_sample=True,
+            num_beams=1,
+            max_new_tokens=self.max_new_tokens,
+            min_new_tokens=self.max_new_tokens,
+            num_return_sequences=num_return_sequences,
+            output_scores=output_scores,
+            output_logits=output_logits,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict_in_generate=return_dict_in_generate,
+            use_cache=use_cache,
+            trunc_input=False,
+            **logits_processor_kwargs,
+            **inputs_dict,
+        )
+
+    def prepare_config_and_inputs_for_generate(self, batch_size=1):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        inputs_dict = {k: v[:batch_size, ...] if isinstance(v, paddle.Tensor) else v for k, v in inputs_dict.items()}
+        inputs_dict.pop("labels", None)
+        config.text_config.eos_token_id = None
+        config.text_config.forced_eos_token_id = None
+        return config, inputs_dict
+
+    def test_config(self):
+        self.config_tester.run_common_tests()
+
+    def test_text_config(self):
+        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+        base_config_dict = config.to_dict()
+        base_config = Idefics3Config(**base_config_dict)
+
+        self.assertEqual(base_config.vocab_size, base_config.text_config.vocab_size)
+        base_config.vocab_size = 55
+        self.assertEqual(base_config.vocab_size, 55)
+        self.assertEqual(base_config.text_config.vocab_size, 55)
+
+    def test_model_forward_with_precomputed_image_features(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        model = Idefics3Model(config)
+        model.eval()
+
+        with paddle.no_grad():
+            outputs = model(
+                input_ids=inputs_dict["input_ids"],
+                attention_mask=inputs_dict["attention_mask"],
+                image_hidden_states=inputs_dict["image_hidden_states"],
+            )
+
+        self.assertEqual(outputs.last_hidden_state.shape, [self.model_tester.batch_size, 3, config.text_config.hidden_size])
+        self.assertEqual(outputs.image_hidden_states.shape, [self.model_tester.batch_size, 1, config.text_config.hidden_size])
+
+    def test_conditional_generation_forward_with_labels(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        model = Idefics3ForConditionalGeneration(config)
+        model.eval()
+
+        with paddle.no_grad():
+            outputs = model(**inputs_dict)
+
+        self.assertEqual(outputs.logits.shape, [self.model_tester.batch_size, 3, config.text_config.vocab_size])
+        self.assertIsNotNone(outputs.loss)
+
+    def test_image_token_count_mismatch_raises(self):
+        config = self.model_tester.get_config()
+        model = Idefics3Model(config)
+
+        input_ids = paddle.to_tensor([[1, self.model_tester.image_token_id, self.model_tester.image_token_id]], dtype="int64")
+        image_hidden_states = paddle.zeros([1, 1, config.text_config.hidden_size], dtype="float32")
+
+        with self.assertRaises(ValueError):
+            model(input_ids=input_ids, image_hidden_states=image_hidden_states)
+
+
+@unittest.skip("Idefics3 tiny checkpoint is not available yet.")
+class Idefics3IntegrationTest(ModelTesterPretrainedMixin, unittest.TestCase):
+    base_model_class = Idefics3ForConditionalGeneration
+    hf_remote_test_model_path = "PaddleFormers/tiny-random-idefics3"
+    paddlehub_remote_test_model_path = "PaddleFormers/tiny-random-idefics3"
+
+    def test_model_from_pretrained_hf_hub(self):
+        super().test_model_from_pretrained_hf_hub()
+
+    def test_model_from_pretrained_paddle_hub(self):
+        super().test_model_from_pretrained_paddle_hub()
+
+    def test_model_from_config_paddle_hub(self):
+        super().test_model_from_config_paddle_hub()
+
+    def test_model_from_pretrained_with_cache_dir(self):
+        super().test_model_from_pretrained_with_cache_dir()
+
+    def test_pretrained_save_and_load(self):
+        super().test_pretrained_save_and_load()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/transformers/idefics3/test_modeling.py
+++ b/tests/transformers/idefics3/test_modeling.py
@@ -3,14 +3,23 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 from __future__ import annotations
 
+import tempfile
 import unittest
 
+import numpy as np
 import paddle
 
-from paddleformers.transformers import Idefics3Config, Idefics3ForConditionalGeneration, Idefics3Model
+from paddleformers.transformers import (
+    Idefics3Config,
+    Idefics3ForConditionalGeneration,
+    Idefics3Model,
+)
 from tests.transformers.test_configuration_common import ConfigTester
 from tests.transformers.test_generation_utils import GenerationTesterMixin
-from tests.transformers.test_modeling_common import ModelTesterMixin, ModelTesterPretrainedMixin
+from tests.transformers.test_modeling_common import (
+    ModelTesterMixin,
+    ModelTesterPretrainedMixin,
+)
 
 
 class Idefics3ModelTester:
@@ -19,17 +28,21 @@ class Idefics3ModelTester:
         parent,
         batch_size=1,
         seq_length=3,
+        is_training=False,
         image_token_id=4,
         pad_token_id=0,
         hidden_size=16,
+        num_hidden_layers=1,
         vocab_size=32,
     ):
         self.parent = parent
         self.batch_size = batch_size
         self.seq_length = seq_length
+        self.is_training = is_training
         self.image_token_id = image_token_id
         self.pad_token_id = pad_token_id
         self.hidden_size = hidden_size
+        self.num_hidden_layers = num_hidden_layers
         self.vocab_size = vocab_size
 
     def get_config(self):
@@ -41,7 +54,7 @@ class Idefics3ModelTester:
                 "model_type": "llama",
                 "hidden_size": self.hidden_size,
                 "intermediate_size": 32,
-                "num_hidden_layers": 1,
+                "num_hidden_layers": self.num_hidden_layers,
                 "num_attention_heads": 4,
                 "num_key_value_heads": 2,
                 "vocab_size": self.vocab_size,
@@ -49,6 +62,7 @@ class Idefics3ModelTester:
                 "bos_token_id": 1,
                 "eos_token_id": 2,
                 "pad_token_id": self.pad_token_id,
+                "fuse_rms_norm": False,
             },
             vision_config={
                 "hidden_size": 8,
@@ -89,6 +103,7 @@ class Idefics3ModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCa
     all_model_classes = (Idefics3Model, Idefics3ForConditionalGeneration)
     all_generative_model_classes = {Idefics3ForConditionalGeneration: {Idefics3Model, "idefics3"}}
     max_new_tokens = 3
+    has_attentions = False
 
     def setUp(self):
         self.model_tester = Idefics3ModelTester(self)
@@ -112,94 +127,6 @@ class Idefics3ModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCa
             logits_processor_kwargs["bad_words_ids"].append([config.image_token_id])
         return logits_processor_kwargs
 
-    def _greedy_generate(
-        self,
-        model,
-        inputs_dict,
-        output_scores=False,
-        output_logits=False,
-        output_attentions=False,
-        output_hidden_states=False,
-        return_dict_in_generate=False,
-        use_cache=True,
-    ):
-        logits_processor_kwargs = self._get_logits_processor_kwargs(do_sample=False, config=model.config)
-        return model.generate(
-            do_sample=False,
-            num_beams=1,
-            max_new_tokens=self.max_new_tokens,
-            min_new_tokens=self.max_new_tokens,
-            output_attentions=output_attentions,
-            output_hidden_states=output_hidden_states,
-            output_scores=output_scores,
-            output_logits=output_logits,
-            return_dict_in_generate=return_dict_in_generate,
-            use_cache=use_cache,
-            trunc_input=False,
-            **logits_processor_kwargs,
-            **inputs_dict,
-        )
-
-    def _beam_search_generate(
-        self,
-        model,
-        inputs_dict,
-        beam_kwargs,
-        output_scores=False,
-        output_logits=False,
-        output_attentions=False,
-        output_hidden_states=False,
-        return_dict_in_generate=False,
-        use_cache=True,
-    ):
-        logits_processor_kwargs = self._get_logits_processor_kwargs(do_sample=False, config=model.config)
-        return model.generate(
-            do_sample=False,
-            max_new_tokens=self.max_new_tokens,
-            min_new_tokens=self.max_new_tokens,
-            output_scores=output_scores,
-            output_logits=output_logits,
-            output_attentions=output_attentions,
-            output_hidden_states=output_hidden_states,
-            return_dict_in_generate=return_dict_in_generate,
-            use_cache=use_cache,
-            trunc_input=False,
-            **beam_kwargs,
-            **logits_processor_kwargs,
-            **inputs_dict,
-        )
-
-    def _sample_generate(
-        self,
-        model,
-        inputs_dict,
-        num_return_sequences,
-        output_scores=False,
-        output_logits=False,
-        output_attentions=False,
-        output_hidden_states=False,
-        return_dict_in_generate=False,
-        use_cache=True,
-    ):
-        paddle.seed(0)
-        logits_processor_kwargs = self._get_logits_processor_kwargs(do_sample=True, config=model.config)
-        return model.generate(
-            do_sample=True,
-            num_beams=1,
-            max_new_tokens=self.max_new_tokens,
-            min_new_tokens=self.max_new_tokens,
-            num_return_sequences=num_return_sequences,
-            output_scores=output_scores,
-            output_logits=output_logits,
-            output_attentions=output_attentions,
-            output_hidden_states=output_hidden_states,
-            return_dict_in_generate=return_dict_in_generate,
-            use_cache=use_cache,
-            trunc_input=False,
-            **logits_processor_kwargs,
-            **inputs_dict,
-        )
-
     def prepare_config_and_inputs_for_generate(self, batch_size=1):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         inputs_dict = {k: v[:batch_size, ...] if isinstance(v, paddle.Tensor) else v for k, v in inputs_dict.items()}
@@ -209,7 +136,65 @@ class Idefics3ModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCa
         return config, inputs_dict
 
     def test_config(self):
-        self.config_tester.run_common_tests()
+        self.config_tester.create_and_test_config_to_json_string()
+        self.config_tester.create_and_test_config_to_json_file()
+        self.config_tester.create_and_test_config_from_and_save_pretrained()
+        self.config_tester.check_config_can_be_init_without_params()
+        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+        base_config = Idefics3Config(**config.to_dict())
+        self.assertEqual(base_config.vocab_size, base_config.text_config.vocab_size)
+        self.assertEqual(base_config.vision_config.model_type, "idefics3_vision")
+        self.assertEqual(base_config.text_config.model_type, "llama")
+
+    def test_save_load(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            model = self._make_model_instance(config, model_class).eval()
+            with paddle.no_grad():
+                expected = model(**self._prepare_for_class(inputs_dict, model_class))[0]
+
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                model.save_pretrained(tmpdirname, save_safetensors=False, save_checkpoint_format="")
+                reloaded = model_class.from_pretrained(
+                    tmpdirname,
+                    convert_from_hf=False,
+                    load_checkpoint_format="",
+                    key_mapping={r"^(.*)$": r"\1"},
+                ).eval()
+
+                with paddle.no_grad():
+                    actual = reloaded(**self._prepare_for_class(inputs_dict, model_class))[0]
+
+            expected = expected.numpy()
+            actual = actual.numpy()
+            expected[np.isnan(expected)] = 0
+            actual[np.isnan(actual)] = 0
+            self.assertLessEqual(np.max(np.abs(expected - actual)), 1e-5)
+
+    def test_resize_tokens_embeddings(self):
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        no_label_inputs = {k: v for k, v in inputs_dict.items() if k != "labels"}
+
+        for model_class in self.all_model_classes:
+            model = self._make_model_instance(config, model_class).eval()
+            old_vocab_size = config.text_config.vocab_size
+
+            model_embed = model.resize_token_embeddings(old_vocab_size + 10)
+            self.assertEqual(model.config.text_config.vocab_size, old_vocab_size + 10)
+            self.assertEqual(model_embed.weight.shape[0], old_vocab_size + 10)
+
+            with paddle.no_grad():
+                outputs = model(**self._prepare_for_class(no_label_inputs, model_class))
+            self.assertIsInstance(outputs[0], paddle.Tensor)
+
+            model_embed = model.resize_token_embeddings(old_vocab_size - 15)
+            self.assertEqual(model.config.text_config.vocab_size, old_vocab_size - 15)
+            self.assertEqual(model_embed.weight.shape[0], old_vocab_size - 15)
+
+            with paddle.no_grad():
+                outputs = model(**self._prepare_for_class(no_label_inputs, model_class))
+            self.assertIsInstance(outputs[0], paddle.Tensor)
 
     def test_text_config(self):
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
@@ -233,8 +218,12 @@ class Idefics3ModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCa
                 image_hidden_states=inputs_dict["image_hidden_states"],
             )
 
-        self.assertEqual(outputs.last_hidden_state.shape, [self.model_tester.batch_size, 3, config.text_config.hidden_size])
-        self.assertEqual(outputs.image_hidden_states.shape, [self.model_tester.batch_size, 1, config.text_config.hidden_size])
+        self.assertEqual(
+            outputs.last_hidden_state.shape, [self.model_tester.batch_size, 3, config.text_config.hidden_size]
+        )
+        self.assertEqual(
+            outputs.image_hidden_states.shape, [self.model_tester.batch_size, 1, config.text_config.hidden_size]
+        )
 
     def test_conditional_generation_forward_with_labels(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
@@ -251,11 +240,102 @@ class Idefics3ModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCa
         config = self.model_tester.get_config()
         model = Idefics3Model(config)
 
-        input_ids = paddle.to_tensor([[1, self.model_tester.image_token_id, self.model_tester.image_token_id]], dtype="int64")
+        input_ids = paddle.to_tensor(
+            [[1, self.model_tester.image_token_id, self.model_tester.image_token_id]], dtype="int64"
+        )
         image_hidden_states = paddle.zeros([1, 1, config.text_config.hidden_size], dtype="float32")
 
         with self.assertRaises(ValueError):
             model(input_ids=input_ids, image_hidden_states=image_hidden_states)
+
+    def test_greedy_generate(self):
+        for model_class in self.all_generative_model_classes:
+            config, inputs_dict = self.prepare_config_and_inputs_for_generate()
+            model = model_class(config).eval()
+
+            outputs = model.generate(
+                do_sample=False,
+                num_beams=1,
+                max_new_tokens=self.max_new_tokens,
+                min_new_tokens=self.max_new_tokens,
+                return_dict_in_generate=False,
+                use_cache=True,
+                trunc_input=False,
+                **self._get_logits_processor_kwargs(do_sample=False, config=model.config),
+                **inputs_dict,
+            )
+
+            self.assertEqual(outputs[0].shape[0], inputs_dict["input_ids"].shape[0])
+            self.assertEqual(outputs[0].shape[1], inputs_dict["input_ids"].shape[1] + self.max_new_tokens)
+
+    def test_beam_search_generate(self):
+        for model_class in self.all_generative_model_classes:
+            config, inputs_dict = self.prepare_config_and_inputs_for_generate()
+            model = model_class(config).eval()
+
+            outputs = model.generate(
+                do_sample=False,
+                decode_strategy="beam_search",
+                num_beams=2,
+                num_return_sequences=2,
+                max_new_tokens=self.max_new_tokens,
+                min_new_tokens=self.max_new_tokens,
+                return_dict_in_generate=False,
+                use_cache=True,
+                trunc_input=False,
+                **self._get_logits_processor_kwargs(do_sample=False, config=model.config),
+                **inputs_dict,
+            )
+
+            self.assertEqual(outputs[0].shape[0], inputs_dict["input_ids"].shape[0] * 2)
+            self.assertEqual(outputs[0].shape[1], inputs_dict["input_ids"].shape[1] + self.max_new_tokens)
+
+    def test_group_beam_search_generate(self):
+        for model_class in self.all_generative_model_classes:
+            config, inputs_dict = self.prepare_config_and_inputs_for_generate()
+            model = model_class(config).eval()
+
+            outputs = model.generate(
+                do_sample=False,
+                decode_strategy="beam_search",
+                num_beams=2,
+                num_beam_groups=2,
+                num_return_sequences=2,
+                diversity_rate=2.0,
+                max_new_tokens=self.max_new_tokens,
+                min_new_tokens=self.max_new_tokens,
+                return_dict_in_generate=False,
+                use_cache=True,
+                trunc_input=False,
+                **self._get_logits_processor_kwargs(do_sample=False, config=model.config),
+                **inputs_dict,
+            )
+
+            self.assertEqual(outputs[0].shape[0], inputs_dict["input_ids"].shape[0] * 2)
+            self.assertEqual(outputs[0].shape[1], inputs_dict["input_ids"].shape[1] + self.max_new_tokens)
+
+    def test_sample_generate(self):
+        for model_class in self.all_generative_model_classes:
+            config, inputs_dict = self.prepare_config_and_inputs_for_generate()
+            model = model_class(config).eval()
+
+            paddle.seed(0)
+            outputs = model.generate(
+                do_sample=True,
+                decode_strategy="sampling",
+                num_beams=1,
+                num_return_sequences=2,
+                max_new_tokens=self.max_new_tokens,
+                min_new_tokens=self.max_new_tokens,
+                return_dict_in_generate=False,
+                use_cache=True,
+                trunc_input=False,
+                **self._get_logits_processor_kwargs(do_sample=True, config=model.config),
+                **inputs_dict,
+            )
+
+            self.assertEqual(outputs[0].shape[0], inputs_dict["input_ids"].shape[0] * 2)
+            self.assertEqual(outputs[0].shape[1], inputs_dict["input_ids"].shape[1] + self.max_new_tokens)
 
 
 @unittest.skip("Idefics3 tiny checkpoint is not available yet.")

--- a/tests/transformers/idefics3/test_processor.py
+++ b/tests/transformers/idefics3/test_processor.py
@@ -9,38 +9,33 @@ import unittest
 
 import paddle
 
-from paddleformers.transformers import (
-    AutoProcessor,
-    AutoTokenizer,
-    Idefics3ImageProcessor,
-    Idefics3Processor,
-)
+from paddleformers.transformers import AutoProcessor, Idefics3Processor
+from tests.testing_utils import gpu_device_initializer
 from tests.transformers.test_processing_common import ProcessorTesterMixin
 
 
+@unittest.skip("Idefics3 tiny checkpoint is not available yet.")
 class Idefics3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Idefics3Processor
+    model_path = "PaddleFormers/tiny-random-idefics3"
 
     @classmethod
     def setUpClass(cls):
         cls.tmpdir = tempfile.mkdtemp()
-        tokenizer = AutoTokenizer.from_pretrained("Paddleformers/tiny-random-llama")
-        tokenizer.add_special_tokens(
-            {
-                "additional_special_tokens": [
-                    "<global-img>",
-                    *[f"<row_{row}_col_{col}>" for row in range(1, 7) for col in range(1, 7)],
-                ]
-            }
-        )
-        image_processor = Idefics3ImageProcessor(
+        processor = Idefics3Processor.from_pretrained(
+            cls.model_path,
             size={"longest_edge": 8},
             max_image_size={"longest_edge": 8},
             do_image_splitting=False,
+            image_seq_len=4,
         )
-        processor = Idefics3Processor(tokenizer=tokenizer, image_processor=image_processor, image_seq_len=4)
         processor.save_pretrained(cls.tmpdir)
         cls.image_token = processor.image_token
+
+    # Use GPU 0 to prevent CUDA illegal memory access during resize
+    @gpu_device_initializer(log_prefix="Idefics3ProcessorTest", gpu_id=0)
+    def setUp(self):
+        pass
 
     def get_tokenizer(self, **kwargs):
         return AutoProcessor.from_pretrained(self.tmpdir, **kwargs).tokenizer

--- a/tests/transformers/idefics3/test_processor.py
+++ b/tests/transformers/idefics3/test_processor.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+from __future__ import annotations
+
+import shutil
+import tempfile
+import unittest
+
+import paddle
+
+from paddleformers.transformers import AutoProcessor, AutoTokenizer, Idefics3ImageProcessor, Idefics3Processor
+from tests.transformers.test_processing_common import ProcessorTesterMixin
+
+
+class Idefics3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
+    processor_class = Idefics3Processor
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdir = tempfile.mkdtemp()
+        tokenizer = AutoTokenizer.from_pretrained("Paddleformers/tiny-random-llama")
+        tokenizer.add_special_tokens(
+            {
+                "additional_special_tokens": [
+                    "<global-img>",
+                    *[f"<row_{row}_col_{col}>" for row in range(1, 7) for col in range(1, 7)],
+                ]
+            }
+        )
+        image_processor = Idefics3ImageProcessor(
+            size={"longest_edge": 8},
+            max_image_size={"longest_edge": 8},
+            do_image_splitting=False,
+        )
+        processor = Idefics3Processor(tokenizer=tokenizer, image_processor=image_processor, image_seq_len=4)
+        processor.save_pretrained(cls.tmpdir)
+        cls.image_token = processor.image_token
+
+    def get_tokenizer(self, **kwargs):
+        return AutoProcessor.from_pretrained(self.tmpdir, **kwargs).tokenizer
+
+    def get_image_processor(self, **kwargs):
+        return AutoProcessor.from_pretrained(self.tmpdir, **kwargs).image_processor
+
+    def get_processor(self, **kwargs):
+        return AutoProcessor.from_pretrained(self.tmpdir, **kwargs)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmpdir, ignore_errors=True)
+
+    def test_model_input_names(self):
+        processor = self.get_processor()
+        text = self.prepare_text_inputs(modalities=["image"])
+        image_input = self.prepare_image_inputs()
+
+        inputs = processor(text=text, images=image_input, return_tensors="pd")
+
+        self.assertSetEqual(set(inputs.keys()), set(processor.model_input_names))
+
+    def test_get_num_vision_tokens(self):
+        processor = self.get_processor()
+
+        output = processor._get_num_multimodal_tokens(image_sizes=[(8, 8), (16, 8)])
+
+        self.assertTrue("num_image_tokens" in output)
+        self.assertEqual(len(output["num_image_tokens"]), 2)
+        self.assertTrue("num_image_patches" in output)
+        self.assertEqual(len(output["num_image_patches"]), 2)
+
+    def test_save_load_pretrained_default(self):
+        tokenizer = self.get_tokenizer()
+        image_processor = self.get_image_processor()
+
+        processor = Idefics3Processor(tokenizer=tokenizer, image_processor=image_processor, image_seq_len=4)
+        processor.save_pretrained(self.tmpdir)
+        processor = Idefics3Processor.from_pretrained(self.tmpdir)
+
+        self.assertEqual(processor.tokenizer.get_vocab(), tokenizer.get_vocab())
+        self.assertEqual(processor.image_processor.to_json_string(), image_processor.to_json_string())
+        self.assertEqual(processor.image_processor.__class__.__name__, "Idefics3ImageProcessor")
+
+    def test_image_processor(self):
+        image_processor = self.get_image_processor()
+        tokenizer = self.get_tokenizer()
+        processor = Idefics3Processor(tokenizer=tokenizer, image_processor=image_processor, image_seq_len=4)
+
+        image_input = self.prepare_image_inputs()
+        input_image_proc = image_processor(image_input, return_tensors="pd")
+        input_processor = processor(images=image_input, text="dummy <image>", return_tensors="pd")
+
+        self.assertTrue(paddle.allclose(input_image_proc["pixel_values"], input_processor["pixel_values"]))
+        self.assertTrue(
+            paddle.equal_all(input_image_proc["pixel_attention_mask"], input_processor["pixel_attention_mask"])
+        )
+
+    def test_processor(self):
+        processor = self.get_processor()
+        image_input = self.prepare_image_inputs()
+
+        inputs = processor(text="lower newer <image>", images=image_input, return_tensors="pd")
+
+        self.assertListEqual(list(inputs.keys()), ["input_ids", "attention_mask", "pixel_values", "pixel_attention_mask"])
+
+        with self.assertRaises(ValueError):
+            processor()
+
+        with self.assertRaises(ValueError):
+            processor(images=image_input, return_tensors="pd")
+
+    def test_replace_image_token_without_split(self):
+        processor = self.get_processor()
+        image_inputs = {"rows": [[0]], "cols": [[0]]}
+
+        replacement = processor.replace_image_token(image_inputs, image_idx=0, image_seq_len=3)
+
+        self.assertEqual(
+            replacement,
+            "<fake_token_around_image><global-img><image><image><image><fake_token_around_image>",
+        )
+
+    def test_replace_image_token_with_split(self):
+        processor = self.get_processor()
+        image_inputs = {"rows": [[1]], "cols": [[2]]}
+
+        replacement = processor.replace_image_token(image_inputs, image_idx=0, image_seq_len=2)
+
+        self.assertIn("<row_1_col_1><image><image>", replacement)
+        self.assertIn("<row_1_col_2><image><image>", replacement)
+        self.assertTrue(replacement.endswith("<global-img><image><image><fake_token_around_image>"))
+
+    def test_get_text_with_replacements(self):
+        processor = self.get_processor()
+        text = ["a <image> b", "c <image> d"]
+        replacements = ["first", "second"]
+
+        replaced = processor.get_text_with_replacements(text, replacements)
+
+        self.assertEqual(replaced, ["a first b", "c second d"])
+
+    def test_validate_inputs_checks_image_count(self):
+        processor = self.get_processor()
+        with self.assertRaises(ValueError):
+            processor.validate_inputs(images=[["img"]], text=["<image> <image>"])
+
+    def test_create_mm_token_type_ids(self):
+        processor = self.get_processor()
+        image_token_id = processor.image_token_id
+        token_type_ids = processor.create_mm_token_type_ids([[1, image_token_id, 2, image_token_id]])
+
+        self.assertEqual(token_type_ids, [[0, 1, 0, 1]])
+
+    @unittest.skip("Idefics3ImageProcessor does not support rescale_factor.")
+    def test_image_processor_defaults_preserved_by_image_kwargs(self):
+        pass
+
+    @unittest.skip("Idefics3ImageProcessor does not support rescale_factor.")
+    def test_kwargs_overrides_default_image_processor_kwargs(self):
+        pass
+
+    @unittest.skip("Idefics3ImageProcessor does not support rescale_factor.")
+    def test_unstructured_kwargs(self):
+        pass
+
+    @unittest.skip("Idefics3ImageProcessor does not support rescale_factor.")
+    def test_unstructured_kwargs_batched(self):
+        pass
+
+    @unittest.skip("Idefics3ImageProcessor does not support rescale_factor.")
+    def test_doubly_passed_kwargs(self):
+        pass
+
+    @unittest.skip("Idefics3ImageProcessor does not support rescale_factor.")
+    def test_structured_kwargs_nested(self):
+        pass
+
+    @unittest.skip("Idefics3ImageProcessor does not support rescale_factor.")
+    def test_structured_kwargs_nested_from_dict(self):
+        pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/transformers/idefics3/test_processor.py
+++ b/tests/transformers/idefics3/test_processor.py
@@ -9,7 +9,12 @@ import unittest
 
 import paddle
 
-from paddleformers.transformers import AutoProcessor, AutoTokenizer, Idefics3ImageProcessor, Idefics3Processor
+from paddleformers.transformers import (
+    AutoProcessor,
+    AutoTokenizer,
+    Idefics3ImageProcessor,
+    Idefics3Processor,
+)
 from tests.transformers.test_processing_common import ProcessorTesterMixin
 
 
@@ -101,7 +106,9 @@ class Idefics3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
         inputs = processor(text="lower newer <image>", images=image_input, return_tensors="pd")
 
-        self.assertListEqual(list(inputs.keys()), ["input_ids", "attention_mask", "pixel_values", "pixel_attention_mask"])
+        self.assertListEqual(
+            list(inputs.keys()), ["input_ids", "attention_mask", "pixel_values", "pixel_attention_mask"]
+        )
 
         with self.assertRaises(ValueError):
             processor()
@@ -138,6 +145,15 @@ class Idefics3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         replaced = processor.get_text_with_replacements(text, replacements)
 
         self.assertEqual(replaced, ["a first b", "c second d"])
+
+    def test_get_text_with_replacements_checks_replacement_count(self):
+        processor = self.get_processor()
+
+        with self.assertRaises(ValueError):
+            processor.get_text_with_replacements(["a <image> b"], [])
+
+        with self.assertRaises(ValueError):
+            processor.get_text_with_replacements(["a b"], ["unused"])
 
     def test_validate_inputs_checks_image_count(self):
         processor = self.get_processor()


### PR DESCRIPTION
# Add Idefics3
添加了idefics3模型的PaddlePaddle 实现，包含模型代码、配置文件、单元测试。
# 对齐验证
## 精度对齐
前 20 个 token 的 logits 对齐结果如下：
* mean diff:  2.125230e-06 
* max diff:   2.622604e-05
token完全一致


## 训练loss对齐
### 训练数据
文本数据
* GSM8K SFT 数据
* 训练步数：300 steps
<img width="1600" height="880" alt="1_idefics3" src="https://github.com/user-attachments/assets/129bf98c-5347-4931-8361-25af08a3c480" />


多模态数据
### 训练结果

<img width="1600" height="880" alt="vl_idefics3" src="https://github.com/user-attachments/assets/4ea41883-187c-4a74-87b0-68e974852087" />

<img width="1600" height="880" alt="vl_idefics3_diff" src="https://github.com/user-attachments/assets/5bb591b5-481d-4eb0-882a-7faaf5ec89f9" />
