### PR TITLE
[Deps] Update PaddleFleet to d62f6d86d38

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,7 @@ try:
         install_requires=REQUIRED_PACKAGES,
         entry_points={"console_scripts": get_console_scripts()},
         extras_require={
-            "paddlefleet": ["paddlefleet==0.4.0.post20260821+4ba2429256b"],
+            "paddlefleet": ["paddlefleet==0.4.0.post20260825+d62f6d86d38"],
         },
         python_requires=">=3.8",
         classifiers=[


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description

Update the optional PaddleFleet dependency on `develop` from `paddlefleet==0.4.0.post20260821+4ba2429256b` to `paddlefleet==0.4.0.post20260825+d62f6d86d38`.

The dependency resolves to PaddleFleet commit [`d62f6d86d3860ebd7008efb84ff969eebce0195e`](https://github.com/PaddlePaddle/PaddleFleet/commit/d62f6d86d3860ebd7008efb84ff969eebce0195e) on the live `release/0.4` branch.

The matching official CUDA 12.9 nightly wheel is [`paddlefleet-0.4.0.post20260825+d62f6d86d38-py3-none-any.whl`](https://paddle-whl.bj.bcebos.com/nightly/cu129/paddlefleet/paddlefleet-0.4.0.post20260825%2Bd62f6d86d38-py3-none-any.whl). Its `METADATA` reports version `0.4.0.post20260825+d62f6d86d38` and its generated version file records the full Fleet commit. The exact wheel is available on the official `cu126`, `cu129`, `cu130`, and `cu132` nightly indexes.

No source compatibility adjustment is needed; this keeps the existing `setup.py` `extras_require.paddlefleet` single-line convention.

### Validation

- Confirmed PaddleFleet `release/0.4` resolves to `d62f6d86d3860ebd7008efb84ff969eebce0195e` via live remote refs and GitHub API.
- Confirmed the official CUDA 12.9 wheel HTTP 200, metadata version, and embedded full commit; the exact wheel is available on all four nightly indexes.
- `python3 -m py_compile setup.py scripts/ci_utils/get_fleet_commit.py`
- `python3 scripts/ci_utils/get_fleet_commit.py` -> `d62f6d86d38`
- `pre-commit run --files setup.py`
- Exact one-file/one-line delta review and `git diff --check` pass.
