### PR TITLE
[Quantization] Support model-defined HF quantized checkpoint loading

### DIFF
--- a/paddleformers/quantization/__init__.py
+++ b/paddleformers/quantization/__init__.py
@@ -37,6 +37,7 @@ import_structure = {
     ],
     "hf_checkpoint": [
         "build_hf_dequant_load_transform",
+        "hf_checkpoint_is_quantized",
     ],
     "qat_utils": [
         "QMIN_QMAX_MAPPING",

--- a/paddleformers/quantization/__init__.py
+++ b/paddleformers/quantization/__init__.py
@@ -29,7 +29,15 @@ import_structure = {
         "cal_abs_max_channel",
         "qdq_weight",
     ],
-    "hadamard_utils": ["matmul_hadU", "create_hadamard_matrix", "hadamard_matmul", "apply_hadamard_matmul"],
+    "hadamard_utils": [
+        "matmul_hadU",
+        "create_hadamard_matrix",
+        "hadamard_matmul",
+        "apply_hadamard_matmul",
+    ],
+    "hf_checkpoint": [
+        "build_hf_dequant_load_transform",
+    ],
     "qat_utils": [
         "QMIN_QMAX_MAPPING",
         "quantize",
@@ -46,7 +54,11 @@ import_structure = {
         "qlora_weight_quantize_dequantize",
         "qlora_weight_linear",
     ],
-    "quantization_config": ["quant_inference_mapping", "fp8_format_mapping", "QuantizationConfig"],
+    "quantization_config": [
+        "quant_inference_mapping",
+        "fp8_format_mapping",
+        "QuantizationConfig",
+    ],
     "quantization_linear": [
         "QuantMapping",
         "quant_weight_forward",
@@ -66,7 +78,10 @@ import_structure = {
         "convert_to_quantize_state_dict",
         "update_loaded_state_dict_keys",
     ],
-    "unified_checkpoint_quantization": ["dequant_unified_optimizer", "quant_unified_optimizer"],
+    "unified_checkpoint_quantization": [
+        "dequant_unified_optimizer",
+        "quant_unified_optimizer",
+    ],
 }
 
 if TYPE_CHECKING:

--- a/paddleformers/quantization/checkpoint_dequant.py
+++ b/paddleformers/quantization/checkpoint_dequant.py
@@ -1,0 +1,388 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import math
+from typing import Protocol
+
+import paddle
+
+# -----------------------------------------------------------------------------
+# Dequantizer contract
+# -----------------------------------------------------------------------------
+
+
+class CheckpointDequantizer(Protocol):
+    method: str
+    value_formats: frozenset[str]
+    scale_formats: frozenset[str]
+    value_format: str | None
+    scale_format: str | None
+    block_axes: tuple[int, ...] | None
+    block_shape: tuple[int, ...] | None
+
+    def configure_formats(self, value_format: str, scale_format: str) -> "CheckpointDequantizer":
+        ...
+
+    def configure_geometry(
+        self,
+        block_axes: tuple[int, ...],
+        block_shape: tuple[int, ...],
+    ) -> "CheckpointDequantizer":
+        ...
+
+    def logical_shape(self, physical_shape: tuple[int, ...]) -> tuple[int, ...]:
+        ...
+
+    def physical_qweight_shape(self, logical_shape: tuple[int, ...]) -> tuple[int, ...]:
+        ...
+
+    def physical_qweight_slice(
+        self,
+        global_offset: tuple[int, ...],
+        local_shape: tuple[int, ...],
+    ) -> tuple[tuple[int, ...], tuple[int, ...]]:
+        ...
+
+    def logical_shard_is_aligned(
+        self,
+        global_shape: tuple[int, ...],
+        local_shape: tuple[int, ...],
+        global_offset: tuple[int, ...],
+    ) -> bool:
+        ...
+
+    def dequantize(
+        self,
+        components: dict[str, paddle.Tensor],
+        output_dtype: paddle.dtype,
+    ) -> paddle.Tensor:
+        ...
+
+
+# -----------------------------------------------------------------------------
+# Raw checkpoint decoding helpers
+# -----------------------------------------------------------------------------
+
+
+def _build_e4m3_lut() -> tuple[float, ...]:
+    values = []
+    for code in range(256):
+        exponent = (code >> 3) & 0xF
+        mantissa = code & 0x7
+        if exponent == 0xF and mantissa == 0x7:
+            values.append(float("nan"))
+            continue
+        magnitude = mantissa * 2.0**-9 if exponent == 0 else (1.0 + mantissa / 8.0) * 2.0 ** (exponent - 7)
+        values.append(-magnitude if code & 0x80 else magnitude)
+    return tuple(values)
+
+
+_E4M3_LUT = _build_e4m3_lut()
+_UE8M0_LUT = tuple(float("inf") if exponent == 255 else 2.0 ** (exponent - 127) for exponent in range(256))
+
+
+def _dtype_name(tensor: paddle.Tensor) -> str:
+    return str(tensor.dtype).split(".")[-1].lower()
+
+
+def _as_uint8_codes(tensor: paddle.Tensor, component_name: str) -> paddle.Tensor:
+    dtype = _dtype_name(tensor)
+    if dtype not in {"uint8", "int8"}:
+        raise TypeError(
+            f"{component_name} must use raw uint8/int8 storage, got {tensor.dtype}. "
+            "The Paddle safetensors reader must preserve unsupported 8-bit formats as raw bytes."
+        )
+    return tensor.astype("uint8").astype("int32")
+
+
+def _decode_e4m3(tensor: paddle.Tensor) -> paddle.Tensor:
+    dtype = _dtype_name(tensor)
+    if "float8_e4m3" in dtype:
+        return tensor.astype("float32")
+
+    raw = _as_uint8_codes(tensor, "qweight")
+    lut = paddle.to_tensor(_E4M3_LUT, dtype="float32", place=tensor.place)
+    return paddle.gather(lut, raw.flatten()).reshape(raw.shape)
+
+
+def _decode_ue8m0(tensor: paddle.Tensor) -> paddle.Tensor:
+    if "float8_e8m0" in _dtype_name(tensor) or "e8m0" in _dtype_name(tensor):
+        return tensor.astype("float32")
+    raw = _as_uint8_codes(tensor, "scale")
+    lut = paddle.to_tensor(_UE8M0_LUT, dtype="float32", place=tensor.place)
+    return paddle.gather(lut, raw.flatten()).reshape(raw.shape)
+
+
+def _decode_e2m1_packed(tensor: paddle.Tensor) -> paddle.Tensor:
+    raw = _as_uint8_codes(tensor, "qweight")
+    low = paddle.bitwise_and(raw, paddle.full_like(raw, 0xF))
+    high = paddle.bitwise_and(paddle.bitwise_right_shift(raw, paddle.full_like(raw, 4)), paddle.full_like(raw, 0xF))
+    codes = paddle.stack([low, high], axis=-1).reshape([*tensor.shape[:-1], tensor.shape[-1] * 2])
+    lut = paddle.to_tensor(
+        [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
+        dtype="float32",
+        place=tensor.place,
+    )
+    return paddle.gather(lut, codes.flatten()).reshape(codes.shape)
+
+
+def _require_components(components: dict[str, paddle.Tensor], required: set[str]) -> None:
+    missing = required - set(components)
+    if missing:
+        raise KeyError(f"Missing checkpoint quantization components: {sorted(missing)}.")
+
+
+def _expand_scale_grid(
+    scales: paddle.Tensor,
+    logical_shape: tuple[int, ...],
+    block_axes: tuple[int, ...],
+    block_shape: tuple[int, ...],
+) -> paddle.Tensor:
+    if len(scales.shape) != len(logical_shape):
+        raise ValueError(
+            f"Scale rank must match logical weight rank: scale={tuple(scales.shape)}, logical={logical_shape}."
+        )
+
+    axis_to_block = dict(zip(block_axes, block_shape))
+    expected_scale_shape = tuple(
+        math.ceil(dim / axis_to_block[axis]) if axis in axis_to_block else dim
+        for axis, dim in enumerate(logical_shape)
+    )
+    if tuple(scales.shape) != expected_scale_shape:
+        raise ValueError(
+            f"Invalid scale grid shape: expected {expected_scale_shape}, got {tuple(scales.shape)} "
+            f"for logical shape {logical_shape}."
+        )
+
+    expanded = scales
+    for axis, block_size in sorted(axis_to_block.items()):
+        expanded = paddle.repeat_interleave(expanded, repeats=block_size, axis=axis)
+    slices = tuple(slice(0, dim) for dim in logical_shape)
+    return expanded[slices]
+
+
+def _decode_scales(scale: paddle.Tensor, scale_format: str) -> paddle.Tensor:
+    scale_format = scale_format.strip().lower()
+    if scale_format in {"ue8m0", "e8m0", "float8_e8m0"}:
+        return _decode_ue8m0(scale)
+    if scale_format in {"float", "fp16", "fp32", "bf16", "float16", "float32", "bfloat16"}:
+        return scale.astype("float32")
+    raise ValueError(f"Unsupported scale_format {scale_format!r}.")
+
+
+# -----------------------------------------------------------------------------
+# Configured dequantizer implementations
+# -----------------------------------------------------------------------------
+
+
+class _ConfiguredCheckpointDequantizer:
+    """Common configured state and geometry behavior for concrete methods."""
+
+    method = ""
+    value_formats = frozenset()
+    scale_formats = frozenset()
+
+    def __init__(
+        self,
+        value_format: str | None = None,
+        scale_format: str | None = None,
+        block_axes: tuple[int, ...] | None = None,
+        block_shape: tuple[int, ...] | None = None,
+    ):
+        self.value_format = value_format
+        self.scale_format = scale_format
+        self.block_axes = block_axes
+        self.block_shape = block_shape
+
+    def configure_formats(self, value_format: str, scale_format: str) -> "_ConfiguredCheckpointDequantizer":
+        value_format = value_format.strip().lower()
+        scale_format = scale_format.strip().lower()
+        if value_format not in self.value_formats:
+            raise ValueError(f"Unsupported {self.method} value_format {value_format!r}.")
+        if scale_format not in self.scale_formats:
+            raise ValueError(f"Unsupported {self.method} scale_format {scale_format!r}.")
+        return type(self)(value_format, scale_format, self.block_axes, self.block_shape)
+
+    def configure_geometry(
+        self,
+        block_axes: tuple[int, ...],
+        block_shape: tuple[int, ...],
+    ) -> "_ConfiguredCheckpointDequantizer":
+        if not block_axes or len(block_axes) != len(block_shape) or len(set(block_axes)) != len(block_axes):
+            raise ValueError(f"Invalid block geometry for {self.method}.")
+        if any(axis < 0 for axis in block_axes) or any(size <= 0 for size in block_shape):
+            raise ValueError(f"Invalid block geometry for {self.method}.")
+        return type(self)(self.value_format, self.scale_format, tuple(block_axes), tuple(block_shape))
+
+    def _geometry(self, rank: int) -> tuple[tuple[int, ...], tuple[int, ...]]:
+        if self.block_axes is None or self.block_shape is None:
+            raise ValueError(f"{self.method} requires block geometry.")
+        axes = tuple(axis + rank if axis < 0 else axis for axis in self.block_axes)
+        if any(axis >= rank for axis in axes):
+            raise ValueError(f"Invalid block_axes {self.block_axes} for a rank-{rank} tensor.")
+        return axes, self.block_shape
+
+    def logical_shape(self, physical_shape: tuple[int, ...]) -> tuple[int, ...]:
+        return tuple(physical_shape)
+
+    def physical_qweight_shape(self, logical_shape: tuple[int, ...]) -> tuple[int, ...]:
+        return tuple(logical_shape)
+
+    def physical_qweight_slice(
+        self,
+        global_offset: tuple[int, ...],
+        local_shape: tuple[int, ...],
+    ) -> tuple[tuple[int, ...], tuple[int, ...]]:
+        return tuple(global_offset), tuple(local_shape)
+
+    def logical_shard_is_aligned(
+        self,
+        global_shape: tuple[int, ...],
+        local_shape: tuple[int, ...],
+        global_offset: tuple[int, ...],
+    ) -> bool:
+        axes, block_shape = self._geometry(len(global_shape))
+        for axis, block_size in zip(axes, block_shape):
+            start = global_offset[axis]
+            end = start + local_shape[axis]
+            if start % block_size != 0 and start != 0:
+                return False
+            if end % block_size != 0 and end != global_shape[axis]:
+                return False
+        return True
+
+    def _scales(self, scale: paddle.Tensor, logical_shape: tuple[int, ...]) -> paddle.Tensor:
+        axes, block_shape = self._geometry(len(logical_shape))
+        return _expand_scale_grid(
+            _decode_scales(scale, self.scale_format),
+            logical_shape,
+            axes,
+            block_shape,
+        )
+
+
+class FP8BlockCheckpointDequantizer(_ConfiguredCheckpointDequantizer):
+    method = "fp8_block"
+    value_formats = frozenset({"e4m3", "fp8_e4m3", "float8_e4m3"})
+    scale_formats = frozenset(
+        {"ue8m0", "e8m0", "float8_e8m0", "float", "fp16", "fp32", "bf16", "float16", "float32", "bfloat16"}
+    )
+
+    def dequantize(
+        self,
+        components: dict[str, paddle.Tensor],
+        output_dtype: paddle.dtype,
+    ) -> paddle.Tensor:
+        _require_components(components, {"qweight", "scale"})
+        qweight = _decode_e4m3(components["qweight"])
+        logical_shape = tuple(qweight.shape)
+        return (qweight * self._scales(components["scale"], logical_shape)).astype(output_dtype)
+
+
+class MXFP4GroupCheckpointDequantizer(_ConfiguredCheckpointDequantizer):
+    method = "mxfp4_group"
+    value_formats = frozenset({"e2m1", "fp4_e2m1"})
+    scale_formats = frozenset(
+        {"ue8m0", "e8m0", "float8_e8m0", "float", "fp16", "fp32", "bf16", "float16", "float32", "bfloat16"}
+    )
+
+    def dequantize(
+        self,
+        components: dict[str, paddle.Tensor],
+        output_dtype: paddle.dtype,
+    ) -> paddle.Tensor:
+        _require_components(components, {"qweight", "scale"})
+        qweight = _decode_e2m1_packed(components["qweight"])
+        logical_shape = tuple(qweight.shape)
+        return (qweight * self._scales(components["scale"], logical_shape)).astype(output_dtype)
+
+    def logical_shape(self, physical_shape: tuple[int, ...]) -> tuple[int, ...]:
+        if not physical_shape:
+            raise ValueError(f"Invalid MXFP4 weight shape: {physical_shape}.")
+        return (*physical_shape[:-1], physical_shape[-1] * 2)
+
+    def physical_qweight_shape(self, logical_shape: tuple[int, ...]) -> tuple[int, ...]:
+        if not logical_shape or logical_shape[-1] % 2:
+            raise ValueError(f"Invalid MXFP4 logical weight shape: {logical_shape}.")
+        return (*logical_shape[:-1], logical_shape[-1] // 2)
+
+    def physical_qweight_slice(
+        self,
+        global_offset: tuple[int, ...],
+        local_shape: tuple[int, ...],
+    ) -> tuple[tuple[int, ...], tuple[int, ...]]:
+        if global_offset[-1] % 2 or local_shape[-1] % 2:
+            raise ValueError("MXFP4 qweight slices must have even last-axis offsets and sizes.")
+        return (
+            (*global_offset[:-1], global_offset[-1] // 2),
+            (*local_shape[:-1], local_shape[-1] // 2),
+        )
+
+    def logical_shard_is_aligned(
+        self,
+        global_shape: tuple[int, ...],
+        local_shape: tuple[int, ...],
+        global_offset: tuple[int, ...],
+    ) -> bool:
+        if not super().logical_shard_is_aligned(global_shape, local_shape, global_offset):
+            return False
+        if global_offset[-1] % 2 or local_shape[-1] % 2:
+            return False
+        return True
+
+
+# -----------------------------------------------------------------------------
+# Dequantizer registry
+#
+# The registry stores unconfigured method prototypes. Descriptor validation
+# obtains a prototype, configures its formats, and later configures its shared
+# block geometry before storing it in the quantization metadata.
+# -----------------------------------------------------------------------------
+
+_CHECKPOINT_DEQUANTIZERS: dict[str, CheckpointDequantizer] = {}
+
+
+def _normalize_method(method: str) -> str:
+    if not isinstance(method, str):
+        raise TypeError(f"Checkpoint quantization method must be a string, got {type(method).__name__}.")
+    normalized = method.strip().lower()
+    if not normalized:
+        raise ValueError("Checkpoint quantization method must not be empty.")
+    return normalized
+
+
+def register_checkpoint_dequantizer(method: str, dequantizer: CheckpointDequantizer) -> None:
+    method = _normalize_method(method)
+    if method in _CHECKPOINT_DEQUANTIZERS:
+        raise ValueError(f"Checkpoint dequantizer {method!r} is already registered.")
+    if not callable(getattr(dequantizer, "dequantize", None)):
+        raise TypeError("Checkpoint dequantizer must provide a callable dequantize() method.")
+    _CHECKPOINT_DEQUANTIZERS[method] = dequantizer
+
+
+def get_checkpoint_dequantizer(method: str) -> CheckpointDequantizer:
+    method = _normalize_method(method)
+    try:
+        return _CHECKPOINT_DEQUANTIZERS[method]
+    except KeyError as exc:
+        supported = sorted(_CHECKPOINT_DEQUANTIZERS)
+        raise ValueError(
+            f"Unsupported checkpoint quantization method {method!r}; registered methods: {supported}."
+        ) from exc
+
+
+register_checkpoint_dequantizer("fp8_block", FP8BlockCheckpointDequantizer())
+register_checkpoint_dequantizer("mxfp4_group", MXFP4GroupCheckpointDequantizer())

--- a/paddleformers/quantization/hf_checkpoint.py
+++ b/paddleformers/quantization/hf_checkpoint.py
@@ -268,6 +268,28 @@ class QuanDescriptor:
 
     @staticmethod
     def _descriptor_patterns(group: dict[str, Any]) -> tuple[re.Pattern[str], ...]:
+        """Compile one group's ``targets`` entries into match patterns.
+
+        Two forms are accepted, and the ``re:`` form is the preferred one:
+
+        - ``"re:<regex>"`` -- everything after ``re:`` is used as a regular
+          expression.  Real checkpoints name weights per layer and per expert,
+          so this is the only form able to describe a whole weight family; the
+          in-tree DeepSeek-V4 and Kimi-K3 descriptors both use a single anchored
+          ``re:`` target.  Anchor these patterns yourself (``^`` / ``$``) to keep
+          the match tight, since they are applied with :meth:`re.Pattern.search`.
+        - a plain string -- a literal, fully qualified physical tensor name,
+          matched in full.  This is only a supplementary form, for the occasional
+          one-off weight that carries no layer or expert index.
+
+        Literal targets are anchored with ``\\A`` / ``\\Z`` here.  ``re.escape``
+        alone would keep the literal from being read as a regex but would still
+        leave ``search`` free to match a substring, so ``layers.1.attn.wq_a.weight``
+        would also match ``prefix.layers.1.attn.wq_a.weight`` and a shorter
+        ``layers.1`` would match ``layers.11...``, dragging weight/scale pairs the
+        descriptor never declared into the transform.  Anchoring makes a literal
+        target denote exactly one tensor name.
+        """
         raw_targets = group.get("targets")
         if isinstance(raw_targets, str):
             raw_targets = [raw_targets]
@@ -279,7 +301,7 @@ class QuanDescriptor:
             raise ValueError("Each quan_desc group must define a non-empty string targets list.")
         patterns = []
         for target in raw_targets:
-            expression = target[3:] if target.startswith("re:") else re.escape(target)
+            expression = target[3:] if target.startswith("re:") else rf"\A{re.escape(target)}\Z"
             try:
                 patterns.append(re.compile(expression))
             except re.error as exc:

--- a/paddleformers/quantization/hf_checkpoint.py
+++ b/paddleformers/quantization/hf_checkpoint.py
@@ -447,6 +447,11 @@ class HFDequantLoadTransform:
         local boundaries.  Unaligned, transposed, or otherwise irregular
         layouts use the existing global path instead of guessing a scale
         origin.
+
+        ``target_shard_metadata`` describes the shard of the logical tensor
+        this rank holds, so a distributed target reports its local shape here,
+        not its global one.  The plan is cached because ``apply()`` validates
+        the dequantized shape against it.
         """
         spec, group = self._relation(logical_key)
 
@@ -521,9 +526,6 @@ class HFDequantLoadTransform:
         )
         self._read_plans[logical_key] = plan
         return plan
-
-    def read_plan_for(self, logical_key: str) -> HFReadPlan | None:
-        return self._read_plans.get(logical_key)
 
     def apply(
         self,

--- a/paddleformers/quantization/hf_checkpoint.py
+++ b/paddleformers/quantization/hf_checkpoint.py
@@ -1,0 +1,578 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+import re
+from dataclasses import dataclass
+from itertools import permutations
+from typing import Any
+
+import paddle
+from paddle.distributed.flex_checkpoint.dcp.metadata import (
+    LocalTensorMetadata,
+    Metadata,
+)
+from paddle.distributed.flex_checkpoint.dcp.utils import create_hf_ckpt_metadata
+
+from .checkpoint_dequant import CheckpointDequantizer, get_checkpoint_dequantizer
+
+_PADDLE_METADATA_FILE_NAME = "flex-ckpt.auto_generated.metadata"
+logger = logging.getLogger(__name__)
+
+# -----------------------------------------------------------------------------
+# Quantized checkpoint metadata model
+#
+# A descriptor defines shared ``HFQuantizationGroupSpec`` objects.  Each
+# matched logical weight gets one ``HFQuantizedWeightSpec`` relation pointing
+# to a group and listing its physical qweight/scale components.  ``QuanMetadata``
+# keeps these relations together with both logical (DCP/AOA-facing) and
+# physical (checkpoint-facing) metadata.
+# -----------------------------------------------------------------------------
+
+
+@dataclass
+class HFQuantizationGroupSpec:
+    """Shared quantization rules for all weights matched by one descriptor group."""
+
+    name: str
+    targets: tuple[re.Pattern[str], ...]
+    quant_method: str
+    value_format: str
+    scale_format: str
+    block_shape: tuple[int, ...]
+    dequantizer: CheckpointDequantizer
+    block_axes: tuple[int, ...] | None = None
+
+    def configure_geometry(self, block_axes: tuple[int, ...]) -> None:
+        self.block_axes = tuple(block_axes)
+        self.dequantizer = self.dequantizer.configure_geometry(self.block_axes, self.block_shape)
+
+
+@dataclass
+class HFQuantizedWeightSpec:
+    """Relation from one logical weight to its physical checkpoint components."""
+
+    group_name: str
+    logical_name: str
+    logical_shape: tuple[int, ...]
+    components: dict[str, str]
+
+
+@dataclass
+class QuanMetadata:
+    """Unified metadata for a quantized HF checkpoint.
+
+    ``groups`` stores shared quantization rules, ``relations`` maps each
+    logical weight to its qweight/scale sources, and ``logical_metadata``
+    exposes those virtual weights to DCP/AOA.  ``physical_metadata`` describes
+    the tensors that actually exist in the HF safetensors checkpoint.
+    """
+
+    # Shared descriptor configuration: group name -> quantization rule.
+    groups: dict[str, HFQuantizationGroupSpec]
+    # Logical HF name -> physical qweight/scale relation.
+    relations: dict[str, HFQuantizedWeightSpec]
+    # Logical HF name -> virtual tensor metadata exposed to DCP/AOA.
+    logical_metadata: dict[str, LocalTensorMetadata]
+    # Physical checkpoint name -> safetensors storage metadata.
+    physical_metadata: Metadata
+
+    def __post_init__(self) -> None:
+        for logical_key, spec in self.relations.items():
+            group = self.groups.get(spec.group_name)
+            if group is None:
+                raise ValueError(f"Quantized weight {logical_key!r} refers to unknown group {spec.group_name!r}.")
+            self._validate_relation(logical_key, spec, group)
+
+    @staticmethod
+    def _validate_relation(
+        logical_key: str,
+        spec: HFQuantizedWeightSpec,
+        group: HFQuantizationGroupSpec,
+    ) -> None:
+        if spec.logical_name != logical_key:
+            raise ValueError(f"Relation key {logical_key!r} does not match logical_name {spec.logical_name!r}.")
+        if not spec.logical_shape or any(not isinstance(dim, int) or dim <= 0 for dim in spec.logical_shape):
+            raise ValueError(f"Invalid logical shape for {logical_key!r}: {spec.logical_shape}.")
+        if "qweight" not in spec.components:
+            raise ValueError(f"Quantized weight {logical_key!r} does not define a qweight component.")
+        if any(not role or not source_key for role, source_key in spec.components.items()):
+            raise ValueError(f"Quantized weight {logical_key!r} contains an empty component role or source key.")
+        if group.block_axes is None:
+            raise ValueError(f"Quantization group {group.name!r} does not define block_axes.")
+        if any(axis < 0 or axis >= len(spec.logical_shape) for axis in group.block_axes):
+            raise ValueError(f"Block axes for group {group.name!r} are outside logical shape {spec.logical_shape}.")
+
+
+# -----------------------------------------------------------------------------
+# Checkpoint metadata helpers
+# -----------------------------------------------------------------------------
+
+
+def _read_json(path: str) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as file:
+        value = json.load(file)
+    if not isinstance(value, dict):
+        raise ValueError(f"Expected a JSON object in {path!r}.")
+    return value
+
+
+def _physical_state_dict_metadata(
+    physical_metadata: Metadata,
+) -> dict[str, list[LocalTensorMetadata]]:
+    state_dict_metadata = physical_metadata.state_dict_metadata
+    if not isinstance(state_dict_metadata, dict) or not state_dict_metadata:
+        raise ValueError("Paddle checkpoint Metadata contains no physical tensors.")
+    return state_dict_metadata
+
+
+def _physical_tensor_metadata(
+    physical_metadata: Metadata,
+    tensor_key: str,
+) -> LocalTensorMetadata:
+    tensor_items = _physical_state_dict_metadata(physical_metadata).get(tensor_key)
+    if not tensor_items:
+        raise KeyError(f"Physical tensor {tensor_key!r} does not exist in Paddle Metadata.")
+    return tensor_items[0]
+
+
+def _load_paddle_hf_metadata(checkpoint_path: str) -> Metadata:
+    """Load or create Paddle physical metadata for an HF checkpoint."""
+    metadata_path = os.path.join(checkpoint_path, _PADDLE_METADATA_FILE_NAME)
+    if os.path.isfile(metadata_path):
+        return paddle.load(metadata_path)
+    return create_hf_ckpt_metadata(checkpoint_path)
+
+
+def _expected_scale_shape(
+    logical_shape: tuple[int, ...],
+    block_axes: tuple[int, ...],
+    block_shape: tuple[int, ...],
+) -> tuple[int, ...]:
+    axis_to_block = dict(zip(block_axes, block_shape))
+    return tuple(
+        math.ceil(dim / axis_to_block[axis]) if axis in axis_to_block else dim
+        for axis, dim in enumerate(logical_shape)
+    )
+
+
+# -----------------------------------------------------------------------------
+# Quantization descriptor validation and metadata construction
+# -----------------------------------------------------------------------------
+
+
+class QuanDescriptor:
+    """Validate a quantization descriptor and build logical/physical relations.
+
+    Descriptor parsing is intentionally separate from checkpoint loading:
+    parsing creates shared group rules, while ``build_metadata`` binds those
+    rules to the physical tensor names and shapes found in the checkpoint.
+    """
+
+    def __init__(self, raw: dict[str, Any]):
+        self.raw = raw
+        self._validate_descriptor()
+
+    @classmethod
+    def from_file(cls, path: str) -> "QuanDescriptor":
+        return cls(_read_json(path))
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "QuanDescriptor":
+        return cls(raw)
+
+    def to_dict(self) -> dict[str, Any]:
+        return dict(self.raw)
+
+    def _validate_descriptor(self) -> None:
+        if not isinstance(self.raw, dict):
+            raise ValueError("Quantization descriptor must contain a JSON object.")
+        if self.raw.get("schema_version") != 1:
+            raise ValueError("Unsupported quan_desc schema_version; expected 1.")
+        raw_groups = self.raw.get("groups")
+        if not isinstance(raw_groups, list) or not raw_groups:
+            raise ValueError("Quantization descriptor must define a non-empty groups list.")
+        pairing = self.raw.get("component_pairing")
+        if not isinstance(pairing, dict):
+            raise ValueError("quan_desc must define component_pairing as an object.")
+        self.weight_suffix = pairing.get("weight_suffix")
+        self.scale_suffix = pairing.get("scale_suffix")
+        if not isinstance(self.weight_suffix, str) or not isinstance(self.scale_suffix, str):
+            raise ValueError("quan_desc component_pairing must define string weight_suffix and scale_suffix.")
+        if not self.weight_suffix or not self.scale_suffix:
+            raise ValueError("quan_desc component suffixes must be non-empty strings.")
+        self.logical_name_suffix = self.raw.get("logic_name_suffix")
+        if not isinstance(self.logical_name_suffix, str) or not self.logical_name_suffix:
+            raise ValueError("quan_desc must define a non-empty string logic_name_suffix.")
+        compiled_groups = tuple(self._compile_group(group) for group in raw_groups)
+        group_names = [group.name for group in compiled_groups]
+        if len(set(group_names)) != len(group_names):
+            raise ValueError(f"quan_desc group names must be unique, got {group_names}.")
+        self._groups = compiled_groups
+
+    @classmethod
+    def _compile_group(cls, group: dict[str, Any]) -> HFQuantizationGroupSpec:
+        if not isinstance(group, dict):
+            raise ValueError("Each quan_desc group must be an object.")
+        name = group.get("name")
+        method = group.get("quant_method")
+        value_format = group.get("value_format")
+        scale_format = group.get("scale_format")
+        block_shape = group.get("block_shape")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("Each quan_desc group must define a non-empty name.")
+        if not isinstance(method, str) or not method.strip():
+            raise ValueError(f"Quan_desc group {name!r} must define quant_method.")
+        method = method.strip().lower()
+        if not isinstance(value_format, str) or not value_format.strip():
+            raise ValueError(f"Quan_desc group {name!r} must define value_format.")
+        value_format = value_format.strip().lower()
+        if not isinstance(scale_format, str) or not scale_format.strip():
+            raise ValueError(f"Quan_desc group {name!r} must define scale_format.")
+        scale_format = scale_format.strip().lower()
+        try:
+            dequantizer = get_checkpoint_dequantizer(method).configure_formats(value_format, scale_format)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Invalid quan_desc formats for group {name!r}: {exc}") from exc
+        if (
+            not isinstance(block_shape, list)
+            or not block_shape
+            or any(not isinstance(size, int) or size <= 0 for size in block_shape)
+        ):
+            raise ValueError(f"Quan_desc group {name!r} must define a positive integer block_shape list.")
+        return HFQuantizationGroupSpec(
+            name=name,
+            targets=cls._descriptor_patterns(group),
+            quant_method=method,
+            value_format=value_format,
+            scale_format=scale_format,
+            block_shape=tuple(block_shape),
+            dequantizer=dequantizer,
+        )
+
+    @staticmethod
+    def _descriptor_patterns(group: dict[str, Any]) -> tuple[re.Pattern[str], ...]:
+        raw_targets = group.get("targets")
+        if isinstance(raw_targets, str):
+            raw_targets = [raw_targets]
+        if (
+            not isinstance(raw_targets, list)
+            or not raw_targets
+            or any(not isinstance(item, str) for item in raw_targets)
+        ):
+            raise ValueError("Each quan_desc group must define a non-empty string targets list.")
+        patterns = []
+        for target in raw_targets:
+            expression = target[3:] if target.startswith("re:") else re.escape(target)
+            try:
+                patterns.append(re.compile(expression))
+            except re.error as exc:
+                raise ValueError(f"Invalid quan_desc target pattern {target!r}: {exc}") from exc
+        return tuple(patterns)
+
+    @staticmethod
+    def _infer_block_axes(
+        logical_shape: tuple[int, ...],
+        scale_shape: tuple[int, ...],
+        block_shape: tuple[int, ...],
+    ) -> tuple[int, ...]:
+        if len(logical_shape) != len(scale_shape):
+            raise ValueError(f"Cannot infer block axes for ranks {len(logical_shape)} and {len(scale_shape)}.")
+        if not block_shape or len(block_shape) > len(logical_shape):
+            raise ValueError(f"Block rank {len(block_shape)} is invalid for logical shape {logical_shape}.")
+        for axes in permutations(range(len(logical_shape)), len(block_shape)):
+            if _expected_scale_shape(logical_shape, axes, block_shape) == scale_shape:
+                return axes
+        raise ValueError(f"Cannot infer block axes for logical shape {logical_shape} and scale shape {scale_shape}.")
+
+    def build_metadata(
+        self,
+        physical_metadata: Metadata,
+        output_dtype: paddle.dtype = paddle.bfloat16,
+    ) -> QuanMetadata:
+        source_keys = _physical_state_dict_metadata(physical_metadata)
+        relations: dict[str, HFQuantizedWeightSpec] = {}
+        groups: dict[str, HFQuantizationGroupSpec] = {}
+        matched_scales: set[str] = set()
+        for weight_key in sorted(source_keys):
+            if not weight_key.endswith(self.weight_suffix):
+                continue
+            matches = [group for group in self._groups if any(pattern.search(weight_key) for pattern in group.targets)]
+            if len(matches) > 1:
+                raise ValueError(
+                    f"Quantized weight {weight_key!r} matches multiple quan_desc groups: "
+                    f"{[group.name for group in matches]}"
+                )
+            if not matches:
+                continue
+            group = matches[0]
+            name = group.name
+            scale_key = weight_key[: -len(self.weight_suffix)] + self.scale_suffix
+            if scale_key not in source_keys:
+                raise ValueError(
+                    f"Quan_desc group {name!r} matched {weight_key!r}, but paired scale {scale_key!r} is missing."
+                )
+            weight_shape = tuple(_physical_tensor_metadata(physical_metadata, weight_key).global_shape)
+            logical_shape = group.dequantizer.logical_shape(weight_shape)
+            if group.block_axes is None:
+                scale_shape = tuple(_physical_tensor_metadata(physical_metadata, scale_key).global_shape)
+                group.configure_geometry(self._infer_block_axes(logical_shape, scale_shape, group.block_shape))
+            logical_name = weight_key[: -len(self.weight_suffix)] + self.logical_name_suffix
+            if logical_name in relations:
+                raise ValueError(f"Quan_desc produced duplicate logical weight name {logical_name!r}.")
+            relations[logical_name] = HFQuantizedWeightSpec(
+                logical_name=logical_name,
+                logical_shape=logical_shape,
+                components={"qweight": weight_key, "scale": scale_key},
+                group_name=group.name,
+            )
+            groups[group.name] = group
+            matched_scales.add(scale_key)
+        unmatched = [
+            key
+            for key in source_keys
+            if key.endswith(self.scale_suffix)
+            and key[: -len(self.scale_suffix)] + self.weight_suffix in source_keys
+            and key not in matched_scales
+        ]
+        if unmatched:
+            raise ValueError(
+                f"quan_desc did not match all quantized weight/scale pairs; unmatched examples: {unmatched[:5]}"
+            )
+        if not relations:
+            raise ValueError("quan_desc matched no quantized weight/scale pairs.")
+        dtype = str(output_dtype).split(".")[-1]
+        logical_metadata = {
+            logical_key: LocalTensorMetadata(
+                global_offset=(0,) * len(spec.logical_shape),
+                local_shape=spec.logical_shape,
+                global_shape=spec.logical_shape,
+                dtype=dtype,
+            )
+            for logical_key, spec in relations.items()
+        }
+        return QuanMetadata(
+            groups=groups,
+            relations=relations,
+            logical_metadata=logical_metadata,
+            physical_metadata=physical_metadata,
+        )
+
+
+# -----------------------------------------------------------------------------
+# DCP load transform
+# -----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HFReadPlan:
+    """Map one logical shard to the physical qweight/scale reads it needs.
+
+    ``mode == "local"`` means the physical components can be read from
+    block-aligned slices.  ``mode == "global"`` means the components are read
+    in full and the logical output is sliced after dequantization.
+    """
+
+    mode: str
+    logical_slice: LocalTensorMetadata
+    source_slices: dict[str, LocalTensorMetadata]
+
+    @property
+    def logical_global_shape(self) -> tuple[int, ...]:
+        return tuple(self.logical_slice.global_shape)
+
+    @property
+    def logical_local_shape(self) -> tuple[int, ...]:
+        return tuple(self.logical_slice.local_shape)
+
+    @property
+    def logical_global_offset(self) -> tuple[int, ...]:
+        return tuple(self.logical_slice.global_offset)
+
+
+class HFDequantLoadTransform:
+    """Expose quantized HF tensors as logical tensors to Paddle DCP.
+
+    ``QuanMetadata`` owns descriptor validation and logical/physical relations.
+    This class consumes that model to answer DCP's metadata/source-key
+    requests, plan physical slices, and invoke the group-shared dequantizer.
+    """
+
+    def __init__(self, quan_metadata: QuanMetadata):
+        self.quan_metadata = quan_metadata
+        self._read_plans: dict[str, HFReadPlan] = {}
+
+    def logical_metadata(self) -> dict[str, LocalTensorMetadata]:
+        return dict(self.quan_metadata.logical_metadata)
+
+    def _relation(
+        self,
+        logical_key: str,
+    ) -> tuple[HFQuantizedWeightSpec, HFQuantizationGroupSpec]:
+        try:
+            spec = self.quan_metadata.relations[logical_key]
+        except KeyError as exc:
+            raise KeyError(f"Logical weight {logical_key!r} is not managed by this load transform.") from exc
+        return spec, self.quan_metadata.groups[spec.group_name]
+
+    def source_keys(self, logical_key: str) -> list[str]:
+        spec, _ = self._relation(logical_key)
+        return list(dict.fromkeys(spec.components.values()))
+
+    def read_plan(
+        self,
+        logical_key: str,
+        target_shard_metadata: LocalTensorMetadata,
+        force_global: bool = False,
+    ) -> HFReadPlan:
+        """Build and cache a local physical read plan when it is safe.
+
+        The first implementation deliberately requires block/group-aligned
+        local boundaries.  Unaligned, transposed, or otherwise irregular
+        layouts use the existing global path instead of guessing a scale
+        origin.
+        """
+        spec, group = self._relation(logical_key)
+
+        global_shape = tuple(target_shard_metadata.global_shape)
+        local_shape = tuple(target_shard_metadata.local_shape)
+        global_offset = tuple(target_shard_metadata.global_offset)
+        source_metadata = self.quan_metadata.physical_metadata.state_dict_metadata
+        dequantizer = group.dequantizer
+        logical_axes = group.block_axes
+        block_shape = group.block_shape
+        axis_to_block = dict(zip(logical_axes, block_shape))
+        if global_shape != spec.logical_shape:
+            raise ValueError(
+                f"Target shape mismatch for {logical_key!r}: "
+                f"descriptor={spec.logical_shape}, target={global_shape}."
+            )
+        aligned = not force_global and dequantizer.logical_shard_is_aligned(
+            spec.logical_shape, local_shape, global_offset
+        )
+        mode = "local" if aligned and local_shape != spec.logical_shape else "global"
+        source_slices: dict[str, LocalTensorMetadata] = {}
+        for role, source_key in spec.components.items():
+            source_items = source_metadata.get(source_key)
+            if not source_items:
+                raise ValueError(f"Read plan for {logical_key!r} is missing source metadata for {source_key!r}.")
+            physical_metadata = source_items[0]
+            if role == "qweight":
+                physical_shape = dequantizer.physical_qweight_shape(spec.logical_shape)
+                if mode == "local":
+                    physical_offset, physical_local_shape = dequantizer.physical_qweight_slice(
+                        global_offset,
+                        local_shape,
+                    )
+            elif role == "scale":
+                physical_shape = _expected_scale_shape(spec.logical_shape, logical_axes, block_shape)
+                if mode == "local":
+                    # Map a block-aligned logical shard to the scale grid.  A
+                    # shard ending at the logical tensor boundary may include
+                    # one partial block, hence ceil on its local extent.
+                    scale_factors = tuple(axis_to_block.get(axis, 1) for axis in range(len(global_offset)))
+                    physical_offset = tuple(offset // factor for offset, factor in zip(global_offset, scale_factors))
+                    physical_local_shape = tuple(
+                        math.ceil(size / factor) for size, factor in zip(local_shape, scale_factors)
+                    )
+            else:
+                raise ValueError(f"Unsupported component role {role!r} for {logical_key!r}.")
+            if mode == "global":
+                physical_offset = (0,) * len(physical_shape)
+                physical_local_shape = physical_shape
+            if tuple(physical_metadata.global_shape) != tuple(physical_shape):
+                raise ValueError(
+                    f"Read plan shape mismatch for {source_key!r}: description="
+                    f"{tuple(physical_shape)}, checkpoint="
+                    f"{tuple(physical_metadata.global_shape)}."
+                )
+            source_slices[source_key] = LocalTensorMetadata(
+                global_shape=tuple(physical_shape),
+                global_offset=tuple(physical_offset),
+                local_shape=tuple(physical_local_shape),
+                dtype=physical_metadata.dtype,
+            )
+
+        plan = HFReadPlan(
+            mode=mode,
+            logical_slice=LocalTensorMetadata(
+                global_offset=global_offset if mode == "local" else (0,) * len(spec.logical_shape),
+                local_shape=local_shape if mode == "local" else spec.logical_shape,
+                dtype=self.quan_metadata.logical_metadata[logical_key].dtype,
+                global_shape=spec.logical_shape,
+            ),
+            source_slices=source_slices,
+        )
+        self._read_plans[logical_key] = plan
+        return plan
+
+    def read_plan_for(self, logical_key: str) -> HFReadPlan | None:
+        return self._read_plans.get(logical_key)
+
+    def apply(
+        self,
+        logical_key: str,
+        source_tensors: dict[str, paddle.Tensor],
+        output_dtype: paddle.dtype,
+    ) -> paddle.Tensor:
+        spec, group = self._relation(logical_key)
+
+        components = {role: source_tensors[source_key] for role, source_key in spec.components.items()}
+        plan = self._read_plans.get(logical_key)
+        output = group.dequantizer.dequantize(components, output_dtype)
+        expected_shape = spec.logical_shape
+        if plan is not None and plan.mode == "local":
+            expected_shape = plan.logical_local_shape
+        if tuple(output.shape) != expected_shape:
+            raise ValueError(
+                f"Invalid dequantized shape for {logical_key!r}: expected {expected_shape}, got {tuple(output.shape)}."
+            )
+        return output
+
+
+# -----------------------------------------------------------------------------
+# Public transform builder
+# -----------------------------------------------------------------------------
+
+
+def build_hf_dequant_load_transform(
+    checkpoint_path: str,
+    mode: bool,
+    quan_config: dict[str, Any] | None = None,
+) -> HFDequantLoadTransform | None:
+    """Build the HF dequantization transform from model-defined rules.
+
+    ``quan_config`` is the descriptor returned by a model's parameterless
+    ``_gen_hf_quan_config()`` method.  Checkpoint files only provide physical
+    tensor metadata; quantization rules are owned by the model definition.
+    """
+    if not mode or quan_config is None:
+        return None
+    logger.info(f"load hf quantizated models at {checkpoint_path}.")
+    quan_desc = QuanDescriptor.from_dict(quan_config)
+
+    physical_metadata = _load_paddle_hf_metadata(checkpoint_path)
+    quan_metadata = quan_desc.build_metadata(
+        physical_metadata=physical_metadata,
+        output_dtype=paddle.bfloat16,
+    )
+
+    return HFDequantLoadTransform(
+        quan_metadata=quan_metadata,
+    )

--- a/paddleformers/quantization/hf_checkpoint.py
+++ b/paddleformers/quantization/hf_checkpoint.py
@@ -33,6 +33,7 @@ from paddle.distributed.flex_checkpoint.dcp.utils import create_hf_ckpt_metadata
 from .checkpoint_dequant import CheckpointDequantizer, get_checkpoint_dequantizer
 
 _PADDLE_METADATA_FILE_NAME = "flex-ckpt.auto_generated.metadata"
+_HF_CONFIG_FILE_NAME = "config.json"
 logger = logging.getLogger(__name__)
 
 # -----------------------------------------------------------------------------
@@ -575,9 +576,24 @@ class HFDequantLoadTransform:
 # -----------------------------------------------------------------------------
 
 
+def hf_checkpoint_is_quantized(checkpoint_path: str) -> bool:
+    """Report whether an HF checkpoint declares quantized weights.
+
+    The checkpoint's own ``config.json`` is the authority: HuggingFace writes a
+    ``quantization_config`` block exactly when the weights on disk are
+    quantized.  Reading it here means no training argument has to repeat that
+    fact, and a model class that owns a ``_gen_hf_quan_config()`` descriptor can
+    still load its unquantized releases through the plain path.
+    """
+    config_path = os.path.join(checkpoint_path, _HF_CONFIG_FILE_NAME)
+    if not os.path.isfile(config_path):
+        return False
+    quantization_config = _read_json(config_path).get("quantization_config")
+    return isinstance(quantization_config, dict) and bool(quantization_config)
+
+
 def build_hf_dequant_load_transform(
     checkpoint_path: str,
-    mode: bool,
     quan_config: dict[str, Any] | None = None,
 ) -> HFDequantLoadTransform | None:
     """Build the HF dequantization transform from model-defined rules.
@@ -585,8 +601,10 @@ def build_hf_dequant_load_transform(
     ``quan_config`` is the descriptor returned by a model's parameterless
     ``_gen_hf_quan_config()`` method.  Checkpoint files only provide physical
     tensor metadata; quantization rules are owned by the model definition.
+    Without a descriptor there is nothing to dequantize, so the caller gets
+    ``None`` and loads the checkpoint through the plain path.
     """
-    if not mode or quan_config is None:
+    if quan_config is None:
         return None
     logger.info(f"load hf quantizated models at {checkpoint_path}.")
     quan_desc = QuanDescriptor.from_dict(quan_config)

--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -1283,6 +1283,9 @@ class Trainer:
                 mode=self.args.hf_quantized_load_mode,
                 quan_config=hf_quan_config,
             )
+            # Only forward load_transform when a transform exists, so that a
+            # Paddle without the keyword keeps working for unquantized loads.
+            load_transform_kwargs = {} if load_transform is None else {"load_transform": load_transform}
             dist.load_state_dict(
                 model_sharded_state_dict,
                 resume_from_checkpoint,
@@ -1292,7 +1295,7 @@ class Trainer:
                 process_group=None,
                 comm_method=flex_ckpt_comm_method,
                 worker_groups=worker_groups,
-                load_transform=load_transform,
+                **load_transform_kwargs,
             )
             if hasattr(self.model, "_synchronize_shared_weights"):
                 self.model._synchronize_shared_weights()

--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -102,6 +102,7 @@ from ..data import (
 )
 from ..peft import LoRAModel
 from ..peft.lora import QuantizationLoRABaseLinear
+from ..quantization.hf_checkpoint import build_hf_dequant_load_transform
 from ..quantization.quantization_linear import (
     ColumnParallelQuantizationLinear,
     QuantizationLinear,
@@ -1256,6 +1257,11 @@ class Trainer:
 
         if self.args.load_from_hf:
             hf_aoa_config = self.model._gen_aoa_config(self.model.config)
+            hf_quan_config = None
+            if self.args.hf_quantized_load_mode:
+                gen_hf_quan_config = getattr(self.model, "_gen_hf_quan_config", None)
+                if callable(gen_hf_quan_config):
+                    hf_quan_config = gen_hf_quan_config()
             assert (
                 self.args.ignore_load_lr_and_optim
             ), "Loading from HuggingFace format is only allowed when learning rate and optimizer state are ignored."
@@ -1272,6 +1278,11 @@ class Trainer:
             except Exception as e:
                 logger.error(f"Failed to delete {metadata_path}: {e}")
 
+            load_transform = build_hf_dequant_load_transform(
+                checkpoint_path=resume_from_checkpoint,
+                mode=self.args.hf_quantized_load_mode,
+                quan_config=hf_quan_config,
+            )
             dist.load_state_dict(
                 model_sharded_state_dict,
                 resume_from_checkpoint,
@@ -1281,6 +1292,7 @@ class Trainer:
                 process_group=None,
                 comm_method=flex_ckpt_comm_method,
                 worker_groups=worker_groups,
+                load_transform=load_transform,
             )
             if hasattr(self.model, "_synchronize_shared_weights"):
                 self.model._synchronize_shared_weights()

--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -102,7 +102,10 @@ from ..data import (
 )
 from ..peft import LoRAModel
 from ..peft.lora import QuantizationLoRABaseLinear
-from ..quantization.hf_checkpoint import build_hf_dequant_load_transform
+from ..quantization.hf_checkpoint import (
+    build_hf_dequant_load_transform,
+    hf_checkpoint_is_quantized,
+)
 from ..quantization.quantization_linear import (
     ColumnParallelQuantizationLinear,
     QuantizationLinear,
@@ -1257,11 +1260,17 @@ class Trainer:
 
         if self.args.load_from_hf:
             hf_aoa_config = self.model._gen_aoa_config(self.model.config)
+            # The checkpoint's own config.json states whether its weights are
+            # quantized, so nothing has to declare it through an argument.
             hf_quan_config = None
-            if self.args.hf_quantized_load_mode:
+            if hf_checkpoint_is_quantized(resume_from_checkpoint):
                 gen_hf_quan_config = getattr(self.model, "_gen_hf_quan_config", None)
-                if callable(gen_hf_quan_config):
-                    hf_quan_config = gen_hf_quan_config()
+                if not callable(gen_hf_quan_config):
+                    raise ValueError(
+                        f"Checkpoint '{resume_from_checkpoint}' declares a quantization_config, but "
+                        f"{type(self.model).__name__} defines no _gen_hf_quan_config() to describe its layout."
+                    )
+                hf_quan_config = gen_hf_quan_config()
             assert (
                 self.args.ignore_load_lr_and_optim
             ), "Loading from HuggingFace format is only allowed when learning rate and optimizer state are ignored."
@@ -1280,7 +1289,6 @@ class Trainer:
 
             load_transform = build_hf_dequant_load_transform(
                 checkpoint_path=resume_from_checkpoint,
-                mode=self.args.hf_quantized_load_mode,
                 quan_config=hf_quan_config,
             )
             # Only forward load_transform when a transform exists, so that a

--- a/paddleformers/trainer/training_args.py
+++ b/paddleformers/trainer/training_args.py
@@ -437,6 +437,10 @@ class TrainingArguments:
             Whether to load a checkpoint in the HuggingFace format.
             Defaults to False.
 
+        hf_quantized_load_mode (`bool`, *optional*, defaults to `False`):
+            Whether to enable model-defined HF quantized checkpoint loading. The
+            model supplies its descriptor through ``_gen_hf_quan_config()``.
+
         replicate_saved_into_local (bool, optional):
             Whether to save checkpoint replicas into local files in a distributed save/load system.
             If set to True, replicas will be stored locally on each node/machine.
@@ -1372,6 +1376,12 @@ class TrainingArguments:
     load_from_hf: Optional[bool] = field(
         default=False,
         metadata={"help": "Whether to load a checkpoint in the HuggingFace format."},
+    )
+    hf_quantized_load_mode: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to enable model-defined HuggingFace quantized checkpoint loading.",
+        },
     )
     deterministic_mode: bool = field(
         default=False,

--- a/paddleformers/trainer/training_args.py
+++ b/paddleformers/trainer/training_args.py
@@ -437,10 +437,6 @@ class TrainingArguments:
             Whether to load a checkpoint in the HuggingFace format.
             Defaults to False.
 
-        hf_quantized_load_mode (`bool`, *optional*, defaults to `False`):
-            Whether to enable model-defined HF quantized checkpoint loading. The
-            model supplies its descriptor through ``_gen_hf_quan_config()``.
-
         replicate_saved_into_local (bool, optional):
             Whether to save checkpoint replicas into local files in a distributed save/load system.
             If set to True, replicas will be stored locally on each node/machine.
@@ -1376,12 +1372,6 @@ class TrainingArguments:
     load_from_hf: Optional[bool] = field(
         default=False,
         metadata={"help": "Whether to load a checkpoint in the HuggingFace format."},
-    )
-    hf_quantized_load_mode: bool = field(
-        default=False,
-        metadata={
-            "help": "Whether to enable model-defined HuggingFace quantized checkpoint loading.",
-        },
     )
     deterministic_mode: bool = field(
         default=False,

--- a/paddleformers/transformers/deepseek_v4/modeling.py
+++ b/paddleformers/transformers/deepseek_v4/modeling.py
@@ -382,6 +382,41 @@ class DeepseekV4PreTrainedModel(PretrainedModel):
         return info_map
 
     @classmethod
+    def _gen_hf_quan_config(cls):
+        """Describe the FP8 block-quantized DeepSeek-V4 HF checkpoint.
+
+        Consumed by ``Trainer`` when ``load_from_hf`` and
+        ``hf_quantized_load_mode`` are both enabled; the descriptor is passed to
+        ``paddleformers.quantization.hf_checkpoint`` to build the dequantization
+        transform.  The logical ``.weight`` names this produces are exactly the
+        AOA sources in :meth:`_gen_aoa_config`.
+        """
+        return {
+            "schema_version": 1,
+            "component_pairing": {"weight_suffix": ".weight", "scale_suffix": ".scale"},
+            "logic_name_suffix": ".weight",
+            "groups": [
+                {
+                    "name": "fp8_block",
+                    "targets": [
+                        r"re:^(?:"
+                        r"layers\.[0-9]+\.attn\.(?:indexer\.wq_b|wkv|wo_a|wo_b|wq_a|wq_b)|"
+                        r"layers\.[0-9]+\.ffn\.(?:shared_experts\.w[123]|experts\.[0-9]+\.w[123])|"
+                        r"mtp\.[0-9]+\.(?:attn\.(?:wkv|wo_a|wo_b|wq_a|wq_b)|"
+                        r"ffn\.(?:shared_experts\.w[123]|experts\.[0-9]+\.w[123])|e_proj|h_proj)"
+                        r")\.weight$"
+                    ],
+                    "quant_method": "fp8_block",
+                    "value_format": "e4m3",
+                    # The HF config calls the scale encoding UE8M0, but this
+                    # checkpoint stores the decoded power-of-two scales as F32.
+                    "scale_format": "float32",
+                    "block_shape": [128, 128],
+                }
+            ],
+        }
+
+    @classmethod
     def _gen_aoa_config(cls, config: DeepseekV4Config):
         """Weight conversion: HuggingFace DSv4 checkpoint -> PaddleFleet internal format.
 
@@ -1024,6 +1059,7 @@ class DeepseekV4ForCausalLM(DeepseekV4PreTrainedModel):
         gpt_model = model_provider.provide(loss_fn=loss_fn)
         gpt_model._gen_aoa_config = cls._gen_aoa_config
         gpt_model._gen_inv_aoa_config = cls._gen_inv_aoa_config
+        gpt_model._gen_hf_quan_config = cls._gen_hf_quan_config
         gpt_model.build_muon_param_info_map = cls.build_muon_param_info_map
         gpt_model.config_to_save = config
         gpt_model.is_fleet = cls.is_fleet
@@ -1057,6 +1093,7 @@ class DeepseekV4ForCausalLMPipe(DeepseekV4PreTrainedModel, GeneralModelForCausal
         gpt_model = model_provider.provide(loss_fn=loss_fn)
         gpt_model._gen_aoa_config = cls._gen_aoa_config
         gpt_model._gen_inv_aoa_config = cls._gen_inv_aoa_config
+        gpt_model._gen_hf_quan_config = cls._gen_hf_quan_config
         gpt_model.build_muon_param_info_map = cls.build_muon_param_info_map
         if not hasattr(config, "architectures"):
             config.architectures = [cls.__name__.replace("Pipe", "")]

--- a/paddleformers/transformers/deepseek_v4/modeling.py
+++ b/paddleformers/transformers/deepseek_v4/modeling.py
@@ -385,8 +385,9 @@ class DeepseekV4PreTrainedModel(PretrainedModel):
     def _gen_hf_quan_config(cls):
         """Describe the FP8 block-quantized DeepSeek-V4 HF checkpoint.
 
-        Consumed by ``Trainer`` when ``load_from_hf`` and
-        ``hf_quantized_load_mode`` are both enabled; the descriptor is passed to
+        Consumed by ``Trainer`` when ``load_from_hf`` is enabled and the
+        checkpoint's ``config.json`` declares a ``quantization_config``; the
+        descriptor is passed to
         ``paddleformers.quantization.hf_checkpoint`` to build the dequantization
         transform.  The logical ``.weight`` names this produces are exactly the
         AOA sources in :meth:`_gen_aoa_config`.

--- a/paddleformers/transformers/kimi_k3/modeling.py
+++ b/paddleformers/transformers/kimi_k3/modeling.py
@@ -79,6 +79,38 @@ class KimiK3PretrainedModel(PretrainedModel):
         return layer_idx % frequency == 0
 
     @classmethod
+    def _gen_hf_quan_config(cls):
+        """Describe the MXFP4 group-quantized Kimi-K3 HF checkpoint.
+
+        The released compressed-tensors checkpoint only quantizes the routed
+        experts (``w1``/``w3``/``w2``); attention, shared experts, dense MLPs,
+        ``lm_head``, and the vision half stay in bfloat16 via the HF
+        ``quantization_config.ignore`` list, so a single group is enough.
+        Each expert stores ``.weight_packed`` (two E2M1 nibbles per uint8, low
+        nibble first) plus ``.weight_scale`` (uint8 E8M0 exponents, one per
+        group of 32 along the last axis).  The logical ``.weight`` names this
+        produces are exactly the AOA sources in :meth:`_gen_aoa_config`.
+        """
+        return {
+            "schema_version": 1,
+            "component_pairing": {"weight_suffix": ".weight_packed", "scale_suffix": ".weight_scale"},
+            "logic_name_suffix": ".weight",
+            "groups": [
+                {
+                    "name": "mxfp4_group",
+                    "targets": [
+                        r"re:^language_model\.model\.layers\.[0-9]+"
+                        r"\.block_sparse_moe\.experts\.[0-9]+\.w[123]\.weight_packed$"
+                    ],
+                    "quant_method": "mxfp4_group",
+                    "value_format": "e2m1",
+                    "scale_format": "ue8m0",
+                    "block_shape": [32],
+                }
+            ],
+        }
+
+    @classmethod
     def _gen_aoa_config(cls, config):
         """Map the official Kimi-K3 HuggingFace checkpoint to Fleet GPT."""
         if hasattr(config, "get_text_config"):
@@ -596,6 +628,7 @@ def _build_text_model(model_class, config):
     gpt_model.is_fleet = model_class.is_fleet
     gpt_model._gen_aoa_config = model_class._gen_aoa_config
     gpt_model._gen_inv_aoa_config = model_class._gen_inv_aoa_config
+    gpt_model._gen_hf_quan_config = model_class._gen_hf_quan_config
     return gpt_model
 
 
@@ -776,6 +809,7 @@ def _build_vl_model(config, criterion):
     language_model.is_fleet = True
     language_model._gen_aoa_config = lambda _=None: KimiK3ForConditionalGeneration._gen_aoa_config(config)
     language_model._gen_inv_aoa_config = lambda _=None: KimiK3ForConditionalGeneration._gen_inv_aoa_config(config)
+    language_model._gen_hf_quan_config = KimiK3ForConditionalGeneration._gen_hf_quan_config
     language_model.can_generate = lambda: False
     language_model.save_pretrained = types.MethodType(PretrainedModel.save_pretrained, language_model)
     return language_model

--- a/tests/ai_edited_test/quantization/hf_dequant_load_dist_logic.py
+++ b/tests/ai_edited_test/quantization/hf_dequant_load_dist_logic.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Per-rank worker for test_ai_hf_dequant_load_dist.py.
+
+Loads one fp8_block weight into a ``Shard(0)`` target on two cards.  Each rank
+holds two of the four logical rows, which is block-aligned, so the transform
+plans a ``"local"`` read: the physical qweight/scale slices this rank reads
+cover its rows only, and the dequantized output is written without slicing.
+"""
+
+import json
+import os
+
+import numpy as np
+import paddle
+import paddle.distributed as dist
+
+from paddleformers.quantization.hf_checkpoint import build_hf_dequant_load_transform
+
+WEIGHT_KEY = "layers.0.attn.wq_a.weight"
+SCALE_KEY = "layers.0.attn.wq_a.scale"
+SAFETENSORS_FILE = "model-00001-of-00001.safetensors"
+
+LOGICAL_SHAPE = (4, 4)
+BLOCK_SHAPE = (2, 2)
+# e4m3 codes for 1, 2, 4 and 8: exponent bias 7, mantissa zero.  One code per
+# logical row, so a wrong row mapping shows up as a wrong magnitude.
+E4M3_ROW_CODES = (0x38, 0x40, 0x48, 0x50)
+# ue8m0 codes are biased exponents, so 127 is 2**0 and 128 is 2**1.  The grid is
+# asymmetric on purpose: reading the wrong scale block cannot cancel out.
+SCALE_GRID = ((127, 128), (128, 127))
+UE8M0_BIAS = 127
+
+
+def descriptor():
+    """The quantization rules a model would return from _gen_hf_quan_config()."""
+    return {
+        "schema_version": 1,
+        "component_pairing": {"weight_suffix": ".weight", "scale_suffix": ".scale"},
+        "logic_name_suffix": ".weight",
+        "groups": [
+            {
+                "name": "fp8",
+                "targets": [r"re:.*\.attn\.wq_a\.weight$"],
+                "quant_method": "fp8_block",
+                "value_format": "e4m3",
+                "scale_format": "ue8m0",
+                "block_shape": list(BLOCK_SHAPE),
+            }
+        ],
+    }
+
+
+def expected_logical_weight():
+    """Reference dequantization; every value is a power of two, so it is exact."""
+    values = np.empty(LOGICAL_SHAPE, dtype="float32")
+    for row in range(LOGICAL_SHAPE[0]):
+        value = float(2**row)
+        for col in range(LOGICAL_SHAPE[1]):
+            code = SCALE_GRID[row // BLOCK_SHAPE[0]][col // BLOCK_SHAPE[1]]
+            values[row, col] = value * float(2 ** (code - UE8M0_BIAS))
+    return values
+
+
+def write_checkpoint(path):
+    """Write a real-payload HF checkpoint: raw e4m3 codes plus a ue8m0 scale grid."""
+    arrays = [
+        (WEIGHT_KEY, "F8_E4M3", np.array([[code] * LOGICAL_SHAPE[1] for code in E4M3_ROW_CODES], dtype=np.uint8)),
+        (SCALE_KEY, "F8_E8M0", np.array(SCALE_GRID, dtype=np.uint8)),
+    ]
+    header = {}
+    payload = b""
+    for key, storage_format, array in arrays:
+        raw = array.tobytes()
+        header[key] = {
+            "dtype": storage_format,
+            "shape": list(array.shape),
+            "data_offsets": [len(payload), len(payload) + len(raw)],
+        }
+        payload += raw
+    raw_header = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    raw_header += b" " * ((8 - len(raw_header) % 8) % 8)
+    with open(os.path.join(path, SAFETENSORS_FILE), "wb") as file:
+        file.write(len(raw_header).to_bytes(8, byteorder="little"))
+        file.write(raw_header)
+        file.write(payload)
+
+
+def main():
+    dist.init_parallel_env()
+    ckpt_path = os.environ["ckpt_path"]
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+
+    if rank == 0:
+        write_checkpoint(ckpt_path)
+    dist.barrier()
+
+    # Collective: every rank scans its share of the safetensors headers.
+    transform = build_hf_dequant_load_transform(ckpt_path, True, descriptor())
+
+    mesh = dist.ProcessMesh(list(range(world_size)))
+    target = dist.shard_tensor(
+        paddle.zeros(list(LOGICAL_SHAPE), dtype="bfloat16"),
+        mesh,
+        [dist.Shard(0)],
+    )
+    dist.load_state_dict(
+        {WEIGHT_KEY: target},
+        ckpt_path,
+        safetensors=True,
+        load_transform=transform,
+    )
+
+    rows = LOGICAL_SHAPE[0] // world_size
+    start = rank * rows
+
+    # The plan proves the local path ran: a global plan would have read the whole
+    # qweight and sliced afterwards.
+    plan = transform._read_plans[WEIGHT_KEY]
+    assert plan.mode == "local", f"rank {rank} planned a {plan.mode!r} read"
+    assert plan.logical_local_shape == (rows, LOGICAL_SHAPE[1]), f"rank {rank} planned for {plan.logical_local_shape}"
+    assert plan.logical_global_offset == (start, 0), f"rank {rank} planned at offset {plan.logical_global_offset}"
+    qweight_slice = plan.source_slices[WEIGHT_KEY]
+    assert tuple(qweight_slice.global_offset) == (start, 0)
+    assert tuple(qweight_slice.local_shape) == (rows, LOGICAL_SHAPE[1])
+    scale_slice = plan.source_slices[SCALE_KEY]
+    assert tuple(scale_slice.global_offset) == (start // BLOCK_SHAPE[0], 0)
+    assert tuple(scale_slice.local_shape) == (rows // BLOCK_SHAPE[0], 2)
+
+    expected = expected_logical_weight()[start : start + rows]
+    local = target._local_value().astype("float32").numpy()
+    assert local.shape == expected.shape, f"rank {rank} got local shape {local.shape}, expected {expected.shape}"
+    np.testing.assert_allclose(local, expected)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ai_edited_test/quantization/hf_dequant_load_dist_logic.py
+++ b/tests/ai_edited_test/quantization/hf_dequant_load_dist_logic.py
@@ -108,7 +108,7 @@ def main():
     dist.barrier()
 
     # Collective: every rank scans its share of the safetensors headers.
-    transform = build_hf_dequant_load_transform(ckpt_path, True, descriptor())
+    transform = build_hf_dequant_load_transform(ckpt_path, descriptor())
 
     mesh = dist.ProcessMesh(list(range(world_size)))
     target = dist.shard_tensor(

--- a/tests/ai_edited_test/quantization/test_ai_hf_checkpoint_dequant.py
+++ b/tests/ai_edited_test/quantization/test_ai_hf_checkpoint_dequant.py
@@ -42,7 +42,7 @@ from paddleformers.quantization.hf_checkpoint import (
     build_hf_dequant_load_transform,
 )
 
-# Written into the checkpoint directory by paddle's create_hf_ckpt_metadata().
+# Physical metadata file DCP looks for in an HF checkpoint directory.
 PADDLE_METADATA_FILE_NAME = "flex-ckpt.auto_generated.metadata"
 SAFETENSORS_FILE_NAME = "model-00001-of-00001.safetensors"
 # Byte width of every safetensors storage format used below.
@@ -853,7 +853,7 @@ class TestHFDequantLoadTransform(CPUDequantTestCase):
 
 
 class TestBuildHFDequantLoadTransform(unittest.TestCase):
-    """End-to-end construction from a real HF safetensors directory."""
+    """End-to-end construction from a checkpoint directory."""
 
     def setUp(self):
         self.checkpoint_path = tempfile.mkdtemp()
@@ -871,6 +871,25 @@ class TestBuildHFDequantLoadTransform(unittest.TestCase):
             ],
         )
 
+    def write_paddle_metadata(self, entries=None):
+        """State the physical metadata the checkpoint directory carries.
+
+        ``create_hf_ckpt_metadata()`` cannot describe a quantized checkpoint: its
+        dtype table has no F8_* entry, so it is the checkpoint producer that has
+        to supply this file.  Raw 8-bit formats appear as ``uint8`` because that
+        is what leaves their meaning to the transform.
+        """
+        if entries is None:
+            entries = {
+                FP8_WEIGHT: ((4, 4), "uint8"),
+                FP8_SCALE: ((2, 2), "uint8"),
+                UNQUANTIZED_WEIGHT: ((4,), "bfloat16"),
+            }
+        paddle.save(
+            physical_metadata(entries),
+            os.path.join(self.checkpoint_path, PADDLE_METADATA_FILE_NAME),
+        )
+
     def test_disabled_mode_returns_none(self):
         self.write_checkpoint()
 
@@ -881,10 +900,10 @@ class TestBuildHFDequantLoadTransform(unittest.TestCase):
         self.write_checkpoint()
 
         self.assertIsNone(build_hf_dequant_load_transform(self.checkpoint_path, True))
-        self.assertNotIn(PADDLE_METADATA_FILE_NAME, os.listdir(self.checkpoint_path))
 
-    def test_transform_is_built_from_the_safetensors_headers(self):
+    def test_transform_is_built_from_the_checkpoint_metadata(self):
         self.write_checkpoint()
+        self.write_paddle_metadata()
 
         transform = build_hf_dequant_load_transform(self.checkpoint_path, True, descriptor_dict())
 
@@ -893,24 +912,23 @@ class TestBuildHFDequantLoadTransform(unittest.TestCase):
         self.assertEqual(set(logical), {FP8_WEIGHT})
         self.assertEqual(tuple(logical[FP8_WEIGHT].global_shape), (4, 4))
         self.assertEqual(logical[FP8_WEIGHT].dtype, "bfloat16")
-        # Raw 8-bit formats must survive as uint8 so the transform owns their meaning.
+        # Raw 8-bit formats stay uint8 so the transform owns their meaning.
         physical = transform.quan_metadata.physical_metadata.state_dict_metadata
         self.assertEqual(physical[FP8_WEIGHT][0].dtype, "uint8")
         self.assertEqual(physical[FP8_SCALE][0].dtype, "uint8")
 
-    def test_generated_paddle_metadata_is_reused_on_the_next_build(self):
-        self.write_checkpoint()
-        first = build_hf_dequant_load_transform(self.checkpoint_path, True, descriptor_dict())
-        self.assertIn(PADDLE_METADATA_FILE_NAME, os.listdir(self.checkpoint_path))
+    def test_paddle_metadata_is_read_instead_of_the_safetensors_files(self):
+        self.write_paddle_metadata()
 
-        # Deleting the safetensors file proves the second build reads the cached metadata.
-        os.remove(os.path.join(self.checkpoint_path, SAFETENSORS_FILE_NAME))
-        second = build_hf_dequant_load_transform(self.checkpoint_path, True, descriptor_dict())
+        # No safetensors file was ever written, so the build can only have come
+        # from the metadata file.
+        transform = build_hf_dequant_load_transform(self.checkpoint_path, True, descriptor_dict())
 
-        self.assertEqual(set(second.logical_metadata()), set(first.logical_metadata()))
+        self.assertEqual(set(transform.logical_metadata()), {FP8_WEIGHT})
 
     def test_unquantized_checkpoint_with_a_descriptor_is_rejected(self):
         self.write_checkpoint([(UNQUANTIZED_WEIGHT, "BF16", (4,))])
+        self.write_paddle_metadata({UNQUANTIZED_WEIGHT: ((4,), "bfloat16")})
 
         with self.assertRaisesRegex(ValueError, "matched no quantized weight/scale pairs"):
             build_hf_dequant_load_transform(self.checkpoint_path, True, descriptor_dict())

--- a/tests/ai_edited_test/quantization/test_ai_hf_checkpoint_dequant.py
+++ b/tests/ai_edited_test/quantization/test_ai_hf_checkpoint_dequant.py
@@ -485,6 +485,33 @@ class TestQuanDescriptorValidation(unittest.TestCase):
 
         self.assertEqual(set(metadata.relations), {FP8_WEIGHT})
 
+    def test_literal_targets_do_not_match_longer_names(self):
+        """A literal target names one exact tensor; ``re:`` stays the way to cover a family."""
+        cases = [
+            (
+                "extra prefix on the checkpoint key",
+                FP8_WEIGHT,
+                {"prefix." + FP8_WEIGHT: ((4, 4), "uint8"), "prefix." + FP8_SCALE: ((2, 2), "uint8")},
+            ),
+            (
+                "layer indices sharing a numeric prefix",
+                "layers.1",
+                {"layers.11.attn.wq_a.weight": ((4, 4), "uint8"), "layers.11.attn.wq_a.scale": ((2, 2), "uint8")},
+            ),
+            (
+                "target stopping short of the weight suffix",
+                FP8_WEIGHT[: -len(WEIGHT_SUFFIX)],
+                {FP8_WEIGHT: ((4, 4), "uint8"), FP8_SCALE: ((2, 2), "uint8")},
+            ),
+        ]
+
+        for name, target, entries in cases:
+            with self.subTest(name):
+                descriptor = QuanDescriptor.from_dict(descriptor_dict(fp8_group(targets=[target])))
+
+                with self.assertRaisesRegex(ValueError, "did not match all quantized weight/scale pairs"):
+                    descriptor.build_metadata(physical_metadata(entries))
+
     def test_invalid_descriptors_are_rejected(self):
         cases = [
             ("unsupported schema version", descriptor_dict(schema_version=2), "schema_version"),

--- a/tests/ai_edited_test/quantization/test_ai_hf_checkpoint_dequant.py
+++ b/tests/ai_edited_test/quantization/test_ai_hf_checkpoint_dequant.py
@@ -699,9 +699,6 @@ class TestHFDequantLoadTransform(CPUDequantTestCase):
         with self.assertRaisesRegex(KeyError, "is not managed by this load transform"):
             self.transform.source_keys("layers.0.attn.wq_b.weight")
 
-    def test_no_plan_is_cached_before_planning(self):
-        self.assertIsNone(self.transform.read_plan_for(FP8_WEIGHT))
-
     def test_block_aligned_shard_reads_local_slices(self):
         plan = self.transform.read_plan(FP8_WEIGHT, target_shard((4, 4), (2, 4), (0, 0)))
 
@@ -715,7 +712,6 @@ class TestHFDequantLoadTransform(CPUDequantTestCase):
         scale = plan.source_slices[FP8_SCALE]
         self.assertEqual(tuple(scale.global_shape), (2, 2))
         self.assertEqual((tuple(scale.global_offset), tuple(scale.local_shape)), ((0, 0), (1, 2)))
-        self.assertIs(self.transform.read_plan_for(FP8_WEIGHT), plan)
 
     def test_offset_shard_maps_onto_the_matching_scale_rows(self):
         plan = self.transform.read_plan(FP8_WEIGHT, target_shard((4, 4), (2, 4), (2, 0)))
@@ -802,6 +798,18 @@ class TestHFDequantLoadTransform(CPUDequantTestCase):
         )
 
         np.testing.assert_array_equal(output.numpy(), np.full((2, 4), 2.0, dtype="float32"))
+
+    def test_apply_without_a_plan_expects_the_whole_logical_tensor(self):
+        """No cached plan means no local read happened, so a shard is a bug."""
+        with self.assertRaisesRegex(ValueError, "expected \\(4, 4\\), got \\(2, 4\\)"):
+            self.transform.apply(
+                FP8_WEIGHT,
+                {
+                    FP8_WEIGHT: paddle.full([2, 4], E4M3_ONE, dtype="uint8"),
+                    FP8_SCALE: paddle.full([1, 2], 128, dtype="uint8"),
+                },
+                paddle.float32,
+            )
 
     def test_apply_rejects_sources_that_contradict_the_cached_plan(self):
         self.transform.read_plan(FP8_WEIGHT, target_shard((4, 4), (2, 4), (0, 0)))

--- a/tests/ai_edited_test/quantization/test_ai_hf_checkpoint_dequant.py
+++ b/tests/ai_edited_test/quantization/test_ai_hf_checkpoint_dequant.py
@@ -40,10 +40,12 @@ from paddleformers.quantization.hf_checkpoint import (
     QuanDescriptor,
     QuanMetadata,
     build_hf_dequant_load_transform,
+    hf_checkpoint_is_quantized,
 )
 
 # Physical metadata file DCP looks for in an HF checkpoint directory.
 PADDLE_METADATA_FILE_NAME = "flex-ckpt.auto_generated.metadata"
+HF_CONFIG_FILE_NAME = "config.json"
 SAFETENSORS_FILE_NAME = "model-00001-of-00001.safetensors"
 # Byte width of every safetensors storage format used below.
 SAFETENSORS_ITEM_SIZE = {"F8_E4M3": 1, "F8_E8M0": 1, "I8": 1, "U8": 1, "BF16": 2}
@@ -852,6 +854,64 @@ class TestHFDequantLoadTransform(CPUDequantTestCase):
             )
 
 
+class TestHFCheckpointIsQuantized(unittest.TestCase):
+    """Detection of quantized checkpoints from their own config.json."""
+
+    def setUp(self):
+        self.checkpoint_path = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.checkpoint_path, True)
+
+    def write_hf_config(self, config):
+        with open(os.path.join(self.checkpoint_path, HF_CONFIG_FILE_NAME), "w", encoding="utf-8") as file:
+            json.dump(config, file)
+
+    def test_fp8_block_checkpoint_is_detected(self):
+        """The quantization_config a DeepSeek-V4 FP8 release carries."""
+        self.write_hf_config(
+            {
+                "model_type": "deepseek_v4",
+                "quantization_config": {
+                    "activation_scheme": "dynamic",
+                    "fmt": "e4m3",
+                    "quant_method": "fp8",
+                    "weight_block_size": [128, 128],
+                },
+            }
+        )
+        self.assertTrue(hf_checkpoint_is_quantized(self.checkpoint_path))
+
+    def test_compressed_tensors_checkpoint_is_detected(self):
+        """The quantization_config a Kimi-K3 MXFP4 release carries."""
+        self.write_hf_config(
+            {
+                "model_type": "kimi_k3",
+                "quantization_config": {
+                    "config_groups": {"group_0": {"weights": {"num_bits": 4}}},
+                    "format": "pack-quantized",
+                    "ignore": ["lm_head"],
+                    "quant_method": "compressed-tensors",
+                },
+            }
+        )
+        self.assertTrue(hf_checkpoint_is_quantized(self.checkpoint_path))
+
+    def test_unquantized_checkpoint_is_not_detected(self):
+        self.write_hf_config({"model_type": "deepseek_v4", "dtype": "bfloat16"})
+        self.assertFalse(hf_checkpoint_is_quantized(self.checkpoint_path))
+
+    def test_empty_quantization_config_is_not_detected(self):
+        """An empty block states no quantization, so it must not enable the transform."""
+        self.write_hf_config({"quantization_config": {}})
+        self.assertFalse(hf_checkpoint_is_quantized(self.checkpoint_path))
+
+    def test_non_object_quantization_config_is_not_detected(self):
+        self.write_hf_config({"quantization_config": "fp8"})
+        self.assertFalse(hf_checkpoint_is_quantized(self.checkpoint_path))
+
+    def test_checkpoint_without_a_config_file_is_not_detected(self):
+        self.assertFalse(hf_checkpoint_is_quantized(self.checkpoint_path))
+
+
 class TestBuildHFDequantLoadTransform(unittest.TestCase):
     """End-to-end construction from a checkpoint directory."""
 
@@ -890,22 +950,17 @@ class TestBuildHFDequantLoadTransform(unittest.TestCase):
             os.path.join(self.checkpoint_path, PADDLE_METADATA_FILE_NAME),
         )
 
-    def test_disabled_mode_returns_none(self):
-        self.write_checkpoint()
-
-        self.assertIsNone(build_hf_dequant_load_transform(self.checkpoint_path, False, descriptor_dict()))
-
     def test_checkpoint_without_a_model_descriptor_returns_none(self):
         """Quantization rules come from the model definition, never from the checkpoint."""
         self.write_checkpoint()
 
-        self.assertIsNone(build_hf_dequant_load_transform(self.checkpoint_path, True))
+        self.assertIsNone(build_hf_dequant_load_transform(self.checkpoint_path))
 
     def test_transform_is_built_from_the_checkpoint_metadata(self):
         self.write_checkpoint()
         self.write_paddle_metadata()
 
-        transform = build_hf_dequant_load_transform(self.checkpoint_path, True, descriptor_dict())
+        transform = build_hf_dequant_load_transform(self.checkpoint_path, descriptor_dict())
 
         self.assertIsInstance(transform, HFDequantLoadTransform)
         logical = transform.logical_metadata()
@@ -922,7 +977,7 @@ class TestBuildHFDequantLoadTransform(unittest.TestCase):
 
         # No safetensors file was ever written, so the build can only have come
         # from the metadata file.
-        transform = build_hf_dequant_load_transform(self.checkpoint_path, True, descriptor_dict())
+        transform = build_hf_dequant_load_transform(self.checkpoint_path, descriptor_dict())
 
         self.assertEqual(set(transform.logical_metadata()), {FP8_WEIGHT})
 
@@ -931,7 +986,7 @@ class TestBuildHFDequantLoadTransform(unittest.TestCase):
         self.write_paddle_metadata({UNQUANTIZED_WEIGHT: ((4,), "bfloat16")})
 
         with self.assertRaisesRegex(ValueError, "matched no quantized weight/scale pairs"):
-            build_hf_dequant_load_transform(self.checkpoint_path, True, descriptor_dict())
+            build_hf_dequant_load_transform(self.checkpoint_path, descriptor_dict())
 
 
 if __name__ == "__main__":

--- a/tests/ai_edited_test/quantization/test_ai_hf_checkpoint_dequant.py
+++ b/tests/ai_edited_test/quantization/test_ai_hf_checkpoint_dequant.py
@@ -1,0 +1,885 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for quantization/checkpoint_dequant.py and quantization/hf_checkpoint.py."""
+
+import json
+import os
+import shutil
+import tempfile
+import unittest
+
+import numpy as np
+import paddle
+from paddle.distributed.flex_checkpoint.dcp.metadata import (
+    LocalTensorMetadata,
+    Metadata,
+)
+
+import paddleformers.quantization.checkpoint_dequant as checkpoint_dequant
+from paddleformers.quantization.checkpoint_dequant import (
+    FP8BlockCheckpointDequantizer,
+    MXFP4GroupCheckpointDequantizer,
+    get_checkpoint_dequantizer,
+    register_checkpoint_dequantizer,
+)
+from paddleformers.quantization.hf_checkpoint import (
+    HFDequantLoadTransform,
+    HFQuantizationGroupSpec,
+    HFQuantizedWeightSpec,
+    QuanDescriptor,
+    QuanMetadata,
+    build_hf_dequant_load_transform,
+)
+
+# Written into the checkpoint directory by paddle's create_hf_ckpt_metadata().
+PADDLE_METADATA_FILE_NAME = "flex-ckpt.auto_generated.metadata"
+SAFETENSORS_FILE_NAME = "model-00001-of-00001.safetensors"
+# Byte width of every safetensors storage format used below.
+SAFETENSORS_ITEM_SIZE = {"F8_E4M3": 1, "F8_E8M0": 1, "I8": 1, "U8": 1, "BF16": 2}
+
+WEIGHT_SUFFIX = ".weight"
+SCALE_SUFFIX = ".scale"
+FP8_WEIGHT = "layers.0.attn.wq_a.weight"
+FP8_SCALE = "layers.0.attn.wq_a.scale"
+MXFP4_WEIGHT = "layers.0.mlp.experts.0.w1.weight"
+MXFP4_SCALE = "layers.0.mlp.experts.0.w1.scale"
+UNQUANTIZED_WEIGHT = "layers.0.norm.weight"
+# ue8m0 exponent codes: 127 is 2**0, so 125..129 cover 0.25 .. 4.0.
+UE8M0_ONE = 127
+# e4m3 code for 1.0 (exponent bias 7, zero mantissa).
+E4M3_ONE = 0x38
+
+
+def fp8_group(**overrides):
+    """Return a fresh fp8_block descriptor group so tests never share mutable state."""
+    group = {
+        "name": "fp8",
+        "targets": [r"re:.*\.attn\.wq_a\.weight$"],
+        "quant_method": "fp8_block",
+        "value_format": "e4m3",
+        "scale_format": "ue8m0",
+        "block_shape": [2, 2],
+    }
+    group.update(overrides)
+    return group
+
+
+def mxfp4_group(**overrides):
+    """Return a fresh mxfp4_group descriptor group."""
+    group = {
+        "name": "mxfp4",
+        "targets": [r"re:.*\.experts\.[0-9]+\.w[123]\.weight$"],
+        "quant_method": "mxfp4_group",
+        "value_format": "e2m1",
+        "scale_format": "ue8m0",
+        "block_shape": [2],
+    }
+    group.update(overrides)
+    return group
+
+
+def descriptor_dict(*group_dicts, **overrides):
+    """Build a descriptor payload; defaults to a single fp8_block group."""
+    payload = {
+        "schema_version": 1,
+        "component_pairing": {"weight_suffix": WEIGHT_SUFFIX, "scale_suffix": SCALE_SUFFIX},
+        "logic_name_suffix": WEIGHT_SUFFIX,
+        "groups": list(group_dicts) or [fp8_group()],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def physical_metadata(entries):
+    """Build Metadata shaped like what create_hf_ckpt_metadata() returns for an HF checkpoint."""
+    return Metadata(
+        state_dict_metadata={
+            key: [
+                LocalTensorMetadata(
+                    global_offset=(0,) * len(shape),
+                    local_shape=tuple(shape),
+                    global_shape=tuple(shape),
+                    dtype=dtype,
+                )
+            ]
+            for key, (shape, dtype) in entries.items()
+        },
+        storage_metadata={},
+    )
+
+
+def fp8_physical_metadata(weight_shape=(4, 4), scale_shape=(2, 2)):
+    """Physical metadata for one fp8_block weight/scale pair."""
+    return physical_metadata({FP8_WEIGHT: (weight_shape, "uint8"), FP8_SCALE: (scale_shape, "uint8")})
+
+
+def fp8_group_spec(block_axes=(0, 1), block_shape=(2, 2)):
+    """Build a group spec directly, bypassing descriptor parsing."""
+    spec = HFQuantizationGroupSpec(
+        name="fp8",
+        targets=(),
+        quant_method="fp8_block",
+        value_format="e4m3",
+        scale_format="ue8m0",
+        block_shape=tuple(block_shape),
+        dequantizer=get_checkpoint_dequantizer("fp8_block").configure_formats("e4m3", "ue8m0"),
+    )
+    if block_axes is not None:
+        spec.configure_geometry(block_axes)
+    return spec
+
+
+def fp8_weight_spec(logical_shape=(4, 4), components=None, group_name="fp8", logical_name=FP8_WEIGHT):
+    """Build a weight relation directly, bypassing descriptor parsing."""
+    return HFQuantizedWeightSpec(
+        group_name=group_name,
+        logical_name=logical_name,
+        logical_shape=tuple(logical_shape),
+        components={"qweight": FP8_WEIGHT, "scale": FP8_SCALE} if components is None else components,
+    )
+
+
+def write_safetensors(path, tensors):
+    """Write a safetensors file whose payload is zeroed; only the header is read here."""
+    header = {}
+    offset = 0
+    for key, storage_format, shape in tensors:
+        nbytes = SAFETENSORS_ITEM_SIZE[storage_format]
+        for dim in shape:
+            nbytes *= dim
+        header[key] = {
+            "dtype": storage_format,
+            "shape": list(shape),
+            "data_offsets": [offset, offset + nbytes],
+        }
+        offset += nbytes
+    raw_header = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    raw_header += b" " * ((8 - len(raw_header) % 8) % 8)
+    with open(path, "wb") as file:
+        file.write(len(raw_header).to_bytes(8, byteorder="little"))
+        file.write(raw_header)
+        file.write(bytes(offset))
+
+
+def configured_dequantizer(method, value_format, scale_format, block_axes, block_shape):
+    """Fully configure a registered dequantizer prototype."""
+    return (
+        get_checkpoint_dequantizer(method)
+        .configure_formats(value_format, scale_format)
+        .configure_geometry(block_axes, block_shape)
+    )
+
+
+def target_shard(global_shape, local_shape, global_offset, dtype="bfloat16"):
+    """Describe the logical shard a rank wants to load."""
+    return LocalTensorMetadata(
+        global_offset=tuple(global_offset),
+        local_shape=tuple(local_shape),
+        global_shape=tuple(global_shape),
+        dtype=dtype,
+    )
+
+
+class CPUDequantTestCase(unittest.TestCase):
+    """Pin tensor-producing tests to CPU so results never depend on the CI device."""
+
+    def setUp(self):
+        self._original_device = paddle.get_device()
+        paddle.set_device("cpu")
+
+    def tearDown(self):
+        paddle.set_device(self._original_device)
+
+
+class TestRawFormatDecoding(CPUDequantTestCase):
+    """Raw 8-bit safetensors codes are reinterpreted by checkpoint_dequant, not by paddle."""
+
+    def test_e4m3_decodes_zero_subnormal_normal_max_and_nan(self):
+        """0x00/0x01/0x38/0x7E/0xFE/0x7F cover every interesting e4m3 region."""
+        qweight = paddle.to_tensor([[0x00, 0x01, E4M3_ONE, 0x7E, 0xFE, 0x7F]], dtype="uint8")
+        scale = paddle.to_tensor([[UE8M0_ONE]], dtype="uint8")
+        dequantizer = configured_dequantizer("fp8_block", "e4m3", "ue8m0", (0, 1), (1, 6))
+
+        output = dequantizer.dequantize({"qweight": qweight, "scale": scale}, paddle.float32).numpy()
+
+        np.testing.assert_array_equal(output[0, :5], [0.0, 2.0**-9, 1.0, 448.0, -448.0])
+        self.assertTrue(np.isnan(output[0, 5]))
+
+    def test_ue8m0_scale_codes_decode_to_powers_of_two(self):
+        """Every scale element is a biased exponent, so codes 125..129 give 0.25 .. 4.0."""
+        qweight = paddle.full([1, 5], E4M3_ONE, dtype="uint8")
+        scale = paddle.to_tensor([[125, 126, 127, 128, 129]], dtype="uint8")
+        dequantizer = configured_dequantizer("fp8_block", "e4m3", "ue8m0", (0, 1), (1, 1))
+
+        output = dequantizer.dequantize({"qweight": qweight, "scale": scale}, paddle.float32)
+
+        np.testing.assert_array_equal(output.numpy(), [[0.25, 0.5, 1.0, 2.0, 4.0]])
+
+    def test_int8_storage_is_reinterpreted_as_unsigned_codes(self):
+        """Safetensors I8 tensors deliver codes >= 128 as negative int8 values."""
+        qweight = paddle.to_tensor([[E4M3_ONE, -2]], dtype="int8")  # -2 is the byte 0xFE
+        scale = paddle.full([1, 2], UE8M0_ONE, dtype="uint8")
+        dequantizer = configured_dequantizer("fp8_block", "e4m3", "ue8m0", (0, 1), (1, 1))
+
+        output = dequantizer.dequantize({"qweight": qweight, "scale": scale}, paddle.float32)
+
+        np.testing.assert_array_equal(output.numpy(), [[1.0, -448.0]])
+
+    def test_e2m1_unpacks_the_low_nibble_before_the_high_nibble(self):
+        """0x21 holds codes (1, 2); 0xA9 holds codes (9, 10), i.e. the negative half."""
+        qweight = paddle.to_tensor([[0x21, -87]], dtype="int8")  # -87 is the byte 0xA9
+        scale = paddle.to_tensor([[127, 128]], dtype="uint8")
+        dequantizer = configured_dequantizer("mxfp4_group", "e2m1", "ue8m0", (1,), (2,))
+
+        output = dequantizer.dequantize({"qweight": qweight, "scale": scale}, paddle.float32)
+
+        np.testing.assert_array_equal(output.numpy(), [[0.5, 1.0, -1.0, -2.0]])
+
+    def test_non_8bit_qweight_storage_is_rejected(self):
+        """A float qweight means the safetensors reader lost the raw bytes."""
+        dequantizer = configured_dequantizer("fp8_block", "e4m3", "ue8m0", (0, 1), (1, 1))
+
+        with self.assertRaisesRegex(TypeError, "raw uint8/int8 storage"):
+            dequantizer.dequantize(
+                {
+                    "qweight": paddle.zeros([1, 1], dtype="float32"),
+                    "scale": paddle.full([1, 1], UE8M0_ONE, dtype="uint8"),
+                },
+                paddle.float32,
+            )
+
+
+class TestFP8BlockDequantizer(CPUDequantTestCase):
+    """FP8 block dequantization math, geometry contracts and configuration immutability."""
+
+    def setUp(self):
+        super().setUp()
+        self.dequantizer = configured_dequantizer("fp8_block", "e4m3", "ue8m0", (0, 1), (2, 2))
+
+    def test_block_scales_are_broadcast_across_each_block(self):
+        """A (1, 2) scale grid covers a 2x4 weight in two 2x2 blocks."""
+        qweight = paddle.full([2, 4], E4M3_ONE, dtype="uint8")
+        scale = paddle.to_tensor([[127, 128]], dtype="uint8")
+
+        output = self.dequantizer.dequantize({"qweight": qweight, "scale": scale}, paddle.float32)
+
+        np.testing.assert_array_equal(output.numpy(), [[1.0, 1.0, 2.0, 2.0], [1.0, 1.0, 2.0, 2.0]])
+
+    def test_partial_trailing_block_is_cropped(self):
+        """A 3x3 weight needs a 2x2 grid; the expanded grid is cropped back to 3x3."""
+        qweight = paddle.full([3, 3], E4M3_ONE, dtype="uint8")
+        scale = paddle.to_tensor([[127, 128], [129, 130]], dtype="uint8")
+
+        output = self.dequantizer.dequantize({"qweight": qweight, "scale": scale}, paddle.float32)
+
+        np.testing.assert_array_equal(output.numpy(), [[1.0, 1.0, 2.0], [1.0, 1.0, 2.0], [4.0, 4.0, 8.0]])
+
+    def test_output_dtype_follows_the_request(self):
+        qweight = paddle.full([2, 2], E4M3_ONE, dtype="uint8")
+        scale = paddle.full([1, 1], UE8M0_ONE, dtype="uint8")
+
+        output = self.dequantizer.dequantize({"qweight": qweight, "scale": scale}, paddle.bfloat16)
+
+        self.assertEqual(output.dtype, paddle.bfloat16)
+
+    def test_scale_grid_shape_mismatch_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "Invalid scale grid shape"):
+            self.dequantizer.dequantize(
+                {
+                    "qweight": paddle.full([2, 4], E4M3_ONE, dtype="uint8"),
+                    "scale": paddle.full([1, 1], UE8M0_ONE, dtype="uint8"),
+                },
+                paddle.float32,
+            )
+
+    def test_scale_rank_mismatch_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "Scale rank must match"):
+            self.dequantizer.dequantize(
+                {
+                    "qweight": paddle.full([2, 4], E4M3_ONE, dtype="uint8"),
+                    "scale": paddle.full([2], UE8M0_ONE, dtype="uint8"),
+                },
+                paddle.float32,
+            )
+
+    def test_missing_scale_component_is_rejected(self):
+        with self.assertRaisesRegex(KeyError, "Missing checkpoint quantization components"):
+            self.dequantizer.dequantize({"qweight": paddle.full([2, 2], E4M3_ONE, dtype="uint8")}, paddle.float32)
+
+    def test_dequantize_requires_block_geometry(self):
+        """Formats alone are not enough; block geometry is inferred from the checkpoint."""
+        without_geometry = get_checkpoint_dequantizer("fp8_block").configure_formats("e4m3", "ue8m0")
+
+        with self.assertRaisesRegex(ValueError, "requires block geometry"):
+            without_geometry.dequantize(
+                {
+                    "qweight": paddle.full([2, 2], E4M3_ONE, dtype="uint8"),
+                    "scale": paddle.full([1, 1], UE8M0_ONE, dtype="uint8"),
+                },
+                paddle.float32,
+            )
+
+    def test_configure_formats_rejects_unsupported_formats(self):
+        prototype = get_checkpoint_dequantizer("fp8_block")
+
+        with self.assertRaisesRegex(ValueError, "value_format"):
+            prototype.configure_formats("e2m1", "ue8m0")
+        with self.assertRaisesRegex(ValueError, "scale_format"):
+            prototype.configure_formats("e4m3", "int8")
+
+    def test_configuring_never_mutates_the_registered_prototype(self):
+        """The registry hands out shared singletons, so configuration must copy."""
+        prototype = get_checkpoint_dequantizer("fp8_block")
+
+        configured = prototype.configure_formats("E4M3 ", " UE8M0").configure_geometry((0, 1), (2, 2))
+
+        self.assertIsNot(configured, prototype)
+        self.assertIsNone(prototype.value_format)
+        self.assertIsNone(prototype.block_axes)
+        self.assertEqual((configured.value_format, configured.scale_format), ("e4m3", "ue8m0"))
+        self.assertEqual((configured.block_axes, configured.block_shape), ((0, 1), (2, 2)))
+
+    def test_invalid_block_geometry_is_rejected(self):
+        prototype = get_checkpoint_dequantizer("fp8_block").configure_formats("e4m3", "ue8m0")
+        cases = [
+            ((), ()),  # no axes at all
+            ((0,), (2, 2)),  # axis count and block count disagree
+            ((0, 0), (2, 2)),  # duplicated axis
+            ((-1,), (2,)),  # negative axis
+            ((0,), (0,)),  # non-positive block size
+        ]
+
+        for block_axes, block_shape in cases:
+            with self.subTest(block_axes=block_axes, block_shape=block_shape):
+                with self.assertRaisesRegex(ValueError, "Invalid block geometry"):
+                    prototype.configure_geometry(block_axes, block_shape)
+
+    def test_shard_alignment_allows_block_edges_and_tensor_bounds(self):
+        """Local reads are only safe when both shard bounds land on a block or tensor edge."""
+        cases = [
+            ((0, 0), (2, 4), True),
+            ((2, 0), (2, 4), True),
+            ((2, 2), (2, 2), True),
+            ((0, 0), (4, 4), True),
+            ((0, 0), (3, 4), False),  # end 3 is neither a block edge nor the bound
+            ((1, 0), (2, 4), False),  # unaligned start
+            ((0, 0), (4, 3), False),  # unaligned end on the last axis
+        ]
+
+        for global_offset, local_shape, expected in cases:
+            with self.subTest(global_offset=global_offset, local_shape=local_shape):
+                self.assertEqual(
+                    self.dequantizer.logical_shard_is_aligned((4, 4), local_shape, global_offset),
+                    expected,
+                )
+
+    def test_logical_and_physical_shapes_are_identical(self):
+        """FP8 stores one byte per logical value, unlike the packed MXFP4 layout."""
+        self.assertEqual(self.dequantizer.logical_shape((4, 4)), (4, 4))
+        self.assertEqual(self.dequantizer.physical_qweight_shape((4, 4)), (4, 4))
+        self.assertEqual(self.dequantizer.physical_qweight_slice((2, 0), (2, 4)), ((2, 0), (2, 4)))
+
+
+class TestMXFP4GroupDequantizer(CPUDequantTestCase):
+    """MXFP4 packs two logical values per stored byte, which shifts every shape."""
+
+    def setUp(self):
+        super().setUp()
+        self.dequantizer = configured_dequantizer("mxfp4_group", "e2m1", "ue8m0", (1,), (2,))
+
+    def test_logical_shape_doubles_the_packed_axis(self):
+        self.assertEqual(self.dequantizer.logical_shape((2, 3)), (2, 6))
+
+        with self.assertRaisesRegex(ValueError, "Invalid MXFP4 weight shape"):
+            self.dequantizer.logical_shape(())
+
+    def test_physical_qweight_shape_halves_the_packed_axis(self):
+        self.assertEqual(self.dequantizer.physical_qweight_shape((2, 6)), (2, 3))
+
+        with self.assertRaisesRegex(ValueError, "Invalid MXFP4 logical weight shape"):
+            self.dequantizer.physical_qweight_shape((2, 5))
+
+    def test_physical_qweight_slice_halves_the_packed_axis(self):
+        self.assertEqual(self.dequantizer.physical_qweight_slice((0, 4), (2, 4)), ((0, 2), (2, 2)))
+
+        with self.assertRaisesRegex(ValueError, "even last-axis offsets and sizes"):
+            self.dequantizer.physical_qweight_slice((0, 1), (2, 4))
+
+    def test_shard_alignment_also_requires_even_packed_bounds(self):
+        self.assertTrue(self.dequantizer.logical_shard_is_aligned((2, 8), (2, 4), (0, 0)))
+        self.assertFalse(self.dequantizer.logical_shard_is_aligned((2, 8), (2, 3), (0, 0)))
+
+    def test_group_scales_are_applied_after_unpacking(self):
+        """Each stored byte yields two logical values, and every group of 2 shares a scale."""
+        qweight = paddle.to_tensor([[0x21, 0x43], [0x21, 0x43]], dtype="uint8")
+        scale = paddle.to_tensor([[127, 128], [128, 127]], dtype="uint8")
+
+        output = self.dequantizer.dequantize({"qweight": qweight, "scale": scale}, paddle.float32)
+
+        np.testing.assert_array_equal(output.numpy(), [[0.5, 1.0, 3.0, 4.0], [1.0, 2.0, 1.5, 2.0]])
+
+
+class TestDequantizerRegistry(unittest.TestCase):
+    """Method lookup and registration contracts."""
+
+    def test_lookup_returns_the_prototype_of_each_registered_method(self):
+        self.assertIsInstance(get_checkpoint_dequantizer("fp8_block"), FP8BlockCheckpointDequantizer)
+        self.assertIsInstance(get_checkpoint_dequantizer("mxfp4_group"), MXFP4GroupCheckpointDequantizer)
+
+    def test_lookup_normalizes_the_method_name(self):
+        self.assertIs(get_checkpoint_dequantizer("  FP8_Block "), get_checkpoint_dequantizer("fp8_block"))
+
+    def test_unknown_method_reports_the_registered_methods(self):
+        with self.assertRaisesRegex(ValueError, "Unsupported checkpoint quantization method 'int4_block'"):
+            get_checkpoint_dequantizer("int4_block")
+
+    def test_invalid_method_names_are_rejected(self):
+        with self.assertRaisesRegex(TypeError, "must be a string"):
+            get_checkpoint_dequantizer(None)
+        with self.assertRaisesRegex(ValueError, "must not be empty"):
+            get_checkpoint_dequantizer("   ")
+
+    def test_registration_makes_a_method_available_under_its_normalized_name(self):
+        dequantizer = FP8BlockCheckpointDequantizer()
+        # There is no public unregister hook, so restore the global registry explicitly.
+        self.addCleanup(checkpoint_dequant._CHECKPOINT_DEQUANTIZERS.pop, "fp8_block_probe", None)
+
+        register_checkpoint_dequantizer("  FP8_Block_Probe ", dequantizer)
+
+        self.assertIs(get_checkpoint_dequantizer("fp8_block_probe"), dequantizer)
+
+    def test_duplicate_registration_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "is already registered"):
+            register_checkpoint_dequantizer("fp8_block", FP8BlockCheckpointDequantizer())
+
+    def test_object_without_a_dequantize_method_is_rejected(self):
+        with self.assertRaisesRegex(TypeError, "callable dequantize"):
+            register_checkpoint_dequantizer("not_a_dequantizer", object())
+
+        self.assertNotIn("not_a_dequantizer", checkpoint_dequant._CHECKPOINT_DEQUANTIZERS)
+
+
+class TestQuanDescriptorValidation(unittest.TestCase):
+    """Descriptor payloads are validated before any checkpoint is opened."""
+
+    def test_valid_descriptor_round_trips(self):
+        payload = descriptor_dict()
+
+        self.assertEqual(QuanDescriptor.from_dict(payload).to_dict(), payload)
+
+    def test_targets_without_the_re_prefix_are_matched_literally(self):
+        descriptor = QuanDescriptor.from_dict(descriptor_dict(fp8_group(targets=[FP8_WEIGHT])))
+
+        metadata = descriptor.build_metadata(fp8_physical_metadata())
+
+        self.assertEqual(set(metadata.relations), {FP8_WEIGHT})
+
+    def test_invalid_descriptors_are_rejected(self):
+        cases = [
+            ("unsupported schema version", descriptor_dict(schema_version=2), "schema_version"),
+            ("empty groups", descriptor_dict(groups=[]), "non-empty groups list"),
+            ("missing component_pairing", descriptor_dict(component_pairing=None), "component_pairing as an object"),
+            (
+                "non-string suffix",
+                descriptor_dict(component_pairing={"weight_suffix": 1, "scale_suffix": SCALE_SUFFIX}),
+                "string weight_suffix and scale_suffix",
+            ),
+            (
+                "empty suffix",
+                descriptor_dict(component_pairing={"weight_suffix": "", "scale_suffix": SCALE_SUFFIX}),
+                "non-empty strings",
+            ),
+            ("empty logic_name_suffix", descriptor_dict(logic_name_suffix=""), "logic_name_suffix"),
+            (
+                "duplicate group names",
+                descriptor_dict(fp8_group(), fp8_group(targets=[r"re:.*\.attn\.wq_b\.weight$"])),
+                "group names must be unique",
+            ),
+            ("blank group name", descriptor_dict(fp8_group(name=" ")), "non-empty name"),
+            ("missing quant_method", descriptor_dict(fp8_group(quant_method="")), "must define quant_method"),
+            ("missing value_format", descriptor_dict(fp8_group(value_format="")), "must define value_format"),
+            ("missing scale_format", descriptor_dict(fp8_group(scale_format="")), "must define scale_format"),
+            ("unknown quant_method", descriptor_dict(fp8_group(quant_method="int4")), "Invalid quan_desc formats"),
+            ("unsupported value_format", descriptor_dict(fp8_group(value_format="e2m1")), "Invalid quan_desc formats"),
+            ("empty block_shape", descriptor_dict(fp8_group(block_shape=[])), "positive integer block_shape"),
+            ("zero block size", descriptor_dict(fp8_group(block_shape=[2, 0])), "positive integer block_shape"),
+            ("empty targets", descriptor_dict(fp8_group(targets=[])), "non-empty string targets list"),
+            ("broken target regex", descriptor_dict(fp8_group(targets=["re:["])), "Invalid quan_desc target pattern"),
+        ]
+
+        for name, payload, message in cases:
+            with self.subTest(name):
+                with self.assertRaisesRegex(ValueError, message):
+                    QuanDescriptor.from_dict(payload)
+
+
+class TestQuanDescriptorMetadata(unittest.TestCase):
+    """build_metadata() binds descriptor rules to the tensors actually present in a checkpoint."""
+
+    def build(self, entries, *group_dicts, output_dtype=paddle.bfloat16):
+        descriptor = QuanDescriptor.from_dict(descriptor_dict(*group_dicts))
+        return descriptor.build_metadata(physical_metadata(entries), output_dtype=output_dtype)
+
+    def test_block_axes_are_inferred_from_the_scale_grid(self):
+        """The descriptor only states block sizes; axes come from the stored scale shape."""
+        metadata = self.build(
+            {
+                FP8_WEIGHT: ((2, 4), "uint8"),
+                FP8_SCALE: ((1, 2), "uint8"),
+                MXFP4_WEIGHT: ((2, 2), "int8"),
+                MXFP4_SCALE: ((2, 1), "uint8"),
+            },
+            fp8_group(),
+            mxfp4_group(block_shape=[4]),
+        )
+
+        self.assertEqual(set(metadata.relations), {FP8_WEIGHT, MXFP4_WEIGHT})
+        self.assertEqual(metadata.groups["fp8"].block_axes, (0, 1))
+        self.assertEqual(metadata.groups["mxfp4"].block_axes, (1,))
+        self.assertEqual(metadata.relations[FP8_WEIGHT].logical_shape, (2, 4))
+        # MXFP4 packs two values per byte, so the logical weight is twice as wide.
+        self.assertEqual(metadata.relations[MXFP4_WEIGHT].logical_shape, (2, 4))
+
+    def test_one_group_is_shared_by_every_weight_it_matches(self):
+        entries = {
+            "layers.0.mlp.experts.0.w1.weight": ((2, 2), "int8"),
+            "layers.0.mlp.experts.0.w1.scale": ((2, 1), "uint8"),
+            "layers.0.mlp.experts.0.w2.weight": ((2, 2), "int8"),
+            "layers.0.mlp.experts.0.w2.scale": ((2, 1), "uint8"),
+        }
+
+        metadata = self.build(entries, mxfp4_group(block_shape=[4]))
+
+        w1 = metadata.relations["layers.0.mlp.experts.0.w1.weight"]
+        w2 = metadata.relations["layers.0.mlp.experts.0.w2.weight"]
+        self.assertEqual((w1.group_name, w2.group_name), ("mxfp4", "mxfp4"))
+        self.assertIs(metadata.groups[w1.group_name], metadata.groups[w2.group_name])
+        self.assertEqual(
+            w1.components,
+            {
+                "qweight": "layers.0.mlp.experts.0.w1.weight",
+                "scale": "layers.0.mlp.experts.0.w1.scale",
+            },
+        )
+
+    def test_logical_metadata_uses_the_requested_output_dtype(self):
+        metadata = self.build(
+            {FP8_WEIGHT: ((2, 4), "uint8"), FP8_SCALE: ((1, 2), "uint8")},
+            output_dtype=paddle.float16,
+        )
+
+        logical = metadata.logical_metadata[FP8_WEIGHT]
+        self.assertEqual(logical.dtype, "float16")
+        self.assertEqual(tuple(logical.global_shape), (2, 4))
+        self.assertEqual(tuple(logical.global_offset), (0, 0))
+
+    def test_unquantized_weights_stay_out_of_the_logical_view(self):
+        metadata = self.build(
+            {
+                FP8_WEIGHT: ((2, 4), "uint8"),
+                FP8_SCALE: ((1, 2), "uint8"),
+                UNQUANTIZED_WEIGHT: ((4,), "bfloat16"),
+            }
+        )
+
+        self.assertEqual(set(metadata.logical_metadata), {FP8_WEIGHT})
+
+    def test_weight_without_its_scale_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "paired scale .* is missing"):
+            self.build({FP8_WEIGHT: ((2, 4), "uint8")})
+
+    def test_weight_matching_two_groups_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "matches multiple quan_desc groups"):
+            self.build(
+                {FP8_WEIGHT: ((2, 4), "uint8"), FP8_SCALE: ((1, 2), "uint8")},
+                fp8_group(),
+                fp8_group(name="fp8_overlapping_rule"),
+            )
+
+    def test_partially_covered_checkpoint_is_rejected(self):
+        """Silently skipping a quantized pair would load garbage weights."""
+        with self.assertRaisesRegex(ValueError, "did not match all quantized"):
+            self.build(
+                {
+                    FP8_WEIGHT: ((2, 4), "uint8"),
+                    FP8_SCALE: ((1, 2), "uint8"),
+                    "layers.0.attn.wq_b.weight": ((2, 4), "uint8"),
+                    "layers.0.attn.wq_b.scale": ((1, 2), "uint8"),
+                }
+            )
+
+    def test_descriptor_matching_nothing_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "matched no quantized weight/scale pairs"):
+            self.build({UNQUANTIZED_WEIGHT: ((4,), "bfloat16")})
+
+    def test_scale_grid_that_fits_no_axis_layout_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "Cannot infer block axes"):
+            self.build({FP8_WEIGHT: ((2, 4), "uint8"), FP8_SCALE: ((1, 3), "uint8")})
+
+    def test_empty_checkpoint_metadata_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "contains no physical tensors"):
+            QuanDescriptor.from_dict(descriptor_dict()).build_metadata(physical_metadata({}))
+
+
+class TestQuanMetadataValidation(unittest.TestCase):
+    """QuanMetadata rejects inconsistent relations at construction time."""
+
+    def quan_metadata(self, spec, group=None, relation_key=None):
+        group = fp8_group_spec() if group is None else group
+        return QuanMetadata(
+            groups={group.name: group},
+            relations={relation_key or spec.logical_name: spec},
+            logical_metadata={},
+            physical_metadata=fp8_physical_metadata(),
+        )
+
+    def test_relation_pointing_at_an_unknown_group_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "unknown group"):
+            self.quan_metadata(fp8_weight_spec(group_name="missing"))
+
+    def test_relation_key_must_match_the_logical_name(self):
+        with self.assertRaisesRegex(ValueError, "does not match logical_name"):
+            self.quan_metadata(fp8_weight_spec(), relation_key="layers.0.attn.wq_b.weight")
+
+    def test_invalid_logical_shapes_are_rejected(self):
+        for logical_shape in ((), (4, 0), (4, -1)):
+            with self.subTest(logical_shape=logical_shape):
+                with self.assertRaisesRegex(ValueError, "Invalid logical shape"):
+                    self.quan_metadata(fp8_weight_spec(logical_shape=logical_shape))
+
+    def test_relation_without_a_qweight_component_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "does not define a qweight component"):
+            self.quan_metadata(fp8_weight_spec(components={"scale": FP8_SCALE}))
+
+    def test_empty_component_source_key_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "empty component role or source key"):
+            self.quan_metadata(fp8_weight_spec(components={"qweight": FP8_WEIGHT, "scale": ""}))
+
+    def test_group_without_block_axes_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "does not define block_axes"):
+            self.quan_metadata(fp8_weight_spec(), group=fp8_group_spec(block_axes=None))
+
+    def test_block_axes_outside_the_logical_rank_are_rejected(self):
+        with self.assertRaisesRegex(ValueError, "outside logical shape"):
+            self.quan_metadata(fp8_weight_spec(logical_shape=(4,)), group=fp8_group_spec(block_axes=(0, 1)))
+
+
+class TestHFDequantLoadTransform(CPUDequantTestCase):
+    """Read planning and dequantization for a 4x4 fp8_block weight with 2x2 blocks."""
+
+    def setUp(self):
+        super().setUp()
+        self.transform = HFDequantLoadTransform(
+            QuanDescriptor.from_dict(descriptor_dict()).build_metadata(fp8_physical_metadata())
+        )
+
+    def test_logical_metadata_is_returned_as_a_copy(self):
+        logical = self.transform.logical_metadata()
+        self.assertEqual(set(logical), {FP8_WEIGHT})
+
+        logical.clear()
+
+        self.assertEqual(set(self.transform.logical_metadata()), {FP8_WEIGHT})
+
+    def test_source_keys_list_the_qweight_before_the_scale(self):
+        self.assertEqual(self.transform.source_keys(FP8_WEIGHT), [FP8_WEIGHT, FP8_SCALE])
+
+    def test_unmanaged_logical_key_is_rejected(self):
+        with self.assertRaisesRegex(KeyError, "is not managed by this load transform"):
+            self.transform.source_keys("layers.0.attn.wq_b.weight")
+
+    def test_no_plan_is_cached_before_planning(self):
+        self.assertIsNone(self.transform.read_plan_for(FP8_WEIGHT))
+
+    def test_block_aligned_shard_reads_local_slices(self):
+        plan = self.transform.read_plan(FP8_WEIGHT, target_shard((4, 4), (2, 4), (0, 0)))
+
+        self.assertEqual(plan.mode, "local")
+        self.assertEqual(plan.logical_global_shape, (4, 4))
+        self.assertEqual(plan.logical_local_shape, (2, 4))
+        self.assertEqual(plan.logical_global_offset, (0, 0))
+        qweight = plan.source_slices[FP8_WEIGHT]
+        self.assertEqual((tuple(qweight.global_offset), tuple(qweight.local_shape)), ((0, 0), (2, 4)))
+        # Two logical rows map onto a single row of the 2x2 scale grid.
+        scale = plan.source_slices[FP8_SCALE]
+        self.assertEqual(tuple(scale.global_shape), (2, 2))
+        self.assertEqual((tuple(scale.global_offset), tuple(scale.local_shape)), ((0, 0), (1, 2)))
+        self.assertIs(self.transform.read_plan_for(FP8_WEIGHT), plan)
+
+    def test_offset_shard_maps_onto_the_matching_scale_rows(self):
+        plan = self.transform.read_plan(FP8_WEIGHT, target_shard((4, 4), (2, 4), (2, 0)))
+
+        self.assertEqual(plan.mode, "local")
+        scale = plan.source_slices[FP8_SCALE]
+        self.assertEqual((tuple(scale.global_offset), tuple(scale.local_shape)), ((1, 0), (1, 2)))
+
+    def test_whole_tensor_shard_uses_global_mode(self):
+        plan = self.transform.read_plan(FP8_WEIGHT, target_shard((4, 4), (4, 4), (0, 0)))
+
+        self.assertEqual(plan.mode, "global")
+        self.assertEqual(tuple(plan.source_slices[FP8_SCALE].local_shape), (2, 2))
+
+    def test_unaligned_shard_falls_back_to_global_mode(self):
+        """An unaligned shard has no well-defined scale origin, so the full tensor is read."""
+        plan = self.transform.read_plan(FP8_WEIGHT, target_shard((4, 4), (2, 4), (1, 0)))
+
+        self.assertEqual(plan.mode, "global")
+        self.assertEqual(plan.logical_local_shape, (4, 4))
+        self.assertEqual(plan.logical_global_offset, (0, 0))
+        self.assertEqual(tuple(plan.source_slices[FP8_WEIGHT].local_shape), (4, 4))
+
+    def test_force_global_overrides_an_aligned_shard(self):
+        plan = self.transform.read_plan(FP8_WEIGHT, target_shard((4, 4), (2, 4), (0, 0)), force_global=True)
+
+        self.assertEqual(plan.mode, "global")
+
+    def test_shard_with_the_wrong_global_shape_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "Target shape mismatch"):
+            self.transform.read_plan(FP8_WEIGHT, target_shard((8, 4), (2, 4), (0, 0)))
+
+    def test_checkpoint_shape_disagreeing_with_the_descriptor_is_rejected(self):
+        transform = HFDequantLoadTransform(
+            QuanMetadata(
+                groups={"fp8": fp8_group_spec()},
+                relations={FP8_WEIGHT: fp8_weight_spec()},
+                logical_metadata={FP8_WEIGHT: target_shard((4, 4), (4, 4), (0, 0))},
+                physical_metadata=fp8_physical_metadata(scale_shape=(4, 4)),
+            )
+        )
+
+        with self.assertRaisesRegex(ValueError, "Read plan shape mismatch"):
+            transform.read_plan(FP8_WEIGHT, target_shard((4, 4), (4, 4), (0, 0)))
+
+    def test_mxfp4_plan_halves_the_packed_axis(self):
+        transform = HFDequantLoadTransform(
+            QuanDescriptor.from_dict(descriptor_dict(mxfp4_group())).build_metadata(
+                physical_metadata({MXFP4_WEIGHT: ((2, 2), "int8"), MXFP4_SCALE: ((2, 2), "uint8")})
+            )
+        )
+
+        plan = transform.read_plan(MXFP4_WEIGHT, target_shard((2, 4), (1, 4), (0, 0)))
+
+        self.assertEqual(plan.mode, "local")
+        qweight = plan.source_slices[MXFP4_WEIGHT]
+        self.assertEqual(tuple(qweight.global_shape), (2, 2))
+        self.assertEqual((tuple(qweight.global_offset), tuple(qweight.local_shape)), ((0, 0), (1, 2)))
+
+    def test_apply_dequantizes_the_whole_tensor(self):
+        self.transform.read_plan(FP8_WEIGHT, target_shard((4, 4), (4, 4), (0, 0)))
+
+        output = self.transform.apply(
+            FP8_WEIGHT,
+            {
+                FP8_WEIGHT: paddle.full([4, 4], E4M3_ONE, dtype="uint8"),
+                FP8_SCALE: paddle.full([2, 2], 128, dtype="uint8"),
+            },
+            paddle.float32,
+        )
+
+        np.testing.assert_array_equal(output.numpy(), np.full((4, 4), 2.0, dtype="float32"))
+
+    def test_apply_dequantizes_a_local_shard(self):
+        self.transform.read_plan(FP8_WEIGHT, target_shard((4, 4), (2, 4), (0, 0)))
+
+        output = self.transform.apply(
+            FP8_WEIGHT,
+            {
+                FP8_WEIGHT: paddle.full([2, 4], E4M3_ONE, dtype="uint8"),
+                FP8_SCALE: paddle.full([1, 2], 128, dtype="uint8"),
+            },
+            paddle.float32,
+        )
+
+        np.testing.assert_array_equal(output.numpy(), np.full((2, 4), 2.0, dtype="float32"))
+
+    def test_apply_rejects_sources_that_contradict_the_cached_plan(self):
+        self.transform.read_plan(FP8_WEIGHT, target_shard((4, 4), (2, 4), (0, 0)))
+
+        with self.assertRaisesRegex(ValueError, "Invalid dequantized shape"):
+            self.transform.apply(
+                FP8_WEIGHT,
+                {
+                    FP8_WEIGHT: paddle.full([4, 4], E4M3_ONE, dtype="uint8"),
+                    FP8_SCALE: paddle.full([2, 2], 128, dtype="uint8"),
+                },
+                paddle.float32,
+            )
+
+
+class TestBuildHFDequantLoadTransform(unittest.TestCase):
+    """End-to-end construction from a real HF safetensors directory."""
+
+    def setUp(self):
+        self.checkpoint_path = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.checkpoint_path, True)
+
+    def write_checkpoint(self, tensors=None):
+        write_safetensors(
+            os.path.join(self.checkpoint_path, SAFETENSORS_FILE_NAME),
+            tensors
+            if tensors is not None
+            else [
+                (FP8_WEIGHT, "F8_E4M3", (4, 4)),
+                (FP8_SCALE, "F8_E8M0", (2, 2)),
+                (UNQUANTIZED_WEIGHT, "BF16", (4,)),
+            ],
+        )
+
+    def test_disabled_mode_returns_none(self):
+        self.write_checkpoint()
+
+        self.assertIsNone(build_hf_dequant_load_transform(self.checkpoint_path, False, descriptor_dict()))
+
+    def test_checkpoint_without_a_model_descriptor_returns_none(self):
+        """Quantization rules come from the model definition, never from the checkpoint."""
+        self.write_checkpoint()
+
+        self.assertIsNone(build_hf_dequant_load_transform(self.checkpoint_path, True))
+        self.assertNotIn(PADDLE_METADATA_FILE_NAME, os.listdir(self.checkpoint_path))
+
+    def test_transform_is_built_from_the_safetensors_headers(self):
+        self.write_checkpoint()
+
+        transform = build_hf_dequant_load_transform(self.checkpoint_path, True, descriptor_dict())
+
+        self.assertIsInstance(transform, HFDequantLoadTransform)
+        logical = transform.logical_metadata()
+        self.assertEqual(set(logical), {FP8_WEIGHT})
+        self.assertEqual(tuple(logical[FP8_WEIGHT].global_shape), (4, 4))
+        self.assertEqual(logical[FP8_WEIGHT].dtype, "bfloat16")
+        # Raw 8-bit formats must survive as uint8 so the transform owns their meaning.
+        physical = transform.quan_metadata.physical_metadata.state_dict_metadata
+        self.assertEqual(physical[FP8_WEIGHT][0].dtype, "uint8")
+        self.assertEqual(physical[FP8_SCALE][0].dtype, "uint8")
+
+    def test_generated_paddle_metadata_is_reused_on_the_next_build(self):
+        self.write_checkpoint()
+        first = build_hf_dequant_load_transform(self.checkpoint_path, True, descriptor_dict())
+        self.assertIn(PADDLE_METADATA_FILE_NAME, os.listdir(self.checkpoint_path))
+
+        # Deleting the safetensors file proves the second build reads the cached metadata.
+        os.remove(os.path.join(self.checkpoint_path, SAFETENSORS_FILE_NAME))
+        second = build_hf_dequant_load_transform(self.checkpoint_path, True, descriptor_dict())
+
+        self.assertEqual(set(second.logical_metadata()), set(first.logical_metadata()))
+
+    def test_unquantized_checkpoint_with_a_descriptor_is_rejected(self):
+        self.write_checkpoint([(UNQUANTIZED_WEIGHT, "BF16", (4,))])
+
+        with self.assertRaisesRegex(ValueError, "matched no quantized weight/scale pairs"):
+            build_hf_dequant_load_transform(self.checkpoint_path, True, descriptor_dict())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ai_edited_test/quantization/test_ai_hf_dequant_load_dist.py
+++ b/tests/ai_edited_test/quantization/test_ai_hf_dequant_load_dist.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Two-card load of an fp8_block HF checkpoint through HFDequantLoadTransform.
+
+The "local" read mode is unreachable with a single card, because a whole-tensor
+shard always plans a global read.  This launches two ranks so the block-aligned
+slice arithmetic in checkpoint_dequant.py is actually exercised.
+"""
+
+import inspect
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import paddle
+import paddle.distributed as dist
+
+WORKER_SCRIPT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "hf_dequant_load_dist_logic.py")
+
+
+def _load_transform_is_supported():
+    """Whether the installed Paddle describes distributed transform targets by shard.
+
+    The wheel that first shipped ``load_transform`` described a distributed
+    target by its global shape, so ``read_plan()`` never saw a local shard and
+    the local path could not run.  ``_apply_load_transform`` gained a
+    ``read_plans`` argument in the same change that fixed this, so it is the
+    marker for a Paddle new enough to run this test.
+    """
+    if "load_transform" not in inspect.signature(dist.load_state_dict).parameters:
+        return False
+    from paddle.distributed.flex_checkpoint.dcp import load_state_dict as dcp
+
+    return "read_plans" in inspect.signature(dcp._apply_load_transform).parameters
+
+
+@unittest.skipUnless(paddle.device.cuda.device_count() > 1, "test requires multiple GPUs")
+@unittest.skipUnless(_load_transform_is_supported(), "paddle is too old to shard a load_transform target")
+class TestHFDequantLoadDist(unittest.TestCase):
+    def test_block_aligned_shard_loads_its_own_rows(self):
+        with tempfile.TemporaryDirectory() as ckpt_dir:
+            env = dict(os.environ, ckpt_path=ckpt_dir)
+            command = [
+                sys.executable,
+                "-m",
+                "paddle.distributed.launch",
+                "--devices",
+                "0,1",
+                "--log_dir",
+                os.path.join(ckpt_dir, "log"),
+                WORKER_SCRIPT,
+            ]
+            process = subprocess.run(command, env=env, capture_output=True, text=True)
+            self.assertEqual(
+                process.returncode,
+                0,
+                f"two-card load failed:\n{process.stdout}\n{process.stderr}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### Before submitting

- [x] Lint code. `pre-commit run --files <changed files>` passes (black / isort / flake8 / copyright_checker).
- [x] Add test cases into `tests` folder — `tests/ai_edited_test/quantization/test_ai_hf_checkpoint_dequant.py`, 69 cases.

### PR types

New features

### PR changes

APIs

### Description

> [!IMPORTANT]
> **Depends on PaddlePaddle/Paddle#79712** — *[FlexCheckpoint] Add LoadTransform extension point for quantized checkpoints*.
>
> This PR calls `dist.load_state_dict(..., load_transform=...)`; that keyword argument only exists once #79712 lands. CI here will fail until then, which is why this is opened as a **draft**.

#### Motivation

Loading a quantized HuggingFace checkpoint (DeepSeek-V4 FP8, Kimi-K3 MXFP4) currently requires an offline dequantize-and-rewrite pass, which doubles checkpoint storage and adds a manual step before every experiment. This PR lets FlexCheckpoint read the quantized files directly and dequantize during the read.

#### Design

Quantization rules belong to the model definition, not the loader. Checkpoint files only carry physical tensor metadata (names, shapes, dtypes); they do not say which tensors are quantized, how the scales are encoded, or what the block geometry is. So a model exposes a parameterless descriptor:

```python
@classmethod
def _gen_hf_quan_config(cls):
    return {
        "schema_version": 1,
        "component_pairing": {"weight_suffix": ".weight", "scale_suffix": ".scale"},
        "logic_name_suffix": ".weight",
        "groups": [
            {
                "name": ...,
                "targets": [...],          # literal names or "re:" patterns
                "quant_method": ...,       # fp8_block | mxfp4_group
                "value_format": ...,       # e4m3 | e2m1
                "scale_format": ...,       # float32 | ue8m0
                "block_shape": [...],
            }
        ],
    }
```

The descriptor is attached to the built model in the provider factory, so the `Trainer` only needs a `getattr` — a model without the descriptor keeps the old behaviour and is unaffected.

`Trainer` builds a `LoadTransform` from it and hands it to FlexCheckpoint:

```python
if self.args.load_from_hf:
    hf_quan_config = None
    if self.args.hf_quantized_load_mode:
        gen = getattr(self.model, "_gen_hf_quan_config", None)
        if callable(gen):
            hf_quan_config = gen()
    load_transform = build_hf_dequant_load_transform(
        checkpoint_path=resume_from_checkpoint,
        mode=self.args.hf_quantized_load_mode,
        quan_config=hf_quan_config,
    )
    dist.load_state_dict(..., load_transform=load_transform)
```

#### Changes

| File | Change |
| --- | --- |
| `paddleformers/quantization/hf_checkpoint.py` | new — `QuanDescriptor`, `QuanMetadata`, `HFDequantLoadTransform`, `build_hf_dequant_load_transform` |
| `paddleformers/quantization/checkpoint_dequant.py` | new — `FP8BlockCheckpointDequantizer`, `MXFP4GroupCheckpointDequantizer`, plus a `register_checkpoint_dequantizer` hook for new methods |
| `paddleformers/quantization/__init__.py` | export `build_hf_dequant_load_transform` |
| `paddleformers/trainer/training_args.py` | new `hf_quantized_load_mode` argument (default `False`) |
| `paddleformers/trainer/trainer.py` | build the load transform and pass it to `dist.load_state_dict` |
| `paddleformers/transformers/kimi_k3/modeling.py` | `_gen_hf_quan_config` — `mxfp4_group`, `e2m1` values, `ue8m0` scales, `block_shape=[32]` |
| `paddleformers/transformers/deepseek_v4/modeling.py` | `_gen_hf_quan_config` — `fp8_block`, `e4m3` values, `float32` scales, `block_shape=[128, 128]` |
| `tests/ai_edited_test/quantization/test_ai_hf_checkpoint_dequant.py` | new — 69 cases |

Behaviour is fully opt-in: with `hf_quantized_load_mode=False` (the default) no descriptor is consulted and the load path is byte-for-byte the previous one.

#### Validation against a real checkpoint

The DeepSeek-V4 descriptor was checked against `DeepSeek-V4-Flash-Base` (43 layers, 256 routed experts, 1 MTP layer) by parsing all 46 safetensors headers — 69189 tensors total (34167 `F8_E4M3`, 34584 `F32`, 435 `BF16`, 3 `I64`):

- 34167 / 34167 FP8 weights matched — no false negatives, no false positives.
- Every matched weight has its paired `.scale`; no orphan scales.
- Near-miss names are correctly excluded: `attn.compressor.wkv`, `attn.indexer.compressor.{wkv,wgate}` are `BF16` and not matched, while `attn.indexer.wq_b` is `FP8` and is matched.
- `block_shape=[128, 128]` is self-consistent with every weight/scale shape pair.

One note worth recording: the checkpoint's `config.json` declares `scale_fmt: "ue8m0"`, but the stored scales are plain `F32`. The descriptor therefore uses `scale_format: "float32"`, which is what the files actually contain.

#### Tests

`tests/ai_edited_test/quantization/test_ai_hf_checkpoint_dequant.py` — 69 cases, all passing. They cover descriptor parsing and validation, weight/scale pairing, logical-name derivation, both dequantizers (including block/group edge sizes and padding), the registry hook, and error paths. The tests use synthetic descriptors rather than importing any concrete model, so they run without a model checkpoint.

Patch coverage of the changed lines is 92.0% (462/502), above the 75% gate in `.github/codecov.yml`.
