### PR TITLE
perf(trainer): skip the internal-medicine gather on non-sampling steps

### DIFF
--- a/paddleformers/trainer/trainer_callback.py
+++ b/paddleformers/trainer/trainer_callback.py
@@ -1088,10 +1088,20 @@ class InternalMedicineCallback(TrainerCallback):
         if not self._setup_done or self._training_logs is None:
             return
 
+        if not self._sampled_this_step():
+            return
+
         aggregated = self._training_logs.gather_and_aggregate()
         if aggregated:
             self._training_logs.reset()
             self._maybe_write_jsonl(state, aggregated)
+
+    def _sampled_this_step(self):
+        """Whether any monitor sampled during the step that just finished."""
+        monitors = list(self._monitor_dict.values())
+        if not monitors:
+            return True
+        return any(getattr(m, "sampled_this_step", True) for m in monitors)
 
     def _resolve_writer(self):
         """Decide once whether this process should write the jsonl file.


### PR DESCRIPTION
### PR Types
Performance

### PR Changes
Trainer

### Description

`InternalMedicineCallback.on_log` fires on every logging step, but the monitors only sample once every `monitor_interval` steps. On the remaining steps `training_logs.gather_and_aggregate()` still runs a full-world collective over empty payloads.

The cost grows with world size. On a multi-thousand-rank job we measured ~0.9 s per step spent in that empty `all_gather_object`, which dominated the amortized cost of monitoring (`logging_steps=1`, `monitor_interval=200`, i.e. 199 of every 200 steps paid it for nothing).

This gates the call on `monitor.sampled_this_step`, a flag internal_medicine latches inside `step()` before incrementing its step counter:

```python
if not self._sampled_this_step():
    return

aggregated = self._training_logs.gather_and_aggregate()
```

```python
def _sampled_this_step(self):
    """Whether any monitor sampled during the step that just finished."""
    monitors = list(self._monitor_dict.values())
    if not monitors:
        return True
    return any(getattr(m, "sampled_this_step", True) for m in monitors)
```

Two properties this deliberately relies on, both of which rule out simpler-looking alternatives:

1. **The condition has to be identical on every rank.** `gather_and_aggregate()` is a collective; if some ranks skip it, the rest hang in it. `sampled_this_step` is a pure function of the monitors' `step_count`, which advances once per `on_step_end` on every rank. Deciding from *local* metric emptiness does not satisfy this — a pipeline stage with no monitored layer is always empty — and has caused a pipeline-parallel deadlock before.

2. **It must not be re-derived from `state.global_step % monitor_interval`.** `step_count` restarts at 0 when the callback is set up, while `global_step` is restored from the checkpoint. The two drift apart whenever the resume step is not a multiple of `monitor_interval`, and the gate then silently blocks every sampled step (and `reset()` never runs, so the meters accumulate). We observed this drift in a real run's metric log, where the emitted steps had two distinct values mod `monitor_interval`.

`getattr(..., True)` keeps this working against an internal_medicine version that predates the flag: it loses the optimization rather than the metrics.

### Notes

The `sampled_this_step` flag is added on the internal_medicine side; this change degrades gracefully until that lands.

Verified: `pre-commit run --files paddleformers/trainer/trainer_callback.py` passes (black / isort / flake8 / copyright). `_sampled_this_step` checked against empty dict, all-sampled, none-sampled, partially-sampled, and a monitor without the attribute.