### PR TITLE
feat(trainer): add internal_medicine_debug_mode to skip per-unit metric families

### DIFF
--- a/paddleformers/cli/hparams/finetuning_args.py
+++ b/paddleformers/cli/hparams/finetuning_args.py
@@ -90,6 +90,16 @@ class PreTrainingArguments(TrainingArguments):
             "Positive integer = enable monitoring with that sampling interval."
         },
     )
+    internal_medicine_debug_mode: bool = field(
+        default=False,
+        metadata={
+            "help": "Collect the metric families that grow per structural unit "
+            "(moe_health per-expert, mhc_health per hyper-connection cell). These are "
+            "~48% of the keys per step, so they are off by default and only worth the "
+            "cross-rank payload while debugging a specific model. "
+            "See internal_medicine.core.metric_families.DEBUG_ONLY_FAMILIES."
+        },
+    )
     internal_medicine_qk_row_stride: int = field(
         default=1,
         metadata={

--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -528,6 +528,7 @@ class Trainer:
                     monitors=_im_monitors,
                     monitor_interval=_im_interval,
                     qk_row_stride=getattr(self.args, "internal_medicine_qk_row_stride", 1),
+                    debug_mode=getattr(self.args, "internal_medicine_debug_mode", False),
                     log_dir=_im_log_dir,
                 )
             )

--- a/paddleformers/trainer/trainer_callback.py
+++ b/paddleformers/trainer/trainer_callback.py
@@ -970,6 +970,7 @@ class InternalMedicineCallback(TrainerCallback):
         monitor_interval=0,
         verbose: bool = True,
         qk_row_stride: int = 1,
+        debug_mode: bool = False,
         log_dir: str = "",
     ):
         super().__init__()
@@ -977,6 +978,7 @@ class InternalMedicineCallback(TrainerCallback):
         self.monitor_interval = int(monitor_interval) if monitor_interval else 0
         self.verbose = verbose
         self.qk_row_stride = qk_row_stride
+        self.debug_mode = bool(debug_mode)
         self.log_dir = log_dir or ""
         self.log_path = os.path.join(self.log_dir, "internal_medicine.jsonl") if self.log_dir else ""
         self._monitor_dict = {}
@@ -1020,6 +1022,7 @@ class InternalMedicineCallback(TrainerCallback):
 
         try:
             from internal_medicine.backends.paddlefleet import setup_monitors
+            from internal_medicine.core.metric_families import exclusions_for
             from internal_medicine.core.training_logs import training_logs
         except (ImportError, TypeError, SyntaxError) as exc:
             logger.warning(
@@ -1031,6 +1034,10 @@ class InternalMedicineCallback(TrainerCallback):
             )
             return
 
+        # Which families a non-debug run leaves out is the library's call, not a
+        # yaml string: one bit here, the set itself lives next to the taxonomy.
+        exclude_families = exclusions_for(self.debug_mode)
+
         try:
             setup_monitors(
                 model,
@@ -1039,6 +1046,7 @@ class InternalMedicineCallback(TrainerCallback):
                 monitor_interval=self.monitor_interval,
                 verbose=self.verbose,
                 qk_stats={"row_stride": self.qk_row_stride},
+                exclude_families=exclude_families,
             )
             self._training_logs = training_logs
             self._setup_done = True


### PR DESCRIPTION
### PR Category
Trainer / internal medicine monitors

### PR Types
Improvements

### Description

A production run no longer collects the internal-medicine metric families that emit **one curve per structural unit**:

- `moe_health` per-expert shares — `expert_{token,weight}_share_e{i}`
- `mhc_health` per-cell mixing-matrix entries — `{attn,mlp}_h_res_cell{i}`
- `mhc_health` per-stream gate values — `{attn,mlp}_h_{pre,post}_idx{i}`

On a 43-layer mHC + MoE config those are **1392 of 3732 keys per step (37.3%)**, so they dominate the cross-rank aggregation payload, the monitor buffers and the jsonl on disk, while the rest of the schema only grows with depth. Excluded families never enter the metric schema, so this cuts communication and memory, not just the printed keys.

The per-layer aggregates of the same quantities stay on (`h_res_logits_max`, `h_post_mean`, `h_post_stream_concentration`, ...), and those are what the diagnosis layer reads — a cross-check against `diagnose.py` finds none of the excluded metric names referenced there. So the new default costs payload only.

```yaml
internal_medicine_monitors: "qk_stats,moe_health,massive_act,mhc_health,vha_health"
internal_medicine_monitor_interval: 200
internal_medicine_debug_mode: false   # true = collect the per-unit families too
```

The trainer-side surface is deliberately **one bit** rather than a family spec string: which families debug mode adds is a property of the taxonomy, so the set lives beside it as `internal_medicine.core.metric_families.DEBUG_ONLY_FAMILIES` and is pinned by that project's tests. Nothing to typo in a yaml, and changing what "debug" means is a reviewable diff instead of a config sweep.

Changes: `internal_medicine_debug_mode: bool = False` in `PreTrainingArguments`, passed through `Trainer` to `InternalMedicineCallback`, which turns it into the exclusion mapping via `exclusions_for(debug_mode)` at `on_train_begin`.

Requires the family support on the internal_medicine side (bo-ke/llm-internal-medicine#64 plus the `DEBUG_ONLY_FAMILIES` follow-up #65). The import lives inside the existing guarded `try`, so an older library version falls into the "not importable" warning path rather than crashing.