### PR TITLE
[release/1.3][Deps] Update PaddleFleet to fded17c5ab1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,7 @@ try:
         install_requires=REQUIRED_PACKAGES,
         entry_points={"console_scripts": get_console_scripts()},
         extras_require={
-            "paddlefleet": ["paddlefleet==0.4.0.post20260825+d62f6d86d38"],
+            "paddlefleet": ["paddlefleet==0.4.0.post20260829+fded17c5ab1"],
         },
         python_requires=">=3.8",
         classifiers=[


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description

Update the optional PaddleFleet dependency on `release/1.3` from `paddlefleet==0.4.0.post20260825+d62f6d86d38` to `paddlefleet==0.4.0.post20260829+fded17c5ab1`.

The new pin corresponds to PaddleFleet commit [`fded17c5ab1d1cac0789a2014540c045e0dd2c88`](https://github.com/PaddlePaddle/PaddleFleet/commit/fded17c5ab1d1cac0789a2014540c045e0dd2c88). This PR is independently based on the latest real-time `release/1.3` branch. The paired develop update is [#4941](https://github.com/PaddlePaddle/PaddleFormers/pull/4941).

The matching official nightly wheel is available for CUDA 12.6, 12.9, 13.0, and 13.2 indexes.

### Validation

- `python3 -m py_compile setup.py scripts/ci_utils/get_fleet_commit.py`
- `python3 scripts/ci_utils/get_fleet_commit.py` -> `fded17c5ab1`
- `python3 setup.py --name` -> `paddleformers`
- `git diff --check`
- Confirmed the PR branch contains only the dependency pin change in `setup.py` and is based directly on `release/1.3`.
