### PR TITLE
[release/1.3] cherry-pick: perf(trainer): skip the internal-medicine gather on non-sampling steps (#4938)

### DIFF
--- a/paddleformers/trainer/trainer_callback.py
+++ b/paddleformers/trainer/trainer_callback.py
@@ -1046,10 +1046,20 @@ class InternalMedicineCallback(TrainerCallback):
         if not self._setup_done or self._training_logs is None:
             return
 
+        if not self._sampled_this_step():
+            return
+
         aggregated = self._training_logs.gather_and_aggregate()
         if aggregated:
             self._training_logs.reset()
             self._maybe_write_jsonl(state, aggregated)
+
+    def _sampled_this_step(self):
+        """Whether any monitor sampled during the step that just finished."""
+        monitors = list(self._monitor_dict.values())
+        if not monitors:
+            return True
+        return any(getattr(m, "sampled_this_step", True) for m in monitors)
 
     def _resolve_writer(self):
         """Decide once whether this process should write the jsonl file.


### PR DESCRIPTION
### PR Category
Trainer

### PR Types
Performance

### Description

Cherry-pick of #4938 (develop: 62e3c4b) onto release/1.3. Clean pick, no conflicts, identical diff (+10 lines in `paddleformers/trainer/trainer_callback.py`).

`InternalMedicineCallback.on_log` used to call `training_logs.gather_and_aggregate()` on every logging step, but the monitors only produce data on their own sampling steps (`monitor_interval`). On the other steps the gather was a collective over empty data — pure latency, paid by every rank. It now returns early unless some monitor reports `sampled_this_step`.

The cost this removes scales with world size: the aggregation is an `all_gather_object` whose payload is O(K x N) in metric count and rank count, so on a large job the skipped steps were the expensive ones. Behaviour on sampling steps is unchanged, and a callback with no monitors registered still gathers (the `return True` default), so nothing silently stops logging.

merged dev in : #4938 