### PR TITLE
[release/1.3] cherry-pick: feat(trainer): add internal_medicine_debug_mode to skip per-unit metric families (#4940)

### DIFF
--- a/paddleformers/cli/hparams/finetuning_args.py
+++ b/paddleformers/cli/hparams/finetuning_args.py
@@ -85,6 +85,16 @@ class PreTrainingArguments(TrainingArguments):
             "Positive integer is the sampling interval."
         },
     )
+    internal_medicine_debug_mode: bool = field(
+        default=False,
+        metadata={
+            "help": "Collect the metric families that grow per structural unit "
+            "(moe_health per-expert, mhc_health per hyper-connection cell). These are "
+            "~48% of the keys per step, so they are off by default and only worth the "
+            "cross-rank payload while debugging a specific model. "
+            "See internal_medicine.core.metric_families.DEBUG_ONLY_FAMILIES."
+        },
+    )
     internal_medicine_qk_row_stride: int = field(
         default=1,
         metadata={

--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -526,6 +526,7 @@ class Trainer:
                     monitors=_im_monitors,
                     monitor_interval=_im_interval,
                     qk_row_stride=getattr(self.args, "internal_medicine_qk_row_stride", 1),
+                    debug_mode=getattr(self.args, "internal_medicine_debug_mode", False),
                     log_dir=_im_log_dir,
                 )
             )

--- a/paddleformers/trainer/trainer_callback.py
+++ b/paddleformers/trainer/trainer_callback.py
@@ -941,6 +941,7 @@ class InternalMedicineCallback(TrainerCallback):
         monitor_interval=0,
         verbose: bool = True,
         qk_row_stride: int = 1,
+        debug_mode: bool = False,
         log_dir: str = "",
     ):
         super().__init__()
@@ -948,6 +949,7 @@ class InternalMedicineCallback(TrainerCallback):
         self.monitor_interval = int(monitor_interval) if monitor_interval else 0
         self.verbose = verbose
         self.qk_row_stride = qk_row_stride
+        self.debug_mode = bool(debug_mode)
         self.log_dir = log_dir or ""
         self.log_path = os.path.join(self.log_dir, "internal_medicine.jsonl") if self.log_dir else ""
         self._monitor_dict = {}
@@ -980,6 +982,7 @@ class InternalMedicineCallback(TrainerCallback):
 
         try:
             from internal_medicine.backends.paddlefleet import setup_monitors
+            from internal_medicine.core.metric_families import exclusions_for
             from internal_medicine.core.training_logs import training_logs
         except ImportError:
             logger.exception(
@@ -989,6 +992,10 @@ class InternalMedicineCallback(TrainerCallback):
             )
             return
 
+        # Which families a non-debug run leaves out is the library's call, not a
+        # yaml string: one bit here, the set itself lives next to the taxonomy.
+        exclude_families = exclusions_for(self.debug_mode)
+
         try:
             setup_monitors(
                 model,
@@ -997,6 +1004,7 @@ class InternalMedicineCallback(TrainerCallback):
                 monitor_interval=self.monitor_interval,
                 verbose=self.verbose,
                 qk_stats={"row_stride": self.qk_row_stride},
+                exclude_families=exclude_families,
             )
             self._training_logs = training_logs
             self._setup_done = True


### PR DESCRIPTION
### PR Category
Trainer / internal medicine monitors

### PR Types
Improvements

### Description

Cherry-pick of #4940 (develop: e37e6a5) onto release/1.3. The three code files applied cleanly; the only conflict was the submodule path, resolved below.

A production run no longer collects the metric families that emit one curve per structural unit: `moe_health`'s per-expert shares, and `mhc_health`'s per-cell mixing-matrix entries and per-stream gate values. On a 43-layer mHC + MoE config those are 1392 of 3732 keys per step (37.3%) of the cross-rank aggregation payload, the monitor buffers and the jsonl on disk. The per-layer aggregates of the same quantities stay on, and those are what the diagnosis layer reads, so the new default costs payload only. `internal_medicine_debug_mode: true` adds them back.

**Submodule resolution:** release/1.3 pinned `third_party/llm-internal-medicine` at `2d24c2d` while develop was at `d9447ac`, so the pointer hunk conflicted. Resolved to the same target as develop, `734593f`, which is a fast-forward from `2d24c2d` (149 commits). The bump is required: the callback now imports `exclusions_for` from that package, and on an older pin it would silently fall into the existing "library not importable" warning path and register no monitors.

Independent of #4944 (the cherry-pick of #4938); the two touch different parts of `InternalMedicineCallback` and can merge in either order.