### PR TITLE
optimize ema hf-checkpoint

### DIFF
--- a/paddleformers/trainer/trainer_utils.py
+++ b/paddleformers/trainer/trainer_utils.py
@@ -1841,7 +1841,7 @@ def _restore_master_weights_single(master_weights, model, optimizer, group, stru
     nms = reshard_util.NodeModelState(group=group)
     nms_tmp = reshard_util.NodeModelState(group=group)
     nms_tmp.add_master_weights(master_weights)
-    nms_tmp.pack_keys(structure_name_map, get_env_device())
+    nms_tmp.pack_keys(structure_name_map, paddle.device.get_device())
     nms.merge_from(nms_tmp, max(group.rank, 0))
     del nms_tmp
     nms = restore_func(nms, model, optimizer)

--- a/paddleformers/trainer/trainer_utils.py
+++ b/paddleformers/trainer/trainer_utils.py
@@ -1841,7 +1841,7 @@ def _restore_master_weights_single(master_weights, model, optimizer, group, stru
     nms = reshard_util.NodeModelState(group=group)
     nms_tmp = reshard_util.NodeModelState(group=group)
     nms_tmp.add_master_weights(master_weights)
-    nms_tmp.pack_keys(structure_name_map)
+    nms_tmp.pack_keys(structure_name_map, get_env_device())
     nms.merge_from(nms_tmp, max(group.rank, 0))
     del nms_tmp
     nms = restore_func(nms, model, optimizer)
@@ -1853,13 +1853,14 @@ def recover_params_from_master_weight(ema_state_dict, model, optimizer, group):
     master_weights = ema_state_dict.get("master_weights", {})
     tmp = OrderedDict()
     (master_weights, tmp) = (tmp, master_weights)
-    # cast to bf16 and move to cpu
+    # cast to bf16
     for (k, v) in tmp.items():
         name = v.name
-        master_weights[k] = paddle.cast(to_device(v), paddle.bfloat16).cpu()
+        master_weights[k] = paddle.cast(to_device(v), paddle.bfloat16)
         master_weights[k].name = name
 
-    structure_name_map = {k: v.name for (k, v) in model.state_dict().items()}
+    model_state_dict = model.state_dict()
+    structure_name_map = {k: v.name for (k, v) in model_state_dict.items()}
 
     muon_opt = _unwrap_muon_sharding_optimizer(optimizer)
     if muon_opt is not None:
@@ -1898,7 +1899,6 @@ def recover_params_from_master_weight(ema_state_dict, model, optimizer, group):
             master_weights, model, optimizer, group, structure_name_map, restore_func
         )
 
-    model_state_dict = model.state_dict()
     ema_param_state_dict = OrderedDict()
     for key, param in model_state_dict.items():
         if param.name in master_weights and param.dtype == paddle.bfloat16:
@@ -1908,11 +1908,7 @@ def recover_params_from_master_weight(ema_state_dict, model, optimizer, group):
             assert (
                 param.shape == master_weights[param.name].shape
             ), f"got {param.shape} vs {master_weights[param.name].shape}"
-            master_weight = paddle.reshape(master_weights[param.name], param.shape)
-            ema_param_state_dict[key] = paddle.cast(to_device(master_weight), paddle.bfloat16)
-
-    for k, v in master_weights.items():
-        v._clear()
+            ema_param_state_dict[key] = to_device(master_weights[param.name])
 
     del master_weights
     return ema_param_state_dict

--- a/paddleformers/trainer/utils/reshard/common.py
+++ b/paddleformers/trainer/utils/reshard/common.py
@@ -884,9 +884,7 @@ def all_gather_state_dict(state_dict, filter_func, group):
         return res
     group_rank = max(group.rank, 0)
 
-    on_gpu = bool(state_dict) and all(
-        isinstance(v, paddle.Tensor) and v.place.is_gpu_place() for v in state_dict.values()
-    )
+    on_gpu = all(isinstance(v, paddle.Tensor) and v.place.is_gpu_place() for v in state_dict.values())
 
     meta_dict = {}
     for (k, v) in state_dict.items():

--- a/paddleformers/trainer/utils/reshard/common.py
+++ b/paddleformers/trainer/utils/reshard/common.py
@@ -333,11 +333,17 @@ class NodeModelState:
         self._master_weights = flatten(self._master_weights, 3)
         return self
 
-    def pack_keys(self, structure_name_mapping=None):
+    def pack_keys(self, structure_name_mapping=None, place="cpu"):
         """
         change the key of model_weights dict from param_name to (structure_name, param_name);
         change the key of opt dict from opt_name to (structure_name, param_name, opt_name);
-        change the key of master weights dict from param_name to (structure_name, param_name)
+        change the key of master weights dict from param_name to
+        (structure_name, param_name, master_name)
+
+        `place` determines where the packed tensors are stored. `"cpu"` (the default)
+        offloads them to host memory to reduce GPU memory pressure. Using `"gpu"` keeps
+        the state on the GPU instead, trading higher GPU memory usage for avoiding the
+        D2H/H2D round-trip overhead on small states and improving performance.
         """
         # pack key for pp convert
         if structure_name_mapping is not None:
@@ -355,7 +361,7 @@ class NodeModelState:
         (self._model_weights, model_weights_tmp) = (model_weights_tmp, self._model_weights)
         for k in list(model_weights_tmp.keys()):
             t_name = structure_name_mapping[k]
-            self._model_weights[(k, t_name)] = paddle.to_tensor(model_weights_tmp[k]).cpu()
+            self._model_weights[(k, t_name)] = paddle.to_tensor(model_weights_tmp[k], place=place)
             del model_weights_tmp[k]
 
         # opt
@@ -366,7 +372,7 @@ class NodeModelState:
             t_name = opt_name_to_tname[opt_name]
             assert t_name in tname_to_structure_name
             structure_name = tname_to_structure_name[t_name]
-            self._opt_state[(structure_name, t_name, opt_name)] = opt_tmp[opt_name].cpu()
+            self._opt_state[(structure_name, t_name, opt_name)] = opt_tmp[opt_name].to(place)
             del opt_tmp[opt_name]
 
         # master weights
@@ -376,7 +382,7 @@ class NodeModelState:
             assert t_name in tname_to_structure_name
             structure_name = tname_to_structure_name[t_name]
             master_name = getattr(master_weights_tmp[t_name], "name", "")
-            self._master_weights[(structure_name, t_name, master_name)] = master_weights_tmp[t_name].cpu()
+            self._master_weights[(structure_name, t_name, master_name)] = master_weights_tmp[t_name].to(place)
             del master_weights_tmp[t_name]
 
         return self
@@ -737,7 +743,25 @@ def _iter_state_dict_bucket_chunks(buckets, chunk_size, max_chunk_bytes):
         yield chunk
 
 
-def _pack_state_dict_bucket(bucket, state_dict):
+class _HostStagingBuffer:
+    """Reusable host scratch space for packing one broadcast bucket at a time.
+
+    Sized once from the largest bucket this rank owns, then handed out as a typed
+    view per bucket so packing does not allocate a fresh array for every bucket.
+    ``paddle.to_tensor`` copies out of the view, so successive buckets may safely
+    reuse the same storage.
+    """
+
+    def __init__(self, nbytes):
+        self._buf = np.empty([nbytes], dtype=np.uint8) if nbytes > 0 else None
+
+    def view(self, numel, np_dtype):
+        nbytes = numel * np.dtype(np_dtype).itemsize
+        assert self._buf is not None and nbytes <= self._buf.nbytes, f"{nbytes} vs {self._buf}"
+        return self._buf[:nbytes].view(np_dtype)
+
+
+def _pack_state_dict_bucket(bucket, state_dict, staging):
     items = bucket["items"]
     first_key = items[0][0]
     assert first_key in state_dict
@@ -745,7 +769,7 @@ def _pack_state_dict_bucket(bucket, state_dict):
 
     # Scatter the whole bucket on the host first so it takes a single
     # host-to-device copy instead of one small copy per state tensor.
-    staged = np.empty([bucket["numel"]], dtype=np_dtype)
+    staged = staging.view(bucket["numel"], np_dtype)
     for k, _, begin, end in items:
         assert k in state_dict
         value = np.asarray(state_dict.pop(k)).reshape([-1])
@@ -760,27 +784,47 @@ def _pack_state_dict_bucket(bucket, state_dict):
     return tensor
 
 
-def _unpack_state_dict_bucket(bucket, tensor, selected_keys, gathered):
+def _pack_state_dict_bucket_gpu(bucket, state_dict):
+    items = bucket["items"]
+    flat = []
+    for k, _, begin, end in items:
+        assert k in state_dict
+        value = state_dict.pop(k).reshape([-1])
+        assert value.shape[0] == end - begin
+        assert str(value.dtype).split(".")[-1] == bucket["dtype"]
+        flat.append(value)
+
+    # A single-item bucket needs no copy at all: this rank is the broadcast root
+    # for it, and the root does not modify its own buffer.
+    tensor = flat[0] if len(flat) == 1 else paddle.concat(flat)
+    del flat
+    assert tensor.shape[0] == bucket["numel"]
+    return tensor
+
+
+def _unpack_state_dict_bucket(bucket, tensor, selected_keys, gathered, keep_on_gpu):
     selected_items = [item for item in bucket["items"] if item[0] in selected_keys]
     if not selected_items:
         return
 
     if len(selected_items) == len(bucket["items"]):
-        cpu_tensor = tensor.cpu()
+        src = tensor if keep_on_gpu else tensor.cpu()
         for k, shape, begin, end in selected_items:
             # Every item of the bucket is selected, so the slices exactly cover
             # the bucket storage. Hand out views instead of per-item copies:
             # cloning here would duplicate the whole bucket for no gain.
-            gathered[k] = cpu_tensor[begin:end].reshape(shape)
-        del cpu_tensor
+            gathered[k] = src[begin:end].reshape(shape)
+        del src
         return
 
     # Sharded restore normally keeps only a small subset of each bucket on a
-    # rank. Copy just those slices instead of staging the complete bucket on
-    # every rank. ``.cpu()`` already allocates fresh host storage sized to the
-    # slice, so no extra clone is needed.
+    # rank. Copy just those slices instead of keeping the complete bucket alive
+    # on every rank. A slice is a view, so the copy is what releases the bucket:
+    # ``.cpu()`` allocates fresh host storage, and the keep-on-GPU path needs an
+    # explicit clone or a handful of items would pin the whole bucket.
     for k, shape, begin, end in selected_items:
-        gathered[k] = tensor[begin:end].cpu().reshape(shape)
+        piece = tensor[begin:end]
+        gathered[k] = (piece.clone() if keep_on_gpu else piece.cpu()).reshape(shape)
 
 
 def _broadcast_state_dict_chunk(gpu_buckets, group):
@@ -825,17 +869,43 @@ def set_broadcast_max_chunk_bytes(nbytes):
 
 
 def all_gather_state_dict(state_dict, filter_func, group):
+    if group.nranks < 2:
+        # A lone rank has nothing to exchange, so skip the pack/broadcast/unpack
+        # round trip. The rest of the contract still holds: drop what filter_func
+        # rejects, and return paddle tensors even for numpy input (to_tensor maps
+        # the uint16 a BF16 checkpoint loads as back to bfloat16). Host arrays go
+        # to CPU and keys come out sorted, matching the multi-rank paths. Difers
+        res = OrderedDict()
+        for k in sorted(state_dict.keys()):
+            if not filter_func(k):
+                continue
+            v = state_dict[k]
+            res[k] = v if isinstance(v, paddle.Tensor) else paddle.to_tensor(v, place=paddle.CPUPlace())
+        return res
     group_rank = max(group.rank, 0)
 
-    # Convert source tensors to numpy first so packing does not retain their
-    # original GPU allocations.
+    on_gpu = bool(state_dict) and all(
+        isinstance(v, paddle.Tensor) and v.place.is_gpu_place() for v in state_dict.values()
+    )
+
     meta_dict = {}
     for (k, v) in state_dict.items():
+        shape = list(v.shape)
         if isinstance(v, paddle.Tensor):
-            meta_dict[k] = (str(v.dtype).split(".")[-1], list(v.shape), group_rank)
-            state_dict[k] = v.numpy()
+            dtype = str(v.dtype).split(".")[-1]
+            if not on_gpu:
+                # Tensor.numpy() copies into a freshly mapped numpy buffer, costing
+                # a full pass over the shard at ~1.8 GB/s before packing starts.
+                # DLPack (numpy >= 1.22) views the same host memory for free and
+                # keeps it alive as long as the view lives; packing only reads it.
+                # It takes host memory and rejects BF16, so those still pay a copy.
+                if dtype == "bfloat16" or not v.place.is_cpu_place():
+                    state_dict[k] = v.numpy()
+                else:
+                    state_dict[k] = np.from_dlpack(v)
         else:
-            meta_dict[k] = (_normalize_np_dtype_str(str(v.dtype)), list(v.shape), group_rank)
+            dtype = _normalize_np_dtype_str(str(v.dtype))
+        meta_dict[k] = (dtype, shape, group_rank)
 
     meta_dict_list = all_gather_simple_object(meta_dict, group)
 
@@ -856,7 +926,15 @@ def all_gather_state_dict(state_dict, filter_func, group):
             assert k in state_dict
             del state_dict[k]
         if k in selected_keys:
-            gathered[k] = paddle.empty(shape, dtype=dtype, device="cpu")
+            gathered[k] = paddle.empty(shape, dtype=dtype, device="gpu" if on_gpu else "cpu")
+
+    # When using the host route, a staging buffer is required. Iterate over all
+    # buckets here to preallocate the buffer based on the largest bucket, then
+    # reuse it for subsequent packing operations to improve performance.
+    staging = None
+    if not on_gpu:
+        host_staging_nbytes = max((b["nbytes"] for b in buckets if b["rank"] == group_rank), default=0)
+        staging = _HostStagingBuffer(host_staging_nbytes)
 
     if group_rank == 0:
         logger.info(
@@ -894,7 +972,10 @@ def all_gather_state_dict(state_dict, filter_func, group):
         gpu_buckets = []
         for bucket in chunk:
             if bucket["rank"] == group_rank:
-                tensor = _pack_state_dict_bucket(bucket, state_dict)
+                if on_gpu:
+                    tensor = _pack_state_dict_bucket_gpu(bucket, state_dict)
+                else:
+                    tensor = _pack_state_dict_bucket(bucket, state_dict, staging)
             else:
                 tensor = paddle.empty([bucket["numel"]], dtype=bucket["dtype"])
             gpu_buckets.append((bucket, tensor))
@@ -904,9 +985,13 @@ def all_gather_state_dict(state_dict, filter_func, group):
 
         t2 = time.time()
         for bucket, tensor in gpu_buckets:
-            _unpack_state_dict_bucket(bucket, tensor, selected_keys, gathered)
+            _unpack_state_dict_bucket(bucket, tensor, selected_keys, gathered, on_gpu)
         # Release the chunk before packing the next one; keeping the list alive
-        # would hold every bucket of this chunk in device memory.
+        # would hold every bucket of this chunk in device memory. Note this only
+        # caps residency on the host route: keeping the state on GPU hands out
+        # views into the bucket storage, so a fully selected bucket stays resident
+        # through ``gathered`` and _broadcast_max_chunk_bytes no longer bounds
+        # device memory -- the whole gathered state does.
         del gpu_buckets
         _mark_mem(f"reshard/bucketed chunk{done_chunks} released, group_id={group.id}")
 

--- a/paddleformers/trainer/utils/reshard/common.py
+++ b/paddleformers/trainer/utils/reshard/common.py
@@ -884,7 +884,13 @@ def all_gather_state_dict(state_dict, filter_func, group):
         return res
     group_rank = max(group.rank, 0)
 
-    on_gpu = all(isinstance(v, paddle.Tensor) and v.place.is_gpu_place() for v in state_dict.values())
+    on_gpu_local = (
+        all(isinstance(v, paddle.Tensor) and v.place.is_gpu_place() for v in state_dict.values())
+        if len(state_dict) > 0
+        else None
+    )
+    votes = [v for v in all_gather_simple_object(on_gpu_local, group) if v is not None]
+    on_gpu = len(votes) > 0 and all(votes)
 
     meta_dict = {}
     for (k, v) in state_dict.items():

--- a/paddleformers/trainer/utils/reshard/common.py
+++ b/paddleformers/trainer/utils/reshard/common.py
@@ -902,7 +902,7 @@ def all_gather_state_dict(state_dict, filter_func, group):
                 if dtype == "bfloat16" or not v.place.is_cpu_place():
                     state_dict[k] = v.numpy()
                 else:
-                    state_dict[k] = np.from_dlpack(v)
+                    state_dict[k] = np.from_dlpack(v.detach())
         else:
             dtype = _normalize_np_dtype_str(str(v.dtype))
         meta_dict[k] = (dtype, shape, group_rank)

--- a/tests/ai_edited_test/trainer/test_ai_reshard_bucketed_broadcast.py
+++ b/tests/ai_edited_test/trainer/test_ai_reshard_bucketed_broadcast.py
@@ -2,11 +2,13 @@
 """Tests for the bucketed broadcast path in trainer/utils/reshard/common.py.
 
 Mirrors the existing single-process reshard unit tests: no real collective is
-started. all_gather_state_dict short-circuits the broadcast when group.nranks
-< 2, yet still runs the full bucket/pack/unpack/dtype logic, so a fake 1-rank
-group lets us exercise the pack/unpack path in-process. The true multi-root
-collective sequence (>=2 ranks) is out of scope here and belongs to a
-launch-based integration test.
+started. all_gather_state_dict returns early when group.nranks < 2, so a fake
+1-rank group only covers the fast path; the bucket/pack/unpack/dtype logic is
+reached with a fake 2-rank group whose two collective calls (the meta all_gather
+and the bucket broadcast) are stubbed out. Every key then belongs to the local
+rank, so packing and unpacking still run for real. The true multi-root
+collective sequence is out of scope here and belongs to a launch-based
+integration test.
 """
 
 import unittest
@@ -50,6 +52,18 @@ def _bf16_uint16(np_float_array):
     return paddle.to_tensor(np_float_array).astype("bfloat16").numpy()
 
 
+def _all_gather_state_dict_bucketed(state_dict, filter_func, group=None):
+    # The bucketed path lives inline in all_gather_state_dict behind the
+    # nranks < 2 early return, so claim rank 0 of a 2-rank group and stub the
+    # only two steps that need peers: the meta all_gather (this rank owns every
+    # key) and the broadcast (a bucket rooted here is already filled).
+    group = group or _fake_group(nranks=2, rank=0)
+    with patch.object(reshard_common, "all_gather_simple_object", lambda obj, g: [obj]), patch.object(
+        reshard_common, "_broadcast_state_dict_chunk", lambda gpu_buckets, g: None
+    ):
+        return all_gather_state_dict(state_dict, filter_func, group)
+
+
 class TestNormalizeNpDtypeStr(unittest.TestCase):
     def test_uint16_maps_to_bfloat16(self):
         # paddle has no numpy-native bf16; it stores bf16 as uint16 and to_tensor
@@ -84,9 +98,11 @@ class TestBucketedGather(unittest.TestCase):
     def tearDown(self):
         set_broadcast_max_chunk_bytes(_DEFAULT_MAX_CHUNK)
 
-    def _gather(self, state_dict, filter_func, max_chunk_bytes=None):
+    def _gather(self, state_dict, filter_func, max_chunk_bytes=None, bucketed=True):
         if max_chunk_bytes is not None:
             set_broadcast_max_chunk_bytes(max_chunk_bytes)
+        if bucketed:
+            return _all_gather_state_dict_bucketed(_copy_sd(state_dict), filter_func)
         return all_gather_state_dict(_copy_sd(state_dict), filter_func, _fake_group())
 
     def _assert_matches_input(self, out, sd, keys):
@@ -139,6 +155,27 @@ class TestBucketedGather(unittest.TestCase):
         self._assert_matches_input(out, sd, ["empty", "empty2d", "scalar", "normal"])
         self.assertEqual(list(out["scalar"].shape), [])
 
+    def test_cpu_tensor_input(self):
+        # CPU paddle tensors take the DLPack view instead of Tensor.numpy(); BF16
+        # is the dtype DLPack rejects, so it must still fall back to the copy.
+        base = np.random.rand(4, 6).astype("float32")
+        sd = OrderedDict(
+            w=paddle.to_tensor(base, place=paddle.CPUPlace()),
+            w_bf16=paddle.to_tensor(base, place=paddle.CPUPlace()).astype("bfloat16"),
+            b=paddle.to_tensor(np.arange(5, dtype="float32"), place=paddle.CPUPlace()),
+            empty=paddle.zeros([0], dtype="float32").cpu(),
+        )
+        out = self._gather(sd, lambda x: True, bucketed=True)
+        self.assertEqual(set(out.keys()), set(sd.keys()))
+        np.testing.assert_array_equal(out["w"].numpy(), base)
+        np.testing.assert_array_equal(out["b"].numpy(), np.arange(5, dtype="float32"))
+        self.assertEqual(str(out["w_bf16"].dtype).split(".")[-1], "bfloat16")
+        np.testing.assert_array_equal(
+            out["w_bf16"].astype("float32").numpy(),
+            paddle.to_tensor(base).astype("bfloat16").astype("float32").numpy(),
+        )
+        self.assertEqual(list(out["empty"].shape), [0])
+
     def test_oversized_tensor_small_max_chunk(self):
         # Shrink bucket/chunk caps so tiny tensors exercise the multi-chunk and
         # oversized-single-bucket paths with real data (no GB allocations).
@@ -150,6 +187,52 @@ class TestBucketedGather(unittest.TestCase):
             )
             out = self._gather(sd, lambda x: True, max_chunk_bytes=512)
             self._assert_matches_input(out, sd, ["big", "s0", "s1"])
+
+
+class TestSingleRankFastPath(unittest.TestCase):
+    """At nranks < 2 all_gather_state_dict skips packing, but still owes the
+    caller the filtering and the numpy-to-tensor normalization."""
+
+    def test_filters_sorts_and_converts(self):
+        base = np.random.rand(3, 5).astype("float32")
+        sd = OrderedDict(
+            keep_w=_bf16_uint16(base),
+            drop_me=np.random.rand(4).astype("float32"),
+            keep_b=np.random.rand(4).astype("float32"),
+        )
+        out = all_gather_state_dict(_copy_sd(sd), lambda k: k.startswith("keep"), _fake_group())
+        self.assertEqual(list(out.keys()), ["keep_b", "keep_w"])
+        for k, v in out.items():
+            self.assertIsInstance(v, paddle.Tensor, f"{k} was not converted")
+            self.assertTrue(v.place.is_cpu_place(), f"{k} landed on {v.place}")
+        self.assertEqual(str(out["keep_w"].dtype).split(".")[-1], "bfloat16")
+        np.testing.assert_array_equal(out["keep_b"].numpy(), sd["keep_b"])
+
+    def test_tensor_input_is_not_copied(self):
+        t = paddle.to_tensor(np.random.rand(4).astype("float32"))
+        out = all_gather_state_dict(OrderedDict(w=t), lambda x: True, _fake_group())
+        self.assertIs(out["w"], t)
+
+    def test_equivalent_to_bucketed_impl(self):
+        sd = OrderedDict(
+            w=_bf16_uint16(np.random.rand(3, 5).astype("float32")),
+            b=np.random.rand(4).astype("float32"),
+            empty=np.zeros([0], dtype="float32"),
+            scalar=np.asarray(3.14, dtype="float32"),
+        )
+        f = lambda k: k != "b"  # noqa: E731
+        fast = all_gather_state_dict(_copy_sd(sd), f, _fake_group())
+        packed = _all_gather_state_dict_bucketed(_copy_sd(sd), f, _fake_group())
+        self.assertEqual(list(fast.keys()), list(packed.keys()))
+        for k in fast:
+            self.assertEqual(str(fast[k].dtype), str(packed[k].dtype), f"dtype mismatch for {k}")
+            self.assertEqual(str(fast[k].place), str(packed[k].place), f"place mismatch for {k}")
+            self.assertEqual(list(fast[k].shape), list(packed[k].shape), f"shape mismatch for {k}")
+            np.testing.assert_array_equal(
+                fast[k].astype("float32").numpy(),
+                packed[k].astype("float32").numpy(),
+                err_msg=f"value mismatch for {k}",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
ema hf-checkpoint的处理过程为：读取磁盘ema权重信息->按sharding组转权重->按并行方式组装权重->写盘
本pr主要优化按sharding组转权重的过程

【性能瓶颈分析】：在进行通信过程中，原先的代码仅在通信时才把数据放在gpu上，其他时候都放在cpu上。这导致了频繁的数据搬运。的确这可以有效的减少显存的压力。但是ema hf-checkpoint有一下特点：数据来自于gpu，且最终也要放在gpu并送到下一步处理逻辑；数据是bf16格式的权重信息，在合理的sharding下占用很小。针对以上特点，权重全程在显存上的收益更大，性能更好。

【代码修改】：本pr主要做了如下代码修改
- 在all_gather_state_dict下新增短路通道，当rank<2时避免操作，直接返回
- 为通信全链路增加gpu通道，all_gather_state_dict由原先的仅支持cpu输入输出转为根据张量所在设备自动调整通路
- cpu端的共享buffer提前声明，减少后续的重复声明的损耗
- 使用np.from_dlpack代替np.numpy()，减少重复copy的时间损耗（保持numpy的原因是numpy比paddle cpu端的性能下更好）
- 增加单侧：
    a) 因为新增的短路路径，原先很多单侧被短路了，需要补充
    b) 新增p32 / bf16(uint16) / 空张量的混合输入

【性能测试结果】
<img width="2462" height="586" alt="image" src="https://github.com/user-attachments/assets/fe97680f-d725-4b0a-b3a4-8b6cd9156ba7" />
原本的时间全部花在pack unpack上
<img width="1112" height="546" alt="image" src="https://github.com/user-attachments/assets/d23d5046-8249-48d5-97b8-9e259371f230" />
修改后通信基本不花时间