### PR TITLE
[Deps] Update PaddleFleet to 81602f63ca3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,7 @@ try:
         install_requires=REQUIRED_PACKAGES,
         entry_points={"console_scripts": get_console_scripts()},
         extras_require={
-            "paddlefleet": ["paddlefleet==0.4.0.post20260829+fded17c5ab1"],
+            "paddlefleet": ["paddlefleet==0.4.0.post20260901+81602f63ca3"],
         },
         python_requires=">=3.8",
         classifiers=[


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description
Update the optional PaddleFleet dependency from `paddlefleet==0.4.0.post20260829+fded17c5ab1` to `paddlefleet==0.4.0.post20260901+81602f63ca3`.

The target package is built from PaddleFleet `release/0.4` commit `81602f63ca3de17649d58a98f31cc8811381f773`.

### Validation

- Confirmed PaddleFleet `release/0.4` resolves to `81602f63ca3de17649d58a98f31cc8811381f773`.
- Confirmed the target commit is ahead of the current PaddleFormers pin by 7 commits.
- `python3 -m py_compile setup.py`
- `pre-commit run --files setup.py`
- `git diff --check`
