### PR TITLE
perf(trainer): skip internal medicine on first resumed step

### DIFF
--- a/paddleformers/trainer/trainer_callback.py
+++ b/paddleformers/trainer/trainer_callback.py
@@ -1007,6 +1007,7 @@ class InternalMedicineCallback(TrainerCallback):
                 exclude_families=exclude_families,
             )
             self._training_logs = training_logs
+            self._skip_first_step_on_resume(state)
             self._setup_done = True
             logger.info("[InternalMedicine/pfleet] Monitors registered: %s" % list(self._monitor_dict.keys()))
         except Exception:
@@ -1068,6 +1069,30 @@ class InternalMedicineCallback(TrainerCallback):
         if not monitors:
             return True
         return any(getattr(m, "sampled_this_step", True) for m in monitors)
+
+    def _skip_first_step_on_resume(self, state):
+        """Suppress probe work on the first step after checkpoint restoration."""
+        resume_step = int(getattr(state, "global_step", 0) or 0)
+        if resume_step <= 0:
+            return
+
+        skipped = 0
+        for monitor in self._monitor_dict.values():
+            skip = getattr(monitor, "skip_next_steps", None)
+            if skip is not None:
+                skip(1)
+                skipped += 1
+
+        if skipped:
+            logger.info(
+                f"[InternalMedicine/pfleet] Resume detected at global_step={resume_step}; "
+                "skipping internal-medicine collection on the first resumed step."
+            )
+        elif self._monitor_dict:
+            logger.warning(
+                f"[InternalMedicine/pfleet] Resume detected at global_step={resume_step}, but the installed "
+                "internal_medicine package cannot skip the first resumed step."
+            )
 
     def _resolve_writer(self):
         """Decide once whether this process should write the jsonl file.

--- a/tests/trainer/test_trainer_callback.py
+++ b/tests/trainer/test_trainer_callback.py
@@ -19,10 +19,12 @@
 import shutil
 import tempfile
 import unittest
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 from paddleformers.trainer import (
     DefaultFlowCallback,
+    InternalMedicineCallback,
     IntervalStrategy,
     PrinterCallback,
     ProgressCallback,
@@ -158,6 +160,35 @@ class TrainerCallbackTest(unittest.TestCase):
         trainer = self.get_trainer(disable_tqdm=True)
         expected_callbacks = DEFAULT_CALLBACKS.copy() + [PrinterCallback]
         self.check_callbacks_equality(trainer.callback_handler.callbacks, expected_callbacks)
+
+    def test_internal_medicine_skips_first_step_only_on_resume(self):
+        callback = InternalMedicineCallback(monitor_interval=5)
+        cold_monitor = Mock()
+        callback._monitor_dict = {"cold": cold_monitor}
+        callback._skip_first_step_on_resume(SimpleNamespace(global_step=0))
+        cold_monitor.skip_next_steps.assert_not_called()
+
+        resumed_monitor_a = Mock()
+        resumed_monitor_b = Mock()
+        callback._monitor_dict = {
+            "resumed_a": resumed_monitor_a,
+            "resumed_b": resumed_monitor_b,
+        }
+        callback._skip_first_step_on_resume(SimpleNamespace(global_step=123))
+        resumed_monitor_a.skip_next_steps.assert_called_once_with(1)
+        resumed_monitor_b.skip_next_steps.assert_called_once_with(1)
+
+    def test_internal_medicine_does_not_gather_unsampled_step(self):
+        callback = InternalMedicineCallback(monitor_interval=5)
+        callback._setup_done = True
+        callback._monitor_dict = {"monitor": SimpleNamespace(sampled_this_step=False)}
+        callback._training_logs = Mock()
+        callback._maybe_write_jsonl = Mock()
+
+        callback.on_log(None, SimpleNamespace(global_step=124), None)
+
+        callback._training_logs.gather_and_aggregate.assert_not_called()
+        callback._maybe_write_jsonl.assert_not_called()
 
     def test_add_remove_callback(self):
         expected_callbacks = DEFAULT_CALLBACKS.copy() + [ProgressCallback]


### PR DESCRIPTION
### PR types

Performance optimization

### PR changes

Others

### Description

When resuming training from a checkpoint, TrainerState.global_step is restored, but each internal medicine monitor's local step_count restarts from 0. This causes the first resumed training step to be sampled because 0 % monitor_interval == 0.

This change detects checkpoint resume via global_step > 0 and suppresses internal medicine collection for exactly the first resumed step. The monitor still advances its local step_count, while the skipped step avoids metric collection, GPU buffer flush, cross-rank gather, and JSONL output.

Cold-start behavior is unchanged.

### Validation

- End-to-end single-node 8-GPU cold start and checkpoint resume passed.
- Cold-start internal medicine sampling: global steps 1, 6, 11.
- Resume from global step 15 to 21.
- Resumed internal medicine sampling: global step 21 only.
- No internal medicine record was generated for resumed step 16.
- Callback and monitor regression tests passed.

Merged in dev: #4986