### PR TITLE
feat: 新增 Janus-Pro-7B 多模态理解模型支持

### DIFF
--- a/paddleformers/transformers/__init__.py
+++ b/paddleformers/transformers/__init__.py
@@ -240,6 +240,8 @@ import_structure = {
     "llama.modeling": ["LlamaForCausalLM", "LlamaModel", "LlamaForCausalLMPipe", "LlamaRotaryEmbedding"],
     "llama.tokenizer": ["LlamaTokenizer", "Llama3Tokenizer"],
     "llama.tokenizer_fast": ["LlamaTokenizerFast"],
+    "janus.configuration": ["JanusConfig"],
+    "janus.modeling": ["JanusPretrainedModel", "JanusModel", "JanusForCausalLM"],
     "optimization": [
         "LinearDecayWithWarmup",
         "ConstScheduleWithWarmup",
@@ -517,6 +519,7 @@ if TYPE_CHECKING:
     from .kimi_k3 import *
     from .paddleocr_vl import *
     from .llama import *
+    from .janus import *
     from .optimization import *
     from .qwen2 import *
     from .qwen2_5_vl import *

--- a/paddleformers/transformers/auto/configuration.py
+++ b/paddleformers/transformers/auto/configuration.py
@@ -81,6 +81,7 @@ CONFIG_MAPPING_NAMES = OrderedDict(
         ("gemma4", "Gemma4MoeConfig"),  # Temporary: no standalone text ckpt, extract text_config in from_dict
         ("phi4", "Phi4Config"),
         ("phi4flash", "Phi4Config"),
+        ("multi_modality", "JanusConfig"),
     ]
 )
 
@@ -128,6 +129,7 @@ MODEL_NAMES_MAPPING = OrderedDict(
         ("gemma4", "Gemma4MoeForCausalLM"),
         ("phi4", "Phi4ForCausalLM"),
         ("phi4flash", "Phi4ForCausalLM"),
+        ("multi_modality", "Janus"),
     ]
 )
 
@@ -149,6 +151,7 @@ SPECIAL_MODEL_TYPE_TO_MODULE_NAME = OrderedDict(
         ("gemma4_text", "gemma4_moe"),
         ("gemma4", "gemma4_moe"),
         ("phi4flash", "phi4"),
+        ("multi_modality", "janus"),
     ]
 )
 

--- a/paddleformers/transformers/auto/modeling.py
+++ b/paddleformers/transformers/auto/modeling.py
@@ -94,6 +94,7 @@ MAPPING_NAMES = OrderedDict(
         ("Olmo2", "olmo2"),
         ("InternLM3", "intern_lm3"),
         ("InternLM2", "intern"),
+        ("Janus", "janus"),
     ]
 )
 

--- a/paddleformers/transformers/janus/__init__.py
+++ b/paddleformers/transformers/janus/__init__.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from typing import TYPE_CHECKING
+
+from ...utils.lazy_import import _LazyModule
+
+import_structure = {
+    "configuration": ["JanusConfig"],
+    "modeling": ["JanusPretrainedModel", "JanusModel", "JanusForCausalLM"],
+}
+
+if TYPE_CHECKING:
+    from .configuration import JanusConfig
+    from .modeling import JanusForCausalLM, JanusModel, JanusPretrainedModel
+else:
+    sys.modules[__name__] = _LazyModule(
+        __name__,
+        globals()["__file__"],
+        import_structure,
+        module_spec=__spec__,
+    )

--- a/paddleformers/transformers/janus/configuration.py
+++ b/paddleformers/transformers/janus/configuration.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from ..configuration_utils import PretrainedConfig
+from ..llama.configuration import LlamaConfig
+
+_COMPUTE_DTYPE_CHOICES = ("checkpoint", "float16", "bfloat16", "float32", "float64")
+
+
+def _validate_compute_dtype(name: str, value: str | None) -> str | None:
+    if value is None:
+        return None
+    if value not in _COMPUTE_DTYPE_CHOICES:
+        choices = ", ".join(_COMPUTE_DTYPE_CHOICES)
+        raise ValueError(f"{name} must be one of {choices}, got {value!r}")
+    return value
+
+
+class JanusConfig(PretrainedConfig):
+    """Configuration for the Janus understanding path and image branch."""
+
+    model_type = "multi_modality"
+    is_composition = True
+    sub_configs = {"language_config": LlamaConfig}
+
+    _language_defaults = {
+        "vocab_size": 102400,
+        "hidden_size": 4096,
+        "intermediate_size": 11008,
+        "num_hidden_layers": 30,
+        "num_attention_heads": 32,
+        "num_key_value_heads": 32,
+        "head_dim": 128,
+        "max_position_embeddings": 16384,
+        "hidden_act": "silu",
+        "rope_theta": 10000.0,
+        "rms_norm_eps": 1e-6,
+        "tie_word_embeddings": False,
+        "torch_dtype": "bfloat16",
+    }
+
+    def __init__(
+        self,
+        language_config: LlamaConfig | Mapping[str, Any] | None = None,
+        vision_config: Mapping[str, Any] | None = None,
+        aligner_config: Mapping[str, Any] | None = None,
+        gen_vision_config: Mapping[str, Any] | None = None,
+        gen_aligner_config: Mapping[str, Any] | None = None,
+        gen_head_config: Mapping[str, Any] | None = None,
+        language_compute_dtype: str | None = None,
+        vision_compute_dtype: str | None = None,
+        **kwargs,
+    ):
+        if isinstance(language_config, LlamaConfig):
+            normalized_language_config = language_config
+        elif language_config is None:
+            language_values = {}
+            normalized_language_config = None
+        elif isinstance(language_config, Mapping):
+            language_values = dict(language_config)
+            normalized_language_config = None
+        else:
+            raise TypeError("language_config must be a LlamaConfig, mapping, or None")
+
+        if normalized_language_config is None:
+            if language_values.get("model_type", "llama") != "llama":
+                raise ValueError("Janus language_config must use model_type='llama'")
+            for name, default in self._language_defaults.items():
+                language_values.setdefault(name, default)
+            normalized_language_config = LlamaConfig(**language_values)
+
+        self.language_config = normalized_language_config
+        self.vision_config = dict(vision_config or {})
+        self.aligner_config = dict(aligner_config or {})
+        self.gen_vision_config = dict(gen_vision_config or {})
+        self.gen_aligner_config = dict(gen_aligner_config or {})
+        self.gen_head_config = dict(gen_head_config or {})
+        self.language_compute_dtype = _validate_compute_dtype("language_compute_dtype", language_compute_dtype)
+        self.vision_compute_dtype = _validate_compute_dtype("vision_compute_dtype", vision_compute_dtype)
+
+        kwargs.setdefault("architectures", ["JanusForCausalLM"])
+        kwargs.setdefault("torch_dtype", getattr(self.language_config, "dtype", "bfloat16") or "bfloat16")
+        kwargs.setdefault("tie_word_embeddings", False)
+        super().__init__(**kwargs)
+
+
+__all__ = ["JanusConfig"]

--- a/paddleformers/transformers/janus/conversion.py
+++ b/paddleformers/transformers/janus/conversion.py
@@ -1,0 +1,287 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import gc
+from collections.abc import Iterable, Mapping
+from os import PathLike
+from typing import Any
+
+import numpy as np
+import paddle
+
+from ..model_utils import load_state_dict
+
+LANGUAGE_PREFIX = "language_model."
+VISION_PREFIX = "vision_model."
+ALIGNER_PREFIX = "aligner."
+JANUS_PREFIXES = (LANGUAGE_PREFIX, VISION_PREFIX, ALIGNER_PREFIX)
+EXPECTED_JANUS_PRO_7B_LANGUAGE_KEYS = 273
+PROJECTION_NAMES = (
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    "gate_proj",
+    "up_proj",
+    "down_proj",
+)
+VISION_LINEAR_SUFFIXES = (
+    ".qkv.weight",
+    ".q.weight",
+    ".kv.weight",
+    ".proj.weight",
+    ".fc1.weight",
+    ".fc2.weight",
+)
+
+
+def expected_language_keys(target_state_dict: Mapping[str, Any]) -> set[str]:
+    """Return the language parameters expected by the Paddle wrapper."""
+
+    return {key for key in target_state_dict if key.startswith(LANGUAGE_PREFIX)}
+
+
+def expected_multimodal_keys(target_state_dict: Mapping[str, Any]) -> set[str]:
+    """Return all language, vision, and aligner keys in a Janus target."""
+
+    return {key for key in target_state_dict if key.startswith(JANUS_PREFIXES)}
+
+
+def _transpose_2d(value):
+    if isinstance(value, paddle.Tensor):
+        return value.transpose([1, 0]).contiguous()
+    if isinstance(value, np.ndarray):
+        return np.ascontiguousarray(value.transpose([1, 0]))
+    raise TypeError(f"unsupported tensor type {type(value).__name__}")
+
+
+def _format_key_error(
+    *,
+    missing: Iterable[str] = (),
+    duplicates: Iterable[str] = (),
+    unexpected: Iterable[str] = (),
+    shape_mismatches: Iterable[str] = (),
+) -> str:
+    details = []
+    if missing:
+        details.append("missing language keys: " + ", ".join(sorted(missing)))
+    if duplicates:
+        details.append("duplicate language keys: " + ", ".join(sorted(duplicates)))
+    if unexpected:
+        details.append("unexpected language keys: " + ", ".join(sorted(unexpected)))
+    if shape_mismatches:
+        details.append("shape mismatches: " + "; ".join(sorted(shape_mismatches)))
+    return "; ".join(details)
+
+
+def merge_shard_state_dicts(shards: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    """Merge checkpoint dictionaries while rejecting duplicate source keys."""
+
+    merged = {}
+    duplicates = set()
+    for shard in shards:
+        for key, value in shard.items():
+            if key in merged:
+                duplicates.add(key)
+                continue
+            merged[key] = value
+
+    if duplicates:
+        duplicate_language_keys = {key for key in duplicates if key.startswith(LANGUAGE_PREFIX)}
+        if duplicate_language_keys:
+            raise ValueError(_format_key_error(duplicates=duplicate_language_keys))
+        raise ValueError("duplicate checkpoint keys: " + ", ".join(sorted(duplicates)))
+    return merged
+
+
+def convert_language_state_dict(
+    source_state_dict: Mapping[str, Any], target_state_dict: Mapping[str, Any]
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Filter and transpose a Janus language state dict for Paddle."""
+
+    target_keys = expected_language_keys(target_state_dict)
+    accepted = {}
+    skipped = []
+    unexpected = []
+    shape_mismatches = []
+
+    for key, value in source_state_dict.items():
+        if not key.startswith(LANGUAGE_PREFIX):
+            skipped.append(key)
+            continue
+        if key not in target_keys:
+            unexpected.append(key)
+            continue
+
+        converted = value
+        if value.ndim == 2 and any(key.endswith(f".{name}.weight") for name in PROJECTION_NAMES):
+            converted = _transpose_2d(value)
+
+        converted_shape = tuple(converted.shape)
+        target_shape = tuple(target_state_dict[key].shape)
+        if converted_shape != target_shape:
+            shape_mismatches.append(f"{key}: got {converted_shape}, expected {target_shape}")
+            continue
+        accepted[key] = converted
+
+    missing = target_keys - set(accepted)
+    if missing or unexpected or shape_mismatches:
+        raise ValueError(
+            _format_key_error(
+                missing=missing,
+                unexpected=unexpected,
+                shape_mismatches=shape_mismatches,
+            )
+        )
+
+    report = {
+        "accepted_language_keys": len(accepted),
+        "skipped_non_language_keys": len(skipped),
+        "skipped_keys": sorted(skipped),
+    }
+    return accepted, report
+
+
+def _needs_multimodal_transpose(key: str, value: Any) -> bool:
+    if getattr(value, "ndim", None) != 2:
+        return False
+    if key.startswith(LANGUAGE_PREFIX):
+        return any(key.endswith(f".{name}.weight") for name in PROJECTION_NAMES)
+    if key.startswith(VISION_PREFIX):
+        return key.endswith(VISION_LINEAR_SUFFIXES)
+    if key.startswith(ALIGNER_PREFIX):
+        return key.endswith(".weight")
+    return False
+
+
+def convert_janus_state_dict(
+    source_state_dict: Mapping[str, Any], target_state_dict: Mapping[str, Any]
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Convert the complete Janus understanding path.
+
+    The generator-only tensors remain outside the target model and are listed
+    explicitly in the report.  Any missing or unexpected understanding-path
+    key is fatal, so a partial vision conversion cannot be published.
+    """
+
+    target_keys = expected_multimodal_keys(target_state_dict)
+    accepted = {}
+    skipped = []
+    unexpected = []
+    shape_mismatches = []
+
+    for key, value in source_state_dict.items():
+        if not key.startswith(JANUS_PREFIXES):
+            skipped.append(key)
+            continue
+        if key not in target_keys:
+            unexpected.append(key)
+            continue
+
+        converted = _transpose_2d(value) if _needs_multimodal_transpose(key, value) else value
+        converted_shape = tuple(converted.shape)
+        target_shape = tuple(target_state_dict[key].shape)
+        if converted_shape != target_shape:
+            shape_mismatches.append(f"{key}: got {converted_shape}, expected {target_shape}")
+            continue
+        accepted[key] = converted
+
+    missing = target_keys - set(accepted)
+    if missing or unexpected or shape_mismatches:
+        raise ValueError(
+            _format_key_error(
+                missing=missing,
+                unexpected=unexpected,
+                shape_mismatches=shape_mismatches,
+            )
+        )
+
+    report = {
+        "accepted_janus_keys": len(accepted),
+        "accepted_language_keys": sum(key.startswith(LANGUAGE_PREFIX) for key in accepted),
+        "accepted_vision_keys": sum(key.startswith(VISION_PREFIX) for key in accepted),
+        "accepted_aligner_keys": sum(key.startswith(ALIGNER_PREFIX) for key in accepted),
+        "skipped_non_janus_keys": len(skipped),
+        "skipped_keys": sorted(skipped),
+    }
+    return accepted, report
+
+
+def load_and_convert_shards(
+    shard_paths: Iterable[str | PathLike[str]],
+    target_state_dict: Mapping[str, Any],
+    multimodal: bool = False,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Load PyTorch shards sequentially and convert the requested Janus path."""
+
+    janus_state_dict = {}
+    seen_keys = set()
+    skipped_keys = []
+    source_shards = []
+
+    for shard_path in shard_paths:
+        shard_path = str(shard_path)
+        source_shards.append(shard_path)
+        shard = load_state_dict(shard_path, convert_from_hf=True, transpose_weight_keys=None)
+        duplicate_keys = seen_keys.intersection(shard)
+        if duplicate_keys:
+            duplicate_janus_keys = {key for key in duplicate_keys if key.startswith(JANUS_PREFIXES)}
+            if duplicate_janus_keys:
+                raise ValueError(_format_key_error(duplicates=duplicate_janus_keys))
+            raise ValueError("duplicate checkpoint keys: " + ", ".join(sorted(duplicate_keys)))
+
+        seen_keys.update(shard)
+        accepted_prefixes = JANUS_PREFIXES if multimodal else (LANGUAGE_PREFIX,)
+        for key, value in shard.items():
+            if key.startswith(accepted_prefixes):
+                janus_state_dict[key] = value
+            else:
+                skipped_keys.append(key)
+        del shard
+        gc.collect()
+
+    converter = convert_janus_state_dict if multimodal else convert_language_state_dict
+    converted, report = converter(janus_state_dict, target_state_dict)
+    generator_keys = [key for key in skipped_keys if not key.startswith(JANUS_PREFIXES)]
+    report.update(
+        {
+            "skipped_non_language_keys": len(skipped_keys),
+            "skipped_non_janus_keys": len(skipped_keys),
+            "skipped_generator_keys": len(generator_keys),
+            "generator_keys": sorted(generator_keys),
+            "skipped_keys": sorted(skipped_keys),
+            "source_shards": source_shards,
+            "source_checkpoint_keys": len(seen_keys),
+        }
+    )
+    return converted, report
+
+
+__all__ = [
+    "EXPECTED_JANUS_PRO_7B_LANGUAGE_KEYS",
+    "ALIGNER_PREFIX",
+    "JANUS_PREFIXES",
+    "LANGUAGE_PREFIX",
+    "PROJECTION_NAMES",
+    "VISION_LINEAR_SUFFIXES",
+    "VISION_PREFIX",
+    "convert_janus_state_dict",
+    "convert_language_state_dict",
+    "expected_language_keys",
+    "expected_multimodal_keys",
+    "load_and_convert_shards",
+    "merge_shard_state_dicts",
+]

--- a/paddleformers/transformers/janus/modeling.py
+++ b/paddleformers/transformers/janus/modeling.py
@@ -1,0 +1,665 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+from typing import Any, Callable
+
+import paddle
+from paddle import nn
+
+from ...nn.attention.interface import ALL_ATTENTION_FUNCTIONS
+from ..cache_utils import Cache
+from ..llama.modeling import (
+    LLamaAttention,
+    LlamaDecoderLayer,
+    LlamaForCausalLM,
+    LlamaModel,
+    LlamaRotaryEmbedding,
+    rotate_half,
+)
+from ..model_utils import PretrainedModel
+from ..modeling_rope_utils import dynamic_rope_update
+from .configuration import JanusConfig
+from .vision import JanusMlpProjector, JanusVisionModel, _effective_vision_layers
+
+_RUNTIME_DTYPE_MAP = {
+    "float16": paddle.float16,
+    "bfloat16": paddle.bfloat16,
+    "float32": paddle.float32,
+    "float64": paddle.float64,
+}
+
+_HF_WEIGHT_SUFFIXES = (
+    ".safetensors",
+    ".safetensors.index.json",
+    ".bin",
+    ".bin.index.json",
+    ".pt",
+    ".pth",
+)
+
+
+def _dtype_name(value) -> str:
+    """Normalize Paddle dtype values and config strings for policy checks."""
+
+    if value is None:
+        return ""
+    return str(value).lower().replace("paddle.", "")
+
+
+def _is_bfloat16_materialization(config: JanusConfig) -> bool:
+    """Return whether the current construction will materialize BF16 params."""
+
+    candidates = (
+        paddle.get_default_dtype(),
+        getattr(config, "dtype", None),
+        getattr(getattr(config, "language_config", None), "dtype", None),
+        getattr(getattr(config, "language_config", None), "torch_dtype", None),
+    )
+    return any(_dtype_name(value) in ("bfloat16", "bf16") for value in candidates)
+
+
+def _apply_default_bfloat16_policy(config: JanusConfig) -> None:
+    """Make BF16 multimodal construction use the validated parity runtime.
+
+    Checkpoint storage and execution dtype are independent.  An explicit
+    ``checkpoint`` policy remains an opt-out for native-kernel experiments;
+    otherwise an unspecified BF16 policy must not silently select the known
+    cross-framework-divergent visual kernels.
+    """
+
+    if not _is_bfloat16_materialization(config):
+        return
+    if not config.vision_config or not config.aligner_config:
+        return
+
+    params = config.vision_config.get("params") or {}
+    # ``native`` is used by the diagnostic checkpoint to request the raw
+    # BF16 kernels explicitly.  Preserve that choice; otherwise a load of a
+    # checkpoint with no serialized runtime policy would silently rewrite the
+    # experiment into the parity policy below.
+    if params.get("vision_parity_precision") == "native" or (
+        "paddle_high_precision" in params and params["paddle_high_precision"] is False
+    ):
+        return
+
+    if config.language_compute_dtype is None:
+        config.language_compute_dtype = "float32"
+    if config.vision_compute_dtype is None:
+        config.vision_compute_dtype = "float64"
+
+    params = config.vision_config.setdefault("params", {})
+    if "vision_parity_precision" not in params and "paddle_high_precision" not in params:
+        params["vision_parity_precision"] = "fp64_accumulate"
+
+
+def _requested_runtime_dtype(config: JanusConfig, name: str):
+    requested = getattr(config, name, None)
+    if requested in (None, "checkpoint"):
+        return None
+    return _RUNTIME_DTYPE_MAP[requested]
+
+
+def _looks_like_hf_weight_filename(name: str) -> bool:
+    """Return whether a basename follows the conventional HF weight names."""
+
+    name = os.path.basename(os.fspath(name)).lower()
+    return name.startswith(("model.", "model-", "pytorch_model.", "pytorch_model-")) and name.endswith(
+        _HF_WEIGHT_SUFFIXES
+    )
+
+
+def _probe_remote_hf_checkpoint_reference(reference, download_hub=None) -> bool:
+    """Probe an unresolved repository for a conventional HF weight file.
+
+    The parent loader has a native flex-checkpoint default, so an unknown
+    remote reference must not be classified as a raw HF snapshot merely from
+    its repository-id shape.  Cache inspection is attempted first for offline
+    use; the Hub file listing is only a best-effort probe and all errors fall
+    back to ``False`` so native checkpoints retain their normal route.
+    """
+
+    source = download_hub
+    if source is None:
+        source = os.environ.get("DOWNLOAD_SOURCE")
+    if source is not None:
+        source = str(getattr(source, "value", source)).lower()
+        if source not in ("", "default", "huggingface", "hf"):
+            return False
+
+    candidates = (
+        "model.safetensors",
+        "model.safetensors.index.json",
+        "pytorch_model.bin",
+        "pytorch_model.bin.index.json",
+    )
+    try:
+        from huggingface_hub import HfApi, try_to_load_from_cache
+
+        for filename in candidates:
+            cached = try_to_load_from_cache(reference, filename)
+            if isinstance(cached, (str, os.PathLike)) and os.path.isfile(cached):
+                return True
+
+        files = HfApi().list_repo_files(reference, repo_type="model")
+        return any(_looks_like_hf_weight_filename(filename) for filename in files)
+    except Exception:
+        # A transient network/auth/cache failure must not change the default
+        # behavior for repositories that may contain native flex checkpoints.
+        return False
+
+
+def _is_raw_hf_checkpoint_reference(
+    pretrained_model_name_or_path,
+    convert_from_hf=True,
+    download_hub=None,
+    subfolder=None,
+):
+    """Detect a raw Hugging Face checkpoint before the shared loader picks flex format.
+
+    Paddle's flex loader consumes ``*.metadata``/``*.distcp`` directories.  A
+    Hugging Face snapshot instead contains ``model*.safetensors`` (or the
+    equivalent PyTorch files), so Janus routes that case through the existing
+    streaming safetensors loader.  The check is deliberately local to Janus;
+    other models retain the repository-wide default.
+    """
+
+    if convert_from_hf is False or pretrained_model_name_or_path is None:
+        return False
+
+    path = os.fspath(pretrained_model_name_or_path)
+    if os.path.isfile(path):
+        return _looks_like_hf_weight_filename(path) or path.lower().endswith((".safetensors", ".bin", ".pt", ".pth"))
+    if os.path.isdir(path):
+        checkpoint_dir = os.path.join(path, os.fspath(subfolder)) if subfolder else path
+        if not os.path.isdir(checkpoint_dir):
+            return False
+        names = os.listdir(checkpoint_dir)
+        # Flex checkpoints always have both a metadata file and at least one
+        # data shard.  Ignore unrelated ``*.metadata`` sidecars (for example
+        # Hugging Face cache markers) when a raw HF export is present.
+        has_metadata = any(name.endswith(".metadata") for name in names)
+        has_data = any(name.endswith(".distcp") for name in names)
+        if has_metadata and has_data:
+            return False
+        return any(_looks_like_hf_weight_filename(name) for name in names)
+
+    # Non-local references are resolved by the parent loader.  Only a
+    # Hugging Face source is known to provide the raw ``model*.safetensors``
+    # layout.  Other hubs may expose native flex checkpoints and must retain
+    # the repository-wide default.  ``download_hub`` can be an enum or its
+    # string value, while an omitted value follows the shared resolver's
+    # ``DOWNLOAD_SOURCE`` environment default.
+    source = download_hub
+    if source is not None:
+        source = str(getattr(source, "value", source)).lower()
+        if source in ("huggingface", "hf"):
+            return True
+        if source not in ("", "default"):
+            return False
+
+    return _probe_remote_hf_checkpoint_reference(pretrained_model_name_or_path, download_hub)
+
+
+def janus_apply_rotary_pos_emb(
+    q: paddle.Tensor,
+    k: paddle.Tensor,
+    cos: paddle.Tensor,
+    sin: paddle.Tensor,
+    unsqueeze_dim: int = 1,
+) -> tuple[paddle.Tensor, paddle.Tensor]:
+    """Apply the official Janus RoPE arithmetic without changing shared Llama."""
+
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    return (q * cos) + (rotate_half(q) * sin), (k * cos) + (rotate_half(k) * sin)
+
+
+class JanusLlamaAttention(LLamaAttention):
+    """Llama attention with Janus-local input-dtype rotary arithmetic."""
+
+    def forward(
+        self,
+        hidden_states: paddle.Tensor,
+        past_key_values: Cache | None = None,
+        attention_mask: paddle.Tensor | None = None,
+        attn_mask_startend_row_indices: paddle.Tensor | None = None,
+        position_embeddings: tuple[paddle.Tensor, paddle.Tensor] | None = None,
+        use_cache: bool = False,
+    ) -> tuple[paddle.Tensor, list[paddle.Tensor] | None]:
+        if self.config.sequence_parallel:
+            seq_len = self.config.max_sequence_length
+            batch_size = hidden_states.shape[0] * self.config.tensor_model_parallel_size // seq_len
+        else:
+            batch_size, seq_len = hidden_states.shape[:2]
+
+        q_shape = (batch_size, seq_len, -1, self.head_dim)
+        kv_shape = (batch_size, seq_len, -1, self.head_dim)
+        query_states = self.q_proj(hidden_states).reshape(q_shape).transpose(1, 2)
+        key_states = self.k_proj(hidden_states).reshape(kv_shape).transpose(1, 2)
+        value_states = self.v_proj(hidden_states).reshape(kv_shape).transpose(1, 2)
+
+        cos, sin = position_embeddings
+        query_states, key_states = janus_apply_rotary_pos_emb(query_states, key_states, cos, sin)
+
+        if past_key_values is not None:
+            key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx)
+
+        attention_interface: Callable = ALL_ATTENTION_FUNCTIONS["sdpa"]
+        if self.config._attn_implementation != "sdpa":
+            attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+        attn_output, attn_weights = attention_interface(
+            self,
+            query=query_states,
+            key=key_states,
+            value=value_states,
+            attention_mask=attention_mask,
+            attn_mask_startend_row_indices=attn_mask_startend_row_indices,
+            dropout=0.0 if not self.training else self.attention_dropout,
+            scaling=self.scaling,
+        )
+        if self.config.sequence_parallel:
+            attn_output = attn_output.reshape([-1, attn_output.shape[-1]])
+        return self.o_proj(attn_output), attn_weights
+
+
+class JanusLlamaDecoderLayer(LlamaDecoderLayer):
+    """Decoder layer whose attention implementation is private to Janus."""
+
+    def __init__(self, config, layer_idx: int):
+        super().__init__(config, layer_idx)
+        attention_state = self.self_attn.state_dict()
+        self.self_attn = JanusLlamaAttention(config, layer_idx)
+        self.self_attn.set_state_dict(attention_state)
+
+
+class JanusLlamaRotaryEmbedding(LlamaRotaryEmbedding):
+    """RoPE module matching Torch's dtype and promoted-runtime behavior."""
+
+    @dynamic_rope_update
+    def forward(self, x: paddle.Tensor, position_ids: paddle.Tensor):
+        with paddle.amp.auto_cast(enable=False):
+            use_original_frequency = self.rope_type == "default" and x.dtype not in (paddle.bfloat16, paddle.float16)
+            inverse_frequency = self.original_inv_freq if use_original_frequency else self.inv_freq
+            inverse_frequency = inverse_frequency.to(x.place).astype(x.dtype)
+            inv_freq_expanded = inverse_frequency[None, :, None].float().expand([position_ids.shape[0], -1, 1])
+            position_ids_expanded = position_ids[:, None, :].float()
+            freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+            emb = paddle.concat((freqs, freqs), axis=-1)
+            cos = emb.cos() * self.attention_scaling
+            sin = emb.sin() * self.attention_scaling
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+class JanusLlamaModel(LlamaModel):
+    """Llama model assembled with Janus-local decoder and RoPE layers."""
+
+    def __init__(self, config):
+        super().__init__(config)
+        original_layers = list(self.layers)
+        self.layers = nn.LayerList(
+            [JanusLlamaDecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+        )
+        for new_layer, old_layer in zip(self.layers, original_layers):
+            new_layer.set_state_dict(old_layer.state_dict())
+        self.rotary_emb = JanusLlamaRotaryEmbedding(config)
+
+
+def _make_janus_language_model(config) -> LlamaForCausalLM:
+    """Build the shared Llama wrapper, replacing only its local decoder tower."""
+
+    language_model = LlamaForCausalLM(config)
+    original_model = language_model.model
+    janus_model = JanusLlamaModel(config)
+    janus_model.set_state_dict(original_model.state_dict())
+    language_model.model = janus_model
+    language_model.tie_weights()
+    return language_model
+
+
+class JanusPretrainedModel(PretrainedModel):
+    """Base class for the Janus multimodal model."""
+
+    config_class = JanusConfig
+    base_model_prefix = "language_model"
+    transpose_weight_keys = list(LlamaForCausalLM.transpose_weight_keys) + [
+        "qkv",
+        "q",
+        "kv",
+        "proj",
+        "fc1",
+        "fc2",
+        r"aligner\.layers\.\d+",
+    ]
+    input_modalities = ["text", "image"]
+    _keys_to_ignore_on_load_unexpected = [r"^gen_"]
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, *args, **kwargs):
+        # Raw HF snapshots do not contain the metadata required by Paddle's
+        # flex checkpoint reader.  Keep explicit caller choices untouched and
+        # only select the regular streaming loader for an otherwise-default
+        # Janus load.
+        if (
+            "load_checkpoint_format" not in kwargs
+            and "state_dict" not in kwargs
+            and not kwargs.get("enable_auto_parallel", False)
+            and kwargs.get("flex_ckpt_comm_method") is None
+            and _is_raw_hf_checkpoint_reference(
+                pretrained_model_name_or_path,
+                kwargs.get("convert_from_hf", True),
+                kwargs.get("download_hub"),
+                kwargs.get("subfolder"),
+            )
+        ):
+            kwargs["load_checkpoint_format"] = ""
+        return super().from_pretrained(pretrained_model_name_or_path, *args, **kwargs)
+
+    @classmethod
+    def _gen_aoa_config(cls, config: JanusConfig):
+        """Describe the official Janus HF layout for flex checkpoint loads.
+
+        The understanding path intentionally keeps the source names.  Only
+        Linear tensors need a transpose because HF/PyTorch stores them as
+        ``[out_features, in_features]`` while Paddle stores them as
+        ``[in_features, out_features]``.  Generator-only ``gen_*`` tensors are
+        absent from these statements and are therefore ignored by the
+        understanding model.
+        """
+
+        statements = [
+            "language_model.model.embed_tokens.weight -> language_model.model.embed_tokens.weight",
+            "language_model.model.norm.weight -> language_model.model.norm.weight",
+        ]
+        if config.language_config.tie_word_embeddings:
+            statements.append("language_model.model.embed_tokens.weight -> language_model.lm_head.weight")
+        else:
+            statements.append("language_model.lm_head.weight -> language_model.lm_head.weight")
+
+        # Expand transposed layer mappings explicitly.  Paddle's AOA layer
+        # macro infers the layer count from the first source name; a ``^T``
+        # suffix is not present in the checkpoint key and would otherwise
+        # make every transposed rule expand to layer zero only.
+        language_layers = int(config.language_config.num_hidden_layers)
+        for layer_id in range(language_layers):
+            layer_prefix = f"language_model.model.layers.{layer_id}"
+            statements.extend(
+                [
+                    f"{layer_prefix}.input_layernorm.weight -> {layer_prefix}.input_layernorm.weight",
+                    f"{layer_prefix}.post_attention_layernorm.weight -> {layer_prefix}.post_attention_layernorm.weight",
+                ]
+            )
+            statements.extend(
+                [
+                    f"{layer_prefix}.self_attn.{name}.weight^T -> {layer_prefix}.self_attn.{name}.weight"
+                    for name in ("q_proj", "k_proj", "v_proj", "o_proj")
+                ]
+            )
+            statements.extend(
+                [
+                    f"{layer_prefix}.mlp.{name}.weight^T -> {layer_prefix}.mlp.{name}.weight"
+                    for name in ("gate_proj", "up_proj", "down_proj")
+                ]
+            )
+
+        vision_config = config.vision_config or {}
+        vision_params = vision_config.get("params", {})
+        if vision_config:
+            vision_prefix = "vision_model.vision_tower."
+            vision_layers = _effective_vision_layers(vision_params)
+            statements.extend(
+                [
+                    f"{vision_prefix}pos_embed -> {vision_prefix}pos_embed",
+                    f"{vision_prefix}patch_embed.proj.weight -> {vision_prefix}patch_embed.proj.weight",
+                    f"{vision_prefix}patch_embed.proj.bias -> {vision_prefix}patch_embed.proj.bias",
+                    f"{vision_prefix}norm.weight -> {vision_prefix}norm.weight",
+                    f"{vision_prefix}norm.bias -> {vision_prefix}norm.bias",
+                ]
+            )
+            for layer_id in range(vision_layers):
+                block_prefix = f"{vision_prefix}blocks.{layer_id}"
+                statements.extend(
+                    [
+                        f"{block_prefix}.norm1.weight -> {block_prefix}.norm1.weight",
+                        f"{block_prefix}.norm1.bias -> {block_prefix}.norm1.bias",
+                        f"{block_prefix}.norm2.weight -> {block_prefix}.norm2.weight",
+                        f"{block_prefix}.norm2.bias -> {block_prefix}.norm2.bias",
+                        *[
+                            f"{block_prefix}.attn.{name}.weight^T -> {block_prefix}.attn.{name}.weight"
+                            for name in ("qkv", "proj")
+                        ],
+                        *[
+                            f"{block_prefix}.attn.{name}.bias -> {block_prefix}.attn.{name}.bias"
+                            for name in ("qkv", "proj")
+                        ],
+                        *[
+                            f"{block_prefix}.mlp.{name}.weight^T -> {block_prefix}.mlp.{name}.weight"
+                            for name in ("fc1", "fc2")
+                        ],
+                        *[
+                            f"{block_prefix}.mlp.{name}.bias -> {block_prefix}.mlp.{name}.bias"
+                            for name in ("fc1", "fc2")
+                        ],
+                    ]
+                )
+
+            if vision_params.get("class_token", False):
+                statements.append(f"{vision_prefix}cls_token -> {vision_prefix}cls_token")
+
+            if vision_params.get("global_pool", "map") == "map":
+                statements.extend(
+                    [
+                        f"{vision_prefix}attn_pool.latent -> {vision_prefix}attn_pool.latent",
+                        f"{vision_prefix}attn_pool.norm.weight -> {vision_prefix}attn_pool.norm.weight",
+                        f"{vision_prefix}attn_pool.norm.bias -> {vision_prefix}attn_pool.norm.bias",
+                        f"{vision_prefix}attn_pool.q.weight^T -> {vision_prefix}attn_pool.q.weight",
+                        f"{vision_prefix}attn_pool.q.bias -> {vision_prefix}attn_pool.q.bias",
+                        f"{vision_prefix}attn_pool.kv.weight^T -> {vision_prefix}attn_pool.kv.weight",
+                        f"{vision_prefix}attn_pool.kv.bias -> {vision_prefix}attn_pool.kv.bias",
+                        f"{vision_prefix}attn_pool.proj.weight^T -> {vision_prefix}attn_pool.proj.weight",
+                        f"{vision_prefix}attn_pool.proj.bias -> {vision_prefix}attn_pool.proj.bias",
+                        f"{vision_prefix}attn_pool.mlp.fc1.weight^T -> {vision_prefix}attn_pool.mlp.fc1.weight",
+                        f"{vision_prefix}attn_pool.mlp.fc1.bias -> {vision_prefix}attn_pool.mlp.fc1.bias",
+                        f"{vision_prefix}attn_pool.mlp.fc2.weight^T -> {vision_prefix}attn_pool.mlp.fc2.weight",
+                        f"{vision_prefix}attn_pool.mlp.fc2.bias -> {vision_prefix}attn_pool.mlp.fc2.bias",
+                    ]
+                )
+
+        aligner_config = config.aligner_config or {}
+        if aligner_config:
+            aligner_params = aligner_config.get("params", {})
+            projector_type = aligner_params.get("projector_type", "mlp_gelu")
+            if projector_type == "linear":
+                linear_indices = [0]
+            elif projector_type == "mlp_gelu":
+                depth = int(aligner_params.get("depth", 1))
+                linear_indices = [2 * index for index in range(depth)]
+            else:
+                linear_indices = []
+            for index in linear_indices:
+                statements.extend(
+                    [
+                        f"aligner.layers.{index}.weight^T -> aligner.layers.{index}.weight",
+                        f"aligner.layers.{index}.bias -> aligner.layers.{index}.bias",
+                    ]
+                )
+
+        return {"aoa_statements": statements}
+
+
+class JanusForCausalLM(JanusPretrainedModel):
+    """Janus vision tower, aligner, and PaddleFormers Llama language model."""
+
+    def __init__(self, config: JanusConfig, apply_runtime_compute_dtype: bool = True):
+        super().__init__(config)
+        _apply_default_bfloat16_policy(config)
+        vision_config = config.vision_config
+        vision_params = vision_config.get("params", {}) if vision_config else None
+        self.vision_model = JanusVisionModel(vision_params) if vision_config else None
+        aligner_config = config.aligner_config
+        aligner_params = aligner_config.get("params", {}) if aligner_config else None
+        vision_high_precision = bool(self.vision_model is not None and self.vision_model.vision_tower.high_precision)
+        self.aligner = (
+            JanusMlpProjector(aligner_params, high_precision=vision_high_precision) if aligner_config else None
+        )
+        self.language_model = _make_janus_language_model(config.language_config)
+        self.runtime_compute_dtypes = {
+            "language": getattr(config, "language_compute_dtype", None) or "checkpoint",
+            "vision": getattr(config, "vision_compute_dtype", None) or "checkpoint",
+        }
+        if apply_runtime_compute_dtype:
+            self._apply_runtime_compute_dtypes()
+
+    def _apply_runtime_compute_dtypes(self):
+        language_dtype = _requested_runtime_dtype(self.config, "language_compute_dtype")
+        vision_dtype = _requested_runtime_dtype(self.config, "vision_compute_dtype")
+        if language_dtype is not None:
+            self.language_model.to(dtype=language_dtype)
+        if vision_dtype is not None:
+            if self.vision_model is None or self.aligner is None:
+                raise ValueError("vision_compute_dtype requires vision_model and aligner")
+            self.vision_model.to(dtype=vision_dtype)
+            self.aligner.to(dtype=vision_dtype)
+
+    def _language_embedding_dtype(self):
+        return self.language_model.get_input_embeddings().weight.dtype
+
+    def prepare_inputs_embeds(
+        self,
+        input_ids: paddle.Tensor,
+        pixel_values: paddle.Tensor,
+        images_seq_mask: paddle.Tensor,
+        images_emb_mask: paddle.Tensor,
+    ) -> paddle.Tensor:
+        """Replace image placeholder token embeddings with aligned features."""
+
+        if self.vision_model is None or self.aligner is None:
+            raise ValueError("Janus vision_model and aligner are required for image inputs")
+        if pixel_values.ndim == 4:
+            pixel_values = pixel_values.unsqueeze(1)
+        if pixel_values.ndim != 5:
+            raise ValueError(f"pixel_values must have rank 4 or 5, got {pixel_values.shape}")
+        if images_seq_mask.ndim != 2 or images_emb_mask.ndim != 3:
+            raise ValueError("images_seq_mask must be [batch, sequence] and images_emb_mask [batch, image, token]")
+
+        batch_size, num_images = pixel_values.shape[:2]
+        images = pixel_values.reshape([batch_size * num_images, *pixel_values.shape[2:]])
+        image_embeds = self.aligner(self.vision_model(images))
+        image_embeds = image_embeds.astype(self._language_embedding_dtype())
+        image_embeds = image_embeds.reshape([batch_size, num_images * image_embeds.shape[1], image_embeds.shape[2]])
+        image_mask = images_emb_mask.astype("bool").reshape([batch_size, -1])
+        seq_mask = images_seq_mask.astype("bool")
+        if int(seq_mask.astype("int64").sum().item()) != int(image_mask.astype("int64").sum().item()):
+            raise ValueError("the number of image placeholders must equal the number of image embeddings")
+
+        safe_input_ids = paddle.where(input_ids < 0, paddle.zeros_like(input_ids), input_ids)
+        inputs_embeds = self.language_model.get_input_embeddings()(safe_input_ids).clone()
+        hidden_size = inputs_embeds.shape[-1]
+        flat_inputs = inputs_embeds.reshape([-1, hidden_size])
+        flat_inputs[seq_mask.reshape([-1])] = image_embeds.reshape([-1, hidden_size])[image_mask.reshape([-1])]
+        return flat_inputs.reshape(inputs_embeds.shape)
+
+    def forward(
+        self,
+        input_ids: paddle.Tensor | None = None,
+        pixel_values: paddle.Tensor | None = None,
+        images_seq_mask: paddle.Tensor | None = None,
+        images_emb_mask: paddle.Tensor | None = None,
+        inputs_embeds: paddle.Tensor | None = None,
+        labels: paddle.Tensor | None = None,
+        loss_mask: paddle.Tensor | None = None,
+        **kwargs: Any,
+    ):
+        image_kwargs = {
+            "pixel_values": pixel_values,
+            "images_seq_mask": images_seq_mask,
+            "images_emb_mask": images_emb_mask,
+            "images": kwargs.pop("images", None),
+            "image_embeds": kwargs.pop("image_embeds", None),
+        }
+        pixel_values = pixel_values if pixel_values is not None else image_kwargs["images"]
+        image_embeds = image_kwargs["image_embeds"]
+        if pixel_values is not None or image_embeds is not None:
+            if input_ids is None or images_seq_mask is None or images_emb_mask is None:
+                raise ValueError("image inputs require input_ids, images_seq_mask, and images_emb_mask")
+            if image_embeds is None:
+                inputs_embeds = self.prepare_inputs_embeds(
+                    input_ids,
+                    pixel_values,
+                    images_seq_mask,
+                    images_emb_mask,
+                )
+            else:
+                safe_input_ids = paddle.where(input_ids < 0, paddle.zeros_like(input_ids), input_ids)
+                inputs_embeds = self.language_model.get_input_embeddings()(safe_input_ids).clone()
+                image_embeds = image_embeds.astype(self._language_embedding_dtype())
+                image_mask = images_emb_mask.astype("bool").reshape([-1])
+                seq_mask = images_seq_mask.astype("bool")
+                hidden_size = inputs_embeds.shape[-1]
+                flat_inputs = inputs_embeds.reshape([-1, hidden_size])
+                flat_inputs[seq_mask.reshape([-1])] = image_embeds.reshape([-1, hidden_size])[image_mask]
+                inputs_embeds = flat_inputs.reshape(inputs_embeds.shape)
+            input_ids = None
+
+        # Transformers' causal-LM contract scores the token at position ``t``
+        # against the label at ``t + 1``.  The shared Paddle Llama wrapper
+        # intentionally retains its historical pre-aligned-label behavior, so
+        # apply the shift at the Janus boundary where ms-swift supplies the
+        # ordinary, unshifted SFT labels.
+        outputs = self.language_model(
+            input_ids=input_ids,
+            inputs_embeds=inputs_embeds,
+            labels=None,
+            **kwargs,
+        )
+        if labels is None:
+            return outputs
+
+        logits = outputs.logits if hasattr(outputs, "logits") else outputs[0]
+        shifted_logits = logits[..., :-1, :]
+        shifted_labels = labels[..., 1:]
+        shifted_loss_mask = loss_mask[..., 1:] if loss_mask is not None else None
+        loss, _ = self.language_model.criterion(
+            shifted_logits,
+            shifted_labels,
+            shifted_loss_mask,
+        )
+
+        if isinstance(outputs, tuple):
+            return (loss,) + outputs
+        outputs.loss = loss
+        return outputs
+
+    def get_input_embeddings(self):
+        return self.language_model.get_input_embeddings()
+
+    def set_input_embeddings(self, value):
+        return self.language_model.set_input_embeddings(value)
+
+    def get_output_embeddings(self):
+        return self.language_model.get_output_embeddings()
+
+    def set_output_embeddings(self, value):
+        return self.language_model.set_output_embeddings(value)
+
+    def prepare_inputs_for_generation(self, input_ids, **kwargs):
+        return self.language_model.prepare_inputs_for_generation(input_ids, **kwargs)
+
+
+JanusModel = JanusForCausalLM
+
+
+__all__ = ["JanusPretrainedModel", "JanusModel", "JanusForCausalLM"]

--- a/paddleformers/transformers/janus/modeling.py
+++ b/paddleformers/transformers/janus/modeling.py
@@ -113,6 +113,25 @@ def _requested_runtime_dtype(config: JanusConfig, name: str):
     return _RUNTIME_DTYPE_MAP[requested]
 
 
+def _validated_image_masks(
+    images_seq_mask: paddle.Tensor,
+    images_emb_mask: paddle.Tensor,
+    batch_size: int,
+) -> tuple[paddle.Tensor, paddle.Tensor]:
+    if images_seq_mask.ndim != 2 or images_emb_mask.ndim != 3:
+        raise ValueError("images_seq_mask must be [batch, sequence] and images_emb_mask [batch, image, token]")
+    if images_seq_mask.shape[0] != batch_size or images_emb_mask.shape[0] != batch_size:
+        raise ValueError("image masks must have the same batch size as input_ids")
+
+    seq_mask = images_seq_mask.astype("bool")
+    image_mask = images_emb_mask.astype("bool").reshape([batch_size, -1])
+    placeholder_counts = seq_mask.astype("int64").sum(axis=1)
+    embedding_counts = image_mask.astype("int64").sum(axis=1)
+    if not bool(paddle.equal(placeholder_counts, embedding_counts).all().item()):
+        raise ValueError("the number of image placeholders must equal the number of image embeddings for each sample")
+    return seq_mask, image_mask
+
+
 def _looks_like_hf_weight_filename(name: str) -> bool:
     """Return whether a basename follows the conventional HF weight names."""
 
@@ -552,18 +571,13 @@ class JanusForCausalLM(JanusPretrainedModel):
             pixel_values = pixel_values.unsqueeze(1)
         if pixel_values.ndim != 5:
             raise ValueError(f"pixel_values must have rank 4 or 5, got {pixel_values.shape}")
-        if images_seq_mask.ndim != 2 or images_emb_mask.ndim != 3:
-            raise ValueError("images_seq_mask must be [batch, sequence] and images_emb_mask [batch, image, token]")
 
         batch_size, num_images = pixel_values.shape[:2]
         images = pixel_values.reshape([batch_size * num_images, *pixel_values.shape[2:]])
         image_embeds = self.aligner(self.vision_model(images))
         image_embeds = image_embeds.astype(self._language_embedding_dtype())
         image_embeds = image_embeds.reshape([batch_size, num_images * image_embeds.shape[1], image_embeds.shape[2]])
-        image_mask = images_emb_mask.astype("bool").reshape([batch_size, -1])
-        seq_mask = images_seq_mask.astype("bool")
-        if int(seq_mask.astype("int64").sum().item()) != int(image_mask.astype("int64").sum().item()):
-            raise ValueError("the number of image placeholders must equal the number of image embeddings")
+        seq_mask, image_mask = _validated_image_masks(images_seq_mask, images_emb_mask, input_ids.shape[0])
 
         safe_input_ids = paddle.where(input_ids < 0, paddle.zeros_like(input_ids), input_ids)
         inputs_embeds = self.language_model.get_input_embeddings()(safe_input_ids).clone()
@@ -606,11 +620,10 @@ class JanusForCausalLM(JanusPretrainedModel):
                 safe_input_ids = paddle.where(input_ids < 0, paddle.zeros_like(input_ids), input_ids)
                 inputs_embeds = self.language_model.get_input_embeddings()(safe_input_ids).clone()
                 image_embeds = image_embeds.astype(self._language_embedding_dtype())
-                image_mask = images_emb_mask.astype("bool").reshape([-1])
-                seq_mask = images_seq_mask.astype("bool")
+                seq_mask, image_mask = _validated_image_masks(images_seq_mask, images_emb_mask, input_ids.shape[0])
                 hidden_size = inputs_embeds.shape[-1]
                 flat_inputs = inputs_embeds.reshape([-1, hidden_size])
-                flat_inputs[seq_mask.reshape([-1])] = image_embeds.reshape([-1, hidden_size])[image_mask]
+                flat_inputs[seq_mask.reshape([-1])] = image_embeds.reshape([-1, hidden_size])[image_mask.reshape([-1])]
                 inputs_embeds = flat_inputs.reshape(inputs_embeds.shape)
             input_ids = None
 
@@ -655,8 +668,32 @@ class JanusForCausalLM(JanusPretrainedModel):
     def set_output_embeddings(self, value):
         return self.language_model.set_output_embeddings(value)
 
-    def prepare_inputs_for_generation(self, input_ids, **kwargs):
-        return self.language_model.prepare_inputs_for_generation(input_ids, **kwargs)
+    def prepare_inputs_for_generation(
+        self,
+        input_ids,
+        past_key_values=None,
+        inputs_embeds=None,
+        **kwargs,
+    ):
+        model_inputs = self.language_model.prepare_inputs_for_generation(
+            input_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            **kwargs,
+        )
+
+        cache_length = 0
+        if past_key_values is not None:
+            if hasattr(past_key_values, "get_seq_length"):
+                cache_length = past_key_values.get_seq_length()
+            elif isinstance(past_key_values, tuple) and past_key_values and past_key_values[0] is not None:
+                cache_length = past_key_values[0][0].shape[-2]
+
+        if cache_length > 0:
+            # Image features are already represented by the prefill KV cache.
+            for name in ("pixel_values", "images", "image_embeds", "images_seq_mask", "images_emb_mask"):
+                model_inputs[name] = None
+        return model_inputs
 
 
 JanusModel = JanusForCausalLM

--- a/paddleformers/transformers/janus/vision.py
+++ b/paddleformers/transformers/janus/vision.py
@@ -1,0 +1,357 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The timm-style SigLIP tower used by the Janus understanding path.
+
+The official Janus checkpoint contains a fused-qkv ViT rather than the
+Hugging Face SigLIP module used by other PaddleFormers models.  These small
+layers intentionally preserve the source module names so converted tensors can
+be loaded without a second key-renaming layer.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import paddle
+import paddle.nn as nn
+import paddle.nn.functional as F
+
+try:
+    from paddle.incubate.nn.functional import fused_linear as _fused_linear
+except ImportError:  # pragma: no cover - older CPU-only Paddle builds
+    _fused_linear = None
+
+
+_VISION_DEFAULTS = {
+    "siglip_large_patch16_384": {
+        "image_size": 384,
+        "patch_size": 16,
+        "width": 1024,
+        "layers": 24,
+        "heads": 16,
+        "mlp_ratio": 4.0,
+        "global_pool": "map",
+        "class_token": False,
+    },
+    "siglip_so400m_patch14_384": {
+        "image_size": 336,
+        "patch_size": 14,
+        "width": 1152,
+        "layers": 27,
+        "heads": 16,
+        "mlp_ratio": 3.7362,
+        "global_pool": "map",
+        "class_token": False,
+    },
+    "siglip_so400m_patch14_224": {
+        "image_size": 224,
+        "patch_size": 14,
+        "width": 1152,
+        "layers": 27,
+        "heads": 16,
+        "mlp_ratio": 3.7362,
+        "global_pool": "map",
+        "class_token": False,
+    },
+}
+
+
+def _vision_params(params: Mapping[str, Any] | None) -> dict[str, Any]:
+    params = dict(params or {})
+    model_name = params.get("model_name", "siglip_large_patch16_384")
+    if model_name not in _VISION_DEFAULTS:
+        raise ValueError(f"unsupported Janus vision model: {model_name}")
+    values = dict(_VISION_DEFAULTS[model_name])
+    values.update(params)
+    return values
+
+
+def _effective_vision_layers(params: Mapping[str, Any] | None) -> int:
+    """Return the number of SigLIP blocks retained by Janus ``select_layer``.
+
+    The original Janus ``create_siglip_vit`` builds a truncated tower rather
+    than running every block and selecting a hidden state afterwards.  Keep
+    that convention here so the module state and its AOA checkpoint mapping
+    describe the same set of blocks.
+    """
+
+    values = _vision_params(params)
+    total_layers = int(values["layers"])
+    select_layer = values.get("select_layer", -1)
+    try:
+        select_layer = int(select_layer)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"select_layer must be an integer, got {select_layer!r}") from exc
+
+    if select_layer <= 0:
+        effective_layers = min(total_layers, total_layers + select_layer + 1)
+    else:
+        effective_layers = min(total_layers, select_layer)
+    if effective_layers < 1:
+        raise ValueError(f"select_layer={select_layer} selects no vision layers (total layers: {total_layers})")
+    return effective_layers
+
+
+def _layer_norm(layer: nn.LayerNorm, x: paddle.Tensor, high_precision: bool) -> paddle.Tensor:
+    """Accumulate normalization in a wider type without changing boundaries."""
+    if high_precision and x.dtype in (paddle.float32, paddle.bfloat16):
+        # FP32 inputs use FP64 to remove H800 reduction-order drift.  Torch's
+        # BF16 LayerNorm accumulates statistics in FP32, so mirror that while
+        # retaining BF16 outputs at the operator boundary.
+        compute_dtype = "float64" if x.dtype == paddle.float32 else "float32"
+        y = F.layer_norm(
+            x.astype(compute_dtype),
+            layer._normalized_shape,
+            layer.weight.astype(compute_dtype) if layer.weight is not None else None,
+            layer.bias.astype(compute_dtype) if layer.bias is not None else None,
+            layer._epsilon,
+        )
+        return y.astype(x.dtype)
+    return layer(x)
+
+
+def _linear(layer: nn.Linear, x: paddle.Tensor, high_precision: bool) -> paddle.Tensor:
+    """Use FP32 accumulation for BF16 visual projections when requested."""
+    if high_precision and x.dtype == paddle.bfloat16:
+        # Paddle's eager BF16 matmul and Torch's F.linear choose different
+        # reduction kernels.  On CUDA, fused_linear uses the cuBLASLt path and
+        # matches Torch's BF16 result (including its final rounding) exactly.
+        if _fused_linear is not None and paddle.get_device().startswith("gpu"):
+            return _fused_linear(x, layer.weight, layer.bias)
+        y = paddle.matmul(x.astype("float32"), layer.weight.astype("float32"))
+        if layer.bias is not None:
+            y = y + layer.bias.astype("float32")
+        return y.astype(x.dtype)
+    return layer(x)
+
+
+class JanusVisionMlp(nn.Layer):
+    def __init__(self, dim: int, hidden_dim: int, high_precision: bool = False):
+        super().__init__()
+        self.high_precision = high_precision
+        self.fc1 = nn.Linear(dim, hidden_dim)
+        self.act = nn.GELU(approximate="none")
+        self.fc2 = nn.Linear(hidden_dim, dim)
+
+    def forward(self, x: paddle.Tensor) -> paddle.Tensor:
+        return _linear(self.fc2, self.act(_linear(self.fc1, x, self.high_precision)), self.high_precision)
+
+
+class JanusVisionAttention(nn.Layer):
+    def __init__(self, dim: int, num_heads: int, high_precision: bool = False):
+        super().__init__()
+        if dim % num_heads:
+            raise ValueError(f"vision width {dim} is not divisible by {num_heads} heads")
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+        self.scale = self.head_dim**-0.5
+        self.high_precision = high_precision
+        self.qkv = nn.Linear(dim, dim * 3)
+        self.proj = nn.Linear(dim, dim)
+
+    def forward(self, x: paddle.Tensor) -> paddle.Tensor:
+        batch_size, seq_len, dim = x.shape
+        qkv = _linear(self.qkv, x, self.high_precision).reshape(
+            [batch_size, seq_len, 3, self.num_heads, self.head_dim]
+        )
+        qkv = qkv.transpose([2, 0, 3, 1, 4])
+        q, k, v = paddle.unstack(qkv, axis=0)
+        if self.high_precision and x.dtype in (paddle.float32, paddle.bfloat16, paddle.float64):
+            # CUDA BF16 q@k reductions are not ordered identically by Torch and
+            # Paddle.  Keep the checkpoint boundary dtype, but perform the
+            # complete score/softmax/context calculation in FP64 whenever the
+            # explicit parity mode is enabled.  FP64 inputs are already in the
+            # desired work type and follow the same branch.
+            q_work, k_work, v_work = q.astype("float64"), k.astype("float64"), v.astype("float64")
+            scores = paddle.matmul(q_work * self.scale, k_work, transpose_y=True)
+            weights = F.softmax(scores, axis=-1)
+            output = paddle.matmul(weights, v_work).astype(q.dtype)
+        else:
+            # Match official eager path: q @ k^T in the input dtype, then
+            # softmax with a float32 upcast for BF16.
+            q = q * self.scale
+            scores = paddle.matmul(q, k, transpose_y=True)
+            weights = F.softmax(scores.astype("float32"), axis=-1).astype(q.dtype)
+            output = paddle.matmul(weights, v)
+        output = output.transpose([0, 2, 1, 3]).reshape([batch_size, seq_len, dim])
+        return _linear(self.proj, output, self.high_precision)
+
+
+class JanusVisionBlock(nn.Layer):
+    def __init__(self, dim: int, num_heads: int, mlp_ratio: float, high_precision: bool = False):
+        super().__init__()
+        self.high_precision = high_precision
+        self.norm1 = nn.LayerNorm(dim, epsilon=1e-6)
+        self.attn = JanusVisionAttention(dim, num_heads, high_precision=high_precision)
+        self.norm2 = nn.LayerNorm(dim, epsilon=1e-6)
+        self.mlp = JanusVisionMlp(dim, int(dim * mlp_ratio), high_precision=high_precision)
+
+    def forward(self, x: paddle.Tensor) -> paddle.Tensor:
+        x = x + self.attn(_layer_norm(self.norm1, x, self.high_precision))
+        x = x + self.mlp(_layer_norm(self.norm2, x, self.high_precision))
+        return x
+
+
+class JanusAttentionPool(nn.Layer):
+    """State-compatible attention pool retained for checkpoint completeness.
+
+    Janus constructs this module but sets ``ignore_head=True`` in the
+    understanding tower, so the visual forward path returns patch features
+    before this pool.  Keeping the module allows every source tensor to be
+    converted and prevents silently dropping trainable parameters.
+    """
+
+    def __init__(self, dim: int, num_heads: int, mlp_ratio: float):
+        super().__init__()
+        if dim % num_heads:
+            raise ValueError(f"pool width {dim} is not divisible by {num_heads} heads")
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+        self.scale = self.head_dim**-0.5
+        self.latent = self.create_parameter([1, 1, dim])
+        self.q = nn.Linear(dim, dim)
+        self.kv = nn.Linear(dim, dim * 2)
+        self.proj = nn.Linear(dim, dim)
+        self.norm = nn.LayerNorm(dim, epsilon=1e-6)
+        self.mlp = JanusVisionMlp(dim, int(dim * mlp_ratio))
+
+    def forward(self, x: paddle.Tensor) -> paddle.Tensor:
+        batch_size, seq_len, dim = x.shape
+        latent = paddle.tile(self.latent, [batch_size, 1, 1])
+        q = self.q(latent).reshape([batch_size, 1, self.num_heads, self.head_dim]).transpose([0, 2, 1, 3])
+        kv = self.kv(x).reshape([batch_size, seq_len, 2, self.num_heads, self.head_dim]).transpose([2, 0, 3, 1, 4])
+        k, v = paddle.unstack(kv, axis=0)
+        scores = paddle.matmul(q, k, transpose_y=True) * self.scale
+        weights = F.softmax(scores.astype("float32"), axis=-1).astype(q.dtype)
+        pooled = paddle.matmul(weights, v).transpose([0, 2, 1, 3]).reshape([batch_size, 1, dim])
+        pooled = self.proj(pooled)
+        return pooled + self.mlp(self.norm(pooled))
+
+
+class JanusVisionTransformer(nn.Layer):
+    def __init__(self, params: Mapping[str, Any] | None = None):
+        super().__init__()
+        values = _vision_params(params)
+        self.image_size = int(values["image_size"])
+        self.patch_size = int(values["patch_size"])
+        self.width = int(values["width"])
+        self.num_heads = int(values["heads"])
+        self.global_pool = values.get("global_pool", "map")
+        self.class_token = bool(values.get("class_token", False))
+        # ``vision_parity_precision`` is the auditable setting.  Accept the
+        # original boolean flag for checkpoints written before the setting was
+        # made explicit.
+        parity_precision = values.get("vision_parity_precision")
+        if parity_precision is None:
+            parity_precision = "fp64_accumulate" if values.get("paddle_high_precision", False) else "native"
+        if parity_precision not in ("native", "fp64_accumulate"):
+            raise ValueError(f"unsupported vision parity precision: {parity_precision}")
+        self.vision_parity_precision = parity_precision
+        self.high_precision = parity_precision == "fp64_accumulate"
+        self.patch_embed = nn.Layer()
+        self.patch_embed.proj = nn.Conv2D(
+            3,
+            self.width,
+            kernel_size=self.patch_size,
+            stride=self.patch_size,
+        )
+        grid = self.image_size // self.patch_size
+        num_patches = grid * grid
+        prefix = 1 if self.class_token else 0
+        self.pos_embed = self.create_parameter([1, num_patches + prefix, self.width])
+        if self.class_token:
+            self.cls_token = self.create_parameter([1, 1, self.width])
+        self.num_layers = _effective_vision_layers(values)
+        self.blocks = nn.LayerList(
+            [
+                JanusVisionBlock(
+                    self.width,
+                    self.num_heads,
+                    float(values["mlp_ratio"]),
+                    high_precision=self.high_precision,
+                )
+                for _ in range(self.num_layers)
+            ]
+        )
+        self.norm = nn.LayerNorm(self.width, epsilon=1e-6)
+        if self.global_pool == "map":
+            self.attn_pool = JanusAttentionPool(self.width, self.num_heads, float(values["mlp_ratio"]))
+        else:
+            self.attn_pool = None
+
+    def forward(self, pixel_values: paddle.Tensor) -> paddle.Tensor:
+        pixel_values = pixel_values.astype(self.patch_embed.proj.weight.dtype)
+        x = self.patch_embed.proj(pixel_values)
+        x = x.flatten(start_axis=2).transpose([0, 2, 1])
+        if self.class_token:
+            cls = paddle.tile(self.cls_token, [x.shape[0], 1, 1])
+            x = paddle.concat([cls, x], axis=1)
+        x = x + self.pos_embed
+        for block in self.blocks:
+            x = block(x)
+        return _layer_norm(self.norm, x, self.high_precision)
+
+
+class JanusVisionModel(nn.Layer):
+    def __init__(self, params: Mapping[str, Any] | None = None):
+        super().__init__()
+        self.vision_tower = JanusVisionTransformer(params)
+
+    def forward(self, pixel_values: paddle.Tensor) -> paddle.Tensor:
+        return self.vision_tower(pixel_values)
+
+
+class JanusMlpProjector(nn.Layer):
+    def __init__(self, params: Mapping[str, Any] | None = None, high_precision: bool = False):
+        super().__init__()
+        values = dict(params or {})
+        self.high_precision = high_precision
+        input_dim = int(values.get("input_dim", 1024))
+        n_embed = int(values.get("n_embed", 4096))
+        depth = int(values.get("depth", 1))
+        projector_type = values.get("projector_type", "mlp_gelu")
+        if projector_type == "identity":
+            self.layers = nn.Identity()
+        elif projector_type == "linear":
+            self.layers = nn.Linear(input_dim, n_embed)
+        elif projector_type == "mlp_gelu":
+            modules = [nn.Linear(input_dim, n_embed)]
+            for _ in range(1, depth):
+                modules.append(nn.GELU(approximate="none"))
+                modules.append(nn.Linear(n_embed, n_embed))
+            self.layers = nn.Sequential(*modules)
+        else:
+            raise ValueError(f"unsupported Janus projector type: {projector_type}")
+
+    def forward(self, x: paddle.Tensor) -> paddle.Tensor:
+        if self.high_precision and x.dtype == paddle.bfloat16:
+            # Preserve the public Sequential/state-dict shape while routing
+            # its Linear layers through the same FP32-accumulation helper.
+            for layer in self.layers:
+                if isinstance(layer, nn.Linear):
+                    x = _linear(layer, x, self.high_precision)
+                else:
+                    x = layer(x)
+            return x
+        return self.layers(x)
+
+
+__all__ = [
+    "JanusAttentionPool",
+    "JanusMlpProjector",
+    "JanusVisionModel",
+    "JanusVisionTransformer",
+    "_effective_vision_layers",
+]

--- a/tests/transformers/janus/__init__.py
+++ b/tests/transformers/janus/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/transformers/janus/test_modeling.py
+++ b/tests/transformers/janus/test_modeling.py
@@ -301,6 +301,86 @@ class JanusContractTest(unittest.TestCase):
             )
         self.assertEqual(tuple(output.logits.shape), (1, 3, 97))
 
+    def test_image_generation_with_cache_only_uses_images_during_prefill(self):
+        model = JanusForCausalLM(tiny_janus_config(with_vision=True))
+        model.eval()
+        input_ids = paddle.to_tensor([[1, 2, 3]], dtype="int64")
+        pixel_values = paddle.zeros([1, 1, 3, 16, 16], dtype="float32")
+        images_seq_mask = paddle.to_tensor([[False, True, True]], dtype="bool")
+        images_emb_mask = paddle.to_tensor([[[True, True] + [False] * 14]], dtype="bool")
+        vision_outputs = []
+
+        def capture_vision_output(layer, inputs, output):
+            vision_outputs.append(output)
+
+        hook = model.vision_model.register_forward_post_hook(capture_vision_output)
+        try:
+            with paddle.no_grad():
+                output_ids, _ = model.generate(
+                    input_ids=input_ids,
+                    pixel_values=pixel_values,
+                    images_seq_mask=images_seq_mask,
+                    images_emb_mask=images_emb_mask,
+                    decode_strategy="greedy_search",
+                    max_new_tokens=2,
+                    use_cache=True,
+                )
+        finally:
+            hook.remove()
+
+        self.assertEqual(tuple(output_ids.shape), (1, 2))
+        self.assertEqual(len(vision_outputs), 1)
+
+    def test_pixel_values_reject_cross_sample_placeholder_counts(self):
+        model = JanusForCausalLM(tiny_janus_config(with_vision=True))
+        input_ids = paddle.ones([2, 3], dtype="int64")
+        pixel_values = paddle.zeros([2, 1, 3, 16, 16], dtype="float32")
+        images_seq_mask = paddle.to_tensor(
+            [[False, True, True], [False, False, False]],
+            dtype="bool",
+        )
+        images_emb_mask = paddle.to_tensor(
+            [
+                [[True] + [False] * 15],
+                [[True] + [False] * 15],
+            ],
+            dtype="bool",
+        )
+
+        with self.assertRaisesRegex(ValueError, "for each sample"):
+            model(
+                input_ids=input_ids,
+                pixel_values=pixel_values,
+                images_seq_mask=images_seq_mask,
+                images_emb_mask=images_emb_mask,
+                use_cache=False,
+            )
+
+    def test_image_embeds_reject_cross_sample_placeholder_counts(self):
+        model = JanusForCausalLM(tiny_janus_config(with_vision=True))
+        input_ids = paddle.ones([2, 3], dtype="int64")
+        image_embeds = paddle.zeros([2, 16, 32], dtype="float32")
+        images_seq_mask = paddle.to_tensor(
+            [[False, True, True], [False, False, False]],
+            dtype="bool",
+        )
+        images_emb_mask = paddle.to_tensor(
+            [
+                [[True] + [False] * 15],
+                [[True] + [False] * 15],
+            ],
+            dtype="bool",
+        )
+
+        with self.assertRaisesRegex(ValueError, "for each sample"):
+            model(
+                input_ids=input_ids,
+                image_embeds=image_embeds,
+                images_seq_mask=images_seq_mask,
+                images_emb_mask=images_emb_mask,
+                use_cache=False,
+            )
+
     def test_vision_parity_precision_is_explicit_and_validated(self):
         config = tiny_janus_config(with_vision=True)
         config.vision_config["params"]["vision_parity_precision"] = "fp64_accumulate"

--- a/tests/transformers/janus/test_modeling.py
+++ b/tests/transformers/janus/test_modeling.py
@@ -1,0 +1,741 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import re
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+import paddle
+
+from paddleformers.transformers import AutoConfig, AutoModel, AutoModelForCausalLM
+from paddleformers.transformers.janus.configuration import JanusConfig
+from paddleformers.transformers.janus.conversion import (
+    convert_janus_state_dict,
+    convert_language_state_dict,
+    expected_language_keys,
+    expected_multimodal_keys,
+    merge_shard_state_dicts,
+)
+from paddleformers.transformers.janus.modeling import (
+    JanusForCausalLM,
+    JanusLlamaAttention,
+    JanusLlamaModel,
+    JanusLlamaRotaryEmbedding,
+    _is_raw_hf_checkpoint_reference,
+    janus_apply_rotary_pos_emb,
+)
+from paddleformers.transformers.janus.vision import (
+    JanusVisionTransformer,
+    _effective_vision_layers,
+)
+from paddleformers.transformers.llama.configuration import LlamaConfig
+from paddleformers.transformers.llama.modeling import (
+    LlamaForCausalLM,
+    apply_rotary_pos_emb,
+    rotate_half,
+)
+from tests.testing_utils import require_package
+
+
+def tiny_janus_config(with_vision=False):
+    vision_config = {}
+    aligner_config = {}
+    if with_vision:
+        vision_config = {
+            "cls": "CLIPVisionTower",
+            "params": {
+                "image_size": 16,
+                "patch_size": 4,
+                "width": 8,
+                "layers": 1,
+                "heads": 2,
+                "mlp_ratio": 2.0,
+                "global_pool": "map",
+                "paddle_high_precision": True,
+            },
+        }
+        aligner_config = {
+            "cls": "MlpProjector",
+            "params": {
+                "depth": 2,
+                "input_dim": 8,
+                "n_embed": 32,
+                "projector_type": "mlp_gelu",
+            },
+        }
+    return JanusConfig(
+        language_config={
+            "vocab_size": 97,
+            "hidden_size": 32,
+            "intermediate_size": 64,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 8,
+            "max_position_embeddings": 64,
+            "torch_dtype": "float32",
+            "fuse_rms_norm": False,
+        },
+        vision_config=vision_config,
+        aligner_config=aligner_config,
+        architectures=["JanusForCausalLM"],
+    )
+
+
+class JanusContractTest(unittest.TestCase):
+    def test_shared_llama_rotary_default_keeps_float32_accumulation(self):
+        """The shared Llama helper must retain its historical default path."""
+        query = (paddle.arange(1 * 2 * 4 * 8, dtype="float32").reshape([1, 2, 4, 8]) / 7).astype("float16")
+        key = (query * 0.7).astype("float16")
+        phases = paddle.arange(4 * 8, dtype="float32").reshape([1, 4, 8])
+        cos = (phases / 11).cos().astype("float16")
+        sin = (phases / 13).sin().astype("float16")
+
+        actual_query, actual_key = apply_rotary_pos_emb(query, key, cos, sin)
+        expected_query = (
+            query.astype("float32") * cos.unsqueeze(1) + rotate_half(query).astype("float32") * sin.unsqueeze(1)
+        ).astype("float16")
+        expected_key = (
+            key.astype("float32") * cos.unsqueeze(1) + rotate_half(key).astype("float32") * sin.unsqueeze(1)
+        ).astype("float16")
+
+        self.assertTrue(paddle.equal(actual_query, expected_query).all().item())
+        self.assertTrue(paddle.equal(actual_key, expected_key).all().item())
+
+    def test_janus_input_dtype_rotary_is_instance_scoped(self):
+        config = tiny_janus_config()
+        janus_model = JanusForCausalLM(config)
+        self.assertTrue(
+            all(isinstance(layer.self_attn, JanusLlamaAttention) for layer in janus_model.language_model.model.layers)
+        )
+        self.assertIsInstance(janus_model.language_model.model, JanusLlamaModel)
+
+        llama_model = LlamaForCausalLM(config.language_config)
+        self.assertFalse(any(isinstance(layer.self_attn, JanusLlamaAttention) for layer in llama_model.model.layers))
+
+    def test_janus_vision_constructor_does_not_change_global_cublas_switch(self):
+        params = {
+            "image_size": 16,
+            "patch_size": 4,
+            "width": 8,
+            "layers": 1,
+            "heads": 2,
+            "mlp_ratio": 2.0,
+            "paddle_high_precision": True,
+        }
+        with (
+            mock.patch("paddle.is_compiled_with_cuda", return_value=True),
+            mock.patch("paddle.base.core.set_cublas_switch") as set_cublas_switch,
+        ):
+            JanusVisionTransformer(params)
+        set_cublas_switch.assert_not_called()
+
+    def test_bfloat16_rope_rounds_inverse_frequency_before_frequency_product(self):
+        """RoPE must follow the dtype of the model buffer as in the Torch reference."""
+        config = LlamaConfig(
+            hidden_size=32,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            head_dim=8,
+            max_position_embeddings=64,
+            rope_theta=10000.0,
+        )
+        rotary = JanusLlamaRotaryEmbedding(config)
+        hidden_states = paddle.zeros([1, 4, 32], dtype="bfloat16")
+        position_ids = paddle.arange(4, dtype="int64").unsqueeze(0)
+
+        actual_cos, actual_sin = rotary(hidden_states, position_ids)
+
+        inverse_frequency = rotary.inv_freq.astype("bfloat16").astype("float32")
+        frequencies = (inverse_frequency[None, :, None] @ position_ids[:, None, :].astype("float32")).transpose(
+            [0, 2, 1]
+        )
+        embedding = paddle.concat((frequencies, frequencies), axis=-1)
+        expected_cos = embedding.cos().astype("bfloat16")
+        expected_sin = embedding.sin().astype("bfloat16")
+
+        self.assertTrue(paddle.equal(actual_cos, expected_cos).all().item())
+        self.assertTrue(paddle.equal(actual_sin, expected_sin).all().item())
+
+    def test_float32_runtime_rope_uses_unrounded_original_frequency(self):
+        """Promoting a BF16 checkpoint must not retain BF16-rounded RoPE values."""
+        config = LlamaConfig(
+            hidden_size=32,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            head_dim=8,
+            max_position_embeddings=64,
+            rope_theta=10000.0,
+        )
+        rotary = JanusLlamaRotaryEmbedding(config)
+        original = rotary.original_inv_freq.clone()
+        # Simulate the checkpoint/runtime sequence: model is first materialized
+        # in BF16, then the language tower is promoted to FP32.
+        rotary.register_buffer("inv_freq", rotary.inv_freq.astype("bfloat16"), persistable=False)
+
+        hidden_states = paddle.zeros([1, 4, 32], dtype="float32")
+        position_ids = paddle.arange(4, dtype="int64").unsqueeze(0)
+        actual_cos, actual_sin = rotary(hidden_states, position_ids)
+
+        frequencies = (original[None, :, None] @ position_ids[:, None, :].astype("float32")).transpose([0, 2, 1])
+        embedding = paddle.concat((frequencies, frequencies), axis=-1)
+        expected_cos = embedding.cos()
+        expected_sin = embedding.sin()
+
+        self.assertLess(float(paddle.max(paddle.abs(actual_cos - expected_cos))), 1e-7)
+        self.assertLess(float(paddle.max(paddle.abs(actual_sin - expected_sin))), 1e-7)
+
+    @unittest.skipUnless(
+        paddle.is_compiled_with_cuda() and paddle.device.cuda.device_count() > 0,
+        "BF16 elementwise kernels require a CUDA device",
+    )
+    def test_bfloat16_rotary_apply_preserves_reference_rounding(self):
+        paddle.set_device("gpu")
+        query = (paddle.arange(1 * 2 * 4 * 8, dtype="float32").reshape([1, 2, 4, 8]) / 7).astype("bfloat16")
+        key = (query * 0.7).astype("bfloat16")
+        phases = paddle.arange(4 * 8, dtype="float32").reshape([1, 4, 8])
+        cos = (phases / 11).cos().astype("bfloat16")
+        sin = (phases / 13).sin().astype("bfloat16")
+
+        actual_query, actual_key = janus_apply_rotary_pos_emb(query, key, cos, sin)
+
+        def rotate_half(value):
+            return paddle.concat((-value[..., 4:], value[..., :4]), axis=-1)
+
+        expected_query = query * cos.unsqueeze(1) + rotate_half(query) * sin.unsqueeze(1)
+        expected_key = key * cos.unsqueeze(1) + rotate_half(key) * sin.unsqueeze(1)
+        self.assertTrue(paddle.equal(actual_query, expected_query).all().item())
+        self.assertTrue(paddle.equal(actual_key, expected_key).all().item())
+
+    def test_config_defaults_and_round_trip(self):
+        config = JanusConfig(language_config={"vocab_size": 97})
+        self.assertEqual(config.model_type, "multi_modality")
+        self.assertEqual(config.language_config.hidden_size, 4096)
+        self.assertEqual(config.language_config.num_hidden_layers, 30)
+        self.assertEqual(config.language_config.num_key_value_heads, 32)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.save_pretrained(tmpdir)
+            loaded = JanusConfig.from_pretrained(tmpdir)
+        self.assertIsInstance(loaded.language_config, type(config.language_config))
+        self.assertEqual(loaded.language_config.vocab_size, 97)
+
+    def test_auto_classes_resolve_local_config(self):
+        config = tiny_janus_config()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.save_pretrained(tmpdir)
+            self.assertIsInstance(AutoConfig.from_pretrained(tmpdir), JanusConfig)
+        self.assertIsInstance(AutoModel.from_config(config), JanusForCausalLM)
+        self.assertIsInstance(AutoModelForCausalLM.from_config(config), JanusForCausalLM)
+
+    def test_text_forward_and_generation_delegate(self):
+        model = JanusForCausalLM(tiny_janus_config())
+        model.eval()
+        input_ids = paddle.to_tensor([[1, 2, 3, 4]], dtype="int64")
+        output = model(input_ids=input_ids, use_cache=False, return_dict=True)
+        self.assertEqual(tuple(output.logits.shape), (1, 4, 97))
+        self.assertIs(model.get_input_embeddings(), model.language_model.get_input_embeddings())
+        prepared = model.prepare_inputs_for_generation(input_ids, use_cache=False)
+        self.assertIn("input_ids", prepared)
+
+    def test_causal_loss_shifts_labels_like_transformers(self):
+        model = JanusForCausalLM(tiny_janus_config())
+        model.eval()
+        input_ids = paddle.to_tensor([[1, 2, 3, 4, 5]], dtype="int64")
+        labels = paddle.to_tensor([[-100, 2, 3, 4, 5]], dtype="int64")
+
+        with paddle.no_grad():
+            output = model(
+                input_ids=input_ids,
+                labels=labels,
+                use_cache=False,
+                return_dict=True,
+            )
+            expected = paddle.nn.functional.cross_entropy(
+                output.logits[:, :-1, :].reshape([-1, output.logits.shape[-1]]),
+                labels[:, 1:].reshape([-1, 1]),
+                reduction="mean",
+                ignore_index=-100,
+            )
+
+        self.assertAlmostEqual(float(output.loss), float(expected), places=6)
+
+    def test_image_inputs_prepare_embeddings(self):
+        model = JanusForCausalLM(tiny_janus_config(with_vision=True))
+        self.assertTrue(model.vision_model.vision_tower.high_precision)
+        input_ids = paddle.ones([1, 3], dtype="int64")
+        pixel_values = paddle.zeros([1, 1, 3, 16, 16], dtype="float32")
+        images_seq_mask = paddle.to_tensor([[False, True, True]], dtype="bool")
+        images_emb_mask = paddle.to_tensor([[[True, True] + [False] * 14]], dtype="bool")
+        with paddle.no_grad():
+            embeds = model.prepare_inputs_embeds(
+                input_ids,
+                pixel_values,
+                images_seq_mask,
+                images_emb_mask,
+            )
+        self.assertEqual(tuple(embeds.shape), (1, 3, 32))
+
+        with paddle.no_grad():
+            output = model(
+                input_ids=input_ids,
+                pixel_values=pixel_values,
+                images_seq_mask=images_seq_mask,
+                images_emb_mask=images_emb_mask,
+                use_cache=False,
+                return_dict=True,
+            )
+        self.assertEqual(tuple(output.logits.shape), (1, 3, 97))
+
+    def test_vision_parity_precision_is_explicit_and_validated(self):
+        config = tiny_janus_config(with_vision=True)
+        config.vision_config["params"]["vision_parity_precision"] = "fp64_accumulate"
+        model = JanusForCausalLM(config)
+        tower = model.vision_model.vision_tower
+        self.assertEqual(tower.vision_parity_precision, "fp64_accumulate")
+        self.assertTrue(tower.high_precision)
+
+        config.vision_config["params"]["vision_parity_precision"] = "unsupported"
+        with self.assertRaisesRegex(ValueError, "unsupported vision parity precision"):
+            JanusForCausalLM(config)
+
+    def test_bfloat16_parity_policy_promotes_runtime_compute_dtypes(self):
+        """BF16 checkpoints use the auditable mixed-precision runtime policy."""
+        config = tiny_janus_config(with_vision=True)
+        config.language_compute_dtype = "float32"
+        config.vision_compute_dtype = "float64"
+
+        model = JanusForCausalLM.from_config(config, dtype="bfloat16")
+
+        self.assertEqual(model.language_model.model.embed_tokens.weight.dtype, paddle.float32)
+        self.assertEqual(model.language_model.lm_head.weight.dtype, paddle.float32)
+        self.assertEqual(model.vision_model.vision_tower.patch_embed.proj.weight.dtype, paddle.float64)
+        self.assertEqual(model.aligner.layers[0].weight.dtype, paddle.float64)
+
+    def test_bfloat16_multimodal_defaults_to_parity_runtime_policy(self):
+        """An unspecified BF16 multimodal policy must not silently use native kernels."""
+        config = tiny_janus_config(with_vision=True)
+        config.language_config.torch_dtype = "bfloat16"
+
+        model = JanusForCausalLM.from_config(config, dtype="bfloat16")
+
+        self.assertEqual(config.language_compute_dtype, "float32")
+        self.assertEqual(config.vision_compute_dtype, "float64")
+        self.assertEqual(model.language_model.model.embed_tokens.weight.dtype, paddle.float32)
+        self.assertEqual(model.vision_model.vision_tower.patch_embed.proj.weight.dtype, paddle.float64)
+        self.assertEqual(model.aligner.layers[0].weight.dtype, paddle.float64)
+
+    def test_explicit_native_vision_policy_is_not_overridden(self):
+        """A native diagnostic config remains native under BF16 construction."""
+        config = tiny_janus_config(with_vision=True)
+        config.language_config.torch_dtype = "bfloat16"
+        config.vision_config["params"]["vision_parity_precision"] = "native"
+        config.vision_config["params"]["paddle_high_precision"] = False
+
+        model = JanusForCausalLM.from_config(config, dtype="bfloat16")
+
+        self.assertIsNone(config.language_compute_dtype)
+        self.assertIsNone(config.vision_compute_dtype)
+        self.assertEqual(model.runtime_compute_dtypes, {"language": "checkpoint", "vision": "checkpoint"})
+        self.assertFalse(model.vision_model.vision_tower.high_precision)
+
+
+class JanusConversionTest(unittest.TestCase):
+    def setUp(self):
+        self.model = JanusForCausalLM(tiny_janus_config())
+        self.target = {key: value.numpy() for key, value in self.model.state_dict().items()}
+
+    def source_state_dict(self):
+        source = {key: value.copy() for key, value in self.target.items()}
+        for key in source:
+            if any(key.endswith(f".{name}.weight") for name in self.model.transpose_weight_keys):
+                source[key] = source[key].T
+        source["vision_model.dummy.weight"] = np.ones([2, 3], dtype="float32")
+        return source
+
+    def test_language_conversion_transposes_only_linear_weights(self):
+        converted, report = convert_language_state_dict(self.source_state_dict(), self.target)
+
+        self.assertEqual(set(converted), expected_language_keys(self.target))
+        self.assertEqual(report["accepted_language_keys"], len(self.target))
+        self.assertEqual(report["skipped_non_language_keys"], 1)
+        self.assertEqual(report["skipped_keys"], ["vision_model.dummy.weight"])
+        for key, expected in self.target.items():
+            np.testing.assert_array_equal(converted[key], expected)
+
+    def test_language_conversion_reports_all_key_errors(self):
+        source = self.source_state_dict()
+        source.pop("language_model.model.norm.weight")
+        source["language_model.unexpected.weight"] = np.ones([1], dtype="float32")
+
+        with self.assertRaisesRegex(ValueError, "missing.*language_model.model.norm.weight") as context:
+            convert_language_state_dict(source, self.target)
+
+        self.assertIn("unexpected language keys: language_model.unexpected.weight", str(context.exception))
+
+    def test_duplicate_keys_across_shards_are_rejected(self):
+        duplicate_key = "language_model.model.embed_tokens.weight"
+        shards = [
+            {duplicate_key: np.ones([2, 2], dtype="float32")},
+            {duplicate_key: np.zeros([2, 2], dtype="float32")},
+        ]
+
+        with self.assertRaisesRegex(ValueError, f"duplicate language keys: {duplicate_key}"):
+            merge_shard_state_dicts(shards)
+
+    def test_multimodal_conversion_accepts_vision_aligner_and_language(self):
+        model = JanusForCausalLM(tiny_janus_config(with_vision=True))
+        target = {key: value.numpy() for key, value in model.state_dict().items()}
+        source = {}
+        linear_suffixes = (
+            ".qkv.weight",
+            ".proj.weight",
+            ".q.weight",
+            ".kv.weight",
+            ".fc1.weight",
+            ".fc2.weight",
+            "aligner.layers.0.weight",
+            "aligner.layers.2.weight",
+        )
+        for key, value in target.items():
+            if value.ndim == 2 and (
+                key.endswith(linear_suffixes)
+                or any(key.endswith(f".{name}.weight") for name in model.transpose_weight_keys)
+            ):
+                value = value.T
+            source[key] = np.ascontiguousarray(value)
+        source["gen_embed.weight"] = np.ones([2, 3], dtype="float32")
+
+        converted, report = convert_janus_state_dict(source, target)
+
+        self.assertEqual(set(converted), expected_multimodal_keys(target))
+        self.assertGreater(report["accepted_vision_keys"], 0)
+        self.assertEqual(report["accepted_aligner_keys"], 4)
+        self.assertEqual(report["skipped_keys"], ["gen_embed.weight"])
+        for key, expected in target.items():
+            np.testing.assert_array_equal(converted[key], expected)
+
+
+class JanusCheckpointTest(unittest.TestCase):
+    def test_raw_hf_detection_is_scoped_to_huggingface_sources(self):
+        self.assertTrue(_is_raw_hf_checkpoint_reference("deepseek-ai/Janus-Pro-7B", download_hub="huggingface"))
+        self.assertFalse(_is_raw_hf_checkpoint_reference("paddle/Janus-Pro-7B", download_hub="aistudio"))
+        self.assertFalse(_is_raw_hf_checkpoint_reference("paddle/Janus-Pro-7B", download_hub="modelscope"))
+
+    def test_remote_detection_uses_format_probe_when_source_is_unspecified(self):
+        with mock.patch(
+            "paddleformers.transformers.janus.modeling._probe_remote_hf_checkpoint_reference",
+            return_value=False,
+        ) as probe:
+            self.assertFalse(_is_raw_hf_checkpoint_reference("org/native-janus", download_hub=None))
+            probe.assert_called_once_with("org/native-janus", None)
+
+        with mock.patch(
+            "paddleformers.transformers.janus.modeling._probe_remote_hf_checkpoint_reference",
+            return_value=True,
+        ):
+            self.assertTrue(_is_raw_hf_checkpoint_reference("org/raw-janus", download_hub=None))
+
+    def test_select_layer_matches_official_vision_depth_semantics(self):
+        base = {
+            "model_name": "siglip_large_patch16_384",
+            "layers": 4,
+            "image_size": 16,
+            "patch_size": 4,
+            "width": 8,
+            "heads": 2,
+            "mlp_ratio": 2.0,
+        }
+        self.assertEqual(_effective_vision_layers({**base, "select_layer": -1}), 4)
+        self.assertEqual(_effective_vision_layers({**base, "select_layer": -2}), 3)
+        self.assertEqual(_effective_vision_layers({**base, "select_layer": 2}), 2)
+        self.assertEqual(_effective_vision_layers({**base, "select_layer": 0}), 4)
+        with self.assertRaisesRegex(ValueError, "select_layer"):
+            _effective_vision_layers({**base, "select_layer": -5})
+
+        tower = JanusVisionTransformer({**base, "select_layer": -2})
+        self.assertEqual(len(tower.blocks), 3)
+
+    def test_select_layer_keeps_model_and_aoa_depth_in_sync(self):
+        config = tiny_janus_config(with_vision=True)
+        config.vision_config["params"].update({"layers": 3, "select_layer": -2})
+        model = JanusForCausalLM(config)
+        self.assertEqual(len(model.vision_model.vision_tower.blocks), 2)
+        statements = JanusForCausalLM._gen_aoa_config(config)["aoa_statements"]
+        block_ids = {
+            int(match.group(1))
+            for statement in statements
+            for match in [re.search(r"vision_tower\.blocks\.(\d+)\.", statement)]
+            if match
+        }
+        self.assertEqual(block_ids, {0, 1})
+
+    def test_transpose_patterns_are_scoped_to_janus_modules(self):
+        patterns = JanusForCausalLM.transpose_weight_keys
+        self.assertIn(r"aligner\.layers\.\d+", patterns)
+        self.assertNotIn(r"layers\.\d+", patterns)
+        self.assertTrue(
+            any(
+                re.search(rf"\.{pattern}\.weight$", ".aligner.layers.0.weight")
+                or re.fullmatch(rf"{pattern}\.weight", "aligner.layers.0.weight")
+                for pattern in patterns
+            )
+        )
+        self.assertFalse(
+            any(
+                re.search(rf"\.{pattern}\.weight$", ".future.layers.0.weight")
+                or re.fullmatch(rf"{pattern}\.weight", "future.layers.0.weight")
+                for pattern in patterns
+            )
+        )
+
+    def test_unrelated_metadata_does_not_hide_local_hf_safetensors(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "model.safetensors").touch()
+            Path(tmpdir, "README.md.metadata").touch()
+            self.assertTrue(_is_raw_hf_checkpoint_reference(tmpdir))
+
+    def test_raw_hf_detection_supports_variants_and_subfolders(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            weights_dir = Path(tmpdir, "weights")
+            weights_dir.mkdir()
+            Path(weights_dir, "model.fp32.safetensors").touch()
+            self.assertTrue(_is_raw_hf_checkpoint_reference(tmpdir, subfolder="weights"))
+
+    def test_aoa_config_covers_every_tiny_multimodal_parameter(self):
+        from paddle.distributed.flex_checkpoint.aoa.aoa_engine import AOAEngine
+        from paddle.distributed.flex_checkpoint.dcp.sharded_weight import (
+            ShardedWeightDesc,
+        )
+
+        model = JanusForCausalLM(tiny_janus_config(with_vision=True))
+        source = {}
+        target = {}
+        language_projection_names = (
+            "q_proj",
+            "k_proj",
+            "v_proj",
+            "o_proj",
+            "gate_proj",
+            "up_proj",
+            "down_proj",
+        )
+        for key, value in model.state_dict().items():
+            target_shape = tuple(value.shape)
+            transpose = value.ndim == 2 and (
+                (
+                    key.startswith("language_model.")
+                    and any(key.endswith(f".{name}.weight") for name in language_projection_names)
+                )
+                or (
+                    key.startswith("vision_model.")
+                    and key.endswith(
+                        (".qkv.weight", ".q.weight", ".kv.weight", ".proj.weight", ".fc1.weight", ".fc2.weight")
+                    )
+                )
+                or (key.startswith("aligner.") and key.endswith(".weight"))
+            )
+            source_shape = tuple(reversed(target_shape)) if transpose else target_shape
+            source[key] = [ShardedWeightDesc(key, source_shape, source_shape, (0,) * len(source_shape))]
+            target[key] = [ShardedWeightDesc(key, target_shape, target_shape, (0,) * len(target_shape))]
+
+        engine = AOAEngine(JanusForCausalLM._gen_aoa_config(model.config), source, target)
+        self.assertEqual(set(engine.output_vars), set(target))
+        self.assertTrue(
+            all(engine.output_vars[key].shape == tuple(value[0].global_shape) for key, value in target.items())
+        )
+
+    def test_hf_safetensors_are_loaded_directly_with_multimodal_transposes(self):
+        """A raw HF safetensors directory must be loadable without an offline conversion."""
+        from safetensors.numpy import save_file
+
+        source_model = JanusForCausalLM(tiny_janus_config(with_vision=True))
+        source_model.eval()
+        source_state = {}
+        for key, value in source_model.state_dict().items():
+            array = value.numpy()
+            needs_transpose = (
+                (
+                    key.startswith("language_model.")
+                    and any(key.endswith(f".{name}.weight") for name in source_model.transpose_weight_keys)
+                )
+                or (
+                    key.startswith("vision_model.")
+                    and key.endswith(
+                        (".qkv.weight", ".q.weight", ".kv.weight", ".proj.weight", ".fc1.weight", ".fc2.weight")
+                    )
+                )
+                or (key.startswith("aligner.") and key.endswith(".weight") and array.ndim == 2)
+            )
+            if needs_transpose and array.ndim == 2:
+                array = np.ascontiguousarray(array.T)
+            source_state[key] = np.ascontiguousarray(array)
+        # The official checkpoint also contains generator-only tensors.  They
+        # must be ignored by the understanding model rather than treated as a
+        # load error.
+        source_state["gen_embed.weight"] = np.ones([2, 3], dtype="float32")
+
+        input_ids = paddle.to_tensor([[1, 2, 3]], dtype="int64")
+        pixel_values = paddle.zeros([1, 1, 3, 16, 16], dtype="float32")
+        images_seq_mask = paddle.to_tensor([[False, True, True]], dtype="bool")
+        images_emb_mask = paddle.to_tensor([[[True, True] + [False] * 14]], dtype="bool")
+        with paddle.no_grad():
+            expected = source_model(
+                input_ids=input_ids,
+                pixel_values=pixel_values,
+                images_seq_mask=images_seq_mask,
+                images_emb_mask=images_emb_mask,
+                use_cache=False,
+                return_dict=True,
+            ).logits.numpy()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source_model.config.save_pretrained(tmpdir)
+            save_file(source_state, str(Path(tmpdir) / "model.safetensors"))
+            loaded = JanusForCausalLM.from_pretrained(tmpdir)
+            loaded.eval()
+            with paddle.no_grad():
+                actual = loaded(
+                    input_ids=input_ids,
+                    pixel_values=pixel_values,
+                    images_seq_mask=images_seq_mask,
+                    images_emb_mask=images_emb_mask,
+                    use_cache=False,
+                    return_dict=True,
+                ).logits.numpy()
+
+        np.testing.assert_allclose(actual, expected, atol=0.0, rtol=0.0)
+
+    def test_sharded_hf_safetensors_are_loaded_directly(self):
+        """The automatic path must also handle the standard HF shard index."""
+        from safetensors.numpy import save_file
+
+        source_model = JanusForCausalLM(tiny_janus_config())
+        source_state = {}
+        for key, value in source_model.state_dict().items():
+            array = value.numpy()
+            if array.ndim == 2 and any(
+                key.endswith(f".{name}.weight") for name in source_model.transpose_weight_keys[:7]
+            ):
+                array = np.ascontiguousarray(array.T)
+            source_state[key] = np.ascontiguousarray(array)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source_model.config.save_pretrained(tmpdir)
+            keys = sorted(source_state)
+            midpoint = len(keys) // 2
+            shard_names = ("model-00001-of-00002.safetensors", "model-00002-of-00002.safetensors")
+            save_file({key: source_state[key] for key in keys[:midpoint]}, str(Path(tmpdir) / shard_names[0]))
+            save_file({key: source_state[key] for key in keys[midpoint:]}, str(Path(tmpdir) / shard_names[1]))
+            index = {
+                "metadata": {"total_size": sum(array.nbytes for array in source_state.values())},
+                "weight_map": {
+                    key: shard_names[0] if index < midpoint else shard_names[1] for index, key in enumerate(keys)
+                },
+            }
+            (Path(tmpdir) / "model.safetensors.index.json").write_text(json.dumps(index), encoding="utf-8")
+
+            loaded = JanusForCausalLM.from_pretrained(tmpdir)
+
+        for key, value in source_model.state_dict().items():
+            np.testing.assert_array_equal(value.numpy(), loaded.state_dict()[key].numpy())
+
+    def test_save_and_reload_unsharded_and_sharded(self):
+        model = JanusForCausalLM(tiny_janus_config())
+        model.eval()
+        input_ids = paddle.to_tensor([[1, 2, 3, 4]], dtype="int64")
+        expected = model(input_ids=input_ids, use_cache=False, return_dict=True).logits
+
+        for max_shard_size in (None, "10KB"):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                save_kwargs = {"save_safetensors": False, "save_checkpoint_format": ""}
+                if max_shard_size is not None:
+                    save_kwargs["max_shard_size"] = max_shard_size
+                model.save_pretrained(tmpdir, **save_kwargs)
+
+                reloaded = JanusForCausalLM.from_pretrained(
+                    tmpdir,
+                    convert_from_hf=False,
+                    load_checkpoint_format="",
+                )
+                actual = reloaded(input_ids=input_ids, use_cache=False, return_dict=True).logits
+                self.assertTrue(paddle.allclose(expected, actual, atol=0.0, rtol=0.0))
+                self.assertTrue(all(key.startswith("language_model.") for key in reloaded.state_dict()))
+
+    @require_package("transformers", "torch")
+    def test_tiny_torch_paddle_parity(self):
+        import torch
+        import transformers
+
+        config = tiny_janus_config()
+        paddle_model = JanusForCausalLM(config)
+        paddle_model.eval()
+        torch_config = transformers.LlamaConfig(
+            vocab_size=config.language_config.vocab_size,
+            hidden_size=config.language_config.hidden_size,
+            intermediate_size=config.language_config.intermediate_size,
+            num_hidden_layers=config.language_config.num_hidden_layers,
+            num_attention_heads=config.language_config.num_attention_heads,
+            num_key_value_heads=config.language_config.num_key_value_heads,
+            head_dim=config.language_config.head_dim,
+            max_position_embeddings=config.language_config.max_position_embeddings,
+            rms_norm_eps=config.language_config.rms_norm_eps,
+            rope_theta=config.language_config.rope_theta,
+            tie_word_embeddings=False,
+        )
+        torch_model = transformers.LlamaForCausalLM(torch_config)
+        torch_state = {}
+        for paddle_key, paddle_value in paddle_model.state_dict().items():
+            torch_key = paddle_key.removeprefix("language_model.")
+            value = paddle_value.numpy()
+            if value.ndim == 2 and any(
+                torch_key.endswith(f".{name}.weight") for name in paddle_model.transpose_weight_keys
+            ):
+                value = value.T
+            torch_state[torch_key] = torch.from_numpy(np.ascontiguousarray(value))
+        torch_model.load_state_dict(torch_state, strict=True)
+        torch_model.eval()
+
+        input_ids = paddle.to_tensor([[1, 2, 3, 4, 5, 6]], dtype="int64")
+        with paddle.no_grad():
+            paddle_logits = paddle_model(input_ids=input_ids, use_cache=False, return_dict=True).logits
+        torch_input_ids = torch.tensor(input_ids.numpy(), dtype=torch.long)
+        with torch.no_grad():
+            torch_logits = torch_model(torch_input_ids, use_cache=False).logits
+
+        paddle_logits_np = paddle_logits.numpy()
+        torch_logits_np = torch_logits.detach().cpu().numpy()
+        max_abs_diff = np.max(np.abs(paddle_logits_np - torch_logits_np))
+        self.assertLessEqual(max_abs_diff, 1e-2)
+        self.assertEqual(
+            np.argmax(paddle_logits_np, axis=-1)[:, :10].tolist(),
+            np.argmax(torch_logits_np, axis=-1)[:, :10].tolist(),
+        )
+
+        paddle_generated = input_ids.clone()
+        torch_generated = torch_input_ids.clone()
+        for _ in range(10):
+            with paddle.no_grad():
+                next_paddle = paddle.argmax(
+                    paddle_model(input_ids=paddle_generated, use_cache=False, return_dict=True).logits[:, -1, :],
+                    axis=-1,
+                ).unsqueeze(-1)
+            with torch.no_grad():
+                next_torch = torch.argmax(torch_model(torch_generated, use_cache=False).logits[:, -1, :], dim=-1)
+            paddle_generated = paddle.concat([paddle_generated, next_paddle], axis=-1)
+            torch_generated = torch.cat([torch_generated, next_torch.unsqueeze(-1)], dim=-1)
+        self.assertEqual(paddle_generated[:, -10:].numpy().tolist(), torch_generated[:, -10:].tolist())


### PR DESCRIPTION
#### Before submitting

- [x] Lint code. If there are lint issues, please format the code first.
- [x] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types

New features

### PR changes

Models

### Description

## 变更内容

- 新增 Janus-Pro-7B 的 `JanusConfig`、语言模型、视觉塔和图像对齐模块。
- 注册 `AutoConfig`、`AutoModel` 和 `AutoModelForCausalLM`。
- 支持直接加载 Hugging Face `deepseek-ai/Janus-Pro-7B` 的 safetensors 单文件及分片权重。
- 增加 Janus 专用权重映射和 `_gen_aoa_config`，支持 Hugging Face 权重自动转换。
- 当前支持多模态理解和 SFT，暂不包含文生图生成分支。

## 前向精度

- 文本输入 logits 平均绝对 diff：`9.08e-6`，处于 `1e-2` 量级范围内。
- 图像输入 logits 平均绝对 diff：`1.49e-5`，处于 `1e-2` 量级范围内。
- 文本和图像输入的前十个位置 argmax 均一致。
- 十步 greedy 生成 token 均一致。

## 300 步训练验证

- Paddle 与 ms-swift 使用相同的 canonical 多模态 batch 完成 300 步训练。
- 训练采用 1 个语言层和 1 个视觉层的缩减结构，用于验证模型结构、梯度和优化器更新链路。
- loss 差值定义为 `Paddle loss - ms-swift loss`。
- 300 步内差值呈正负波动，平均绝对 diff 为 `1.04e-2`，处于 `1e-2` 量级范围内。

### 训练曲线

<img width="2335" height="1257" alt="janus-loss-300-comparison" src="https://github.com/user-attachments/assets/21a7b42f-3162-4881-b9a2-7dde283c2dc4" />

<img width="2335" height="1257" alt="janus-loss-300-delta" src="https://github.com/user-attachments/assets/46707b32-2547-4f52-8b42-122018fe314c" />


## 测试覆盖

- Janus 配置及 Auto 注册。
- 文本和图像输入前向。
- 权重映射及转置逻辑。
- Hugging Face safetensors 单文件、分片加载和保存重载。
