### PR TITLE
[Trainer] Add phase timings and local-resumability diagnostics to flex checkpoint load

### DIFF
--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -1220,6 +1220,128 @@ class Trainer:
             assert len(metadata_files) == 1, f"Found multiple metadata files in {path}"
             return metadata_files[0]
 
+
+        # ---- phase timings for the flex-checkpoint window -------------------
+        # dist.load_state_dict() is opaque from here: it either reports
+        # "resumable locally, skipping reshard." and reads only this rank's own
+        # .distcp, or it silently degrades to fetching shards across the cluster.
+        # Attributing this window previously meant diffing timestamps of
+        # unrelated log lines, which cannot separate reading a component from the
+        # metadata / optimizer-init work in front of it.
+        #
+        # Logged on every rank with the rank id on purpose: the window is gated
+        # by collectives, so the interesting number is usually the spread across
+        # ranks (one slow reader stalls everyone), not rank 0 alone.
+        #   grep '[flex-load]' workerlog.*
+        _flex_phase_stats = OrderedDict()
+        _flex_nested_stats = OrderedDict()
+        _flex_rank = dist.get_rank() if paddle.distributed.is_initialized() else 0
+        # Every phase launches device work (H2D from the .distcp files, cast
+        # kernels, NCCL), all enqueued asynchronously, so a bare host timer would
+        # charge one phase's execution to whichever later phase blocks first.
+        # Fence both ends: one synchronize per phase is noise next to seconds of
+        # payload.
+        _flex_on_gpu = str(paddle.get_device()).startswith("gpu")
+
+        def flex_fence():
+            if _flex_on_gpu:
+                paddle.device.synchronize()
+
+        @contextlib.contextmanager
+        def flex_phase(name, extra="", nested=False):
+            flex_fence()
+            t0 = time.time()
+            try:
+                yield
+            finally:
+                flex_fence()
+                dt = time.time() - t0
+                # nested phases are kept apart so TOTAL stays a real sum
+                bucket = _flex_nested_stats if nested else _flex_phase_stats
+                bucket[name] = bucket.get(name, 0.0) + dt
+                logger.info(f"[flex-load] rank={_flex_rank} phase={name} seconds={dt:.3f}{extra}")
+
+        def flex_phase_summary():
+            total = sum(_flex_phase_stats.values())
+            parts = ", ".join(f"{k}={v:.2f}s" for k, v in _flex_phase_stats.items())
+            logger.info(f"[flex-load] rank={_flex_rank} TOTAL={total:.2f}s | {parts}")
+            if _flex_nested_stats:
+                sub = ", ".join(f"{k}={v:.2f}s" for k, v in _flex_nested_stats.items())
+                logger.info(f"[flex-load] rank={_flex_rank} NESTED (already inside TOTAL) | {sub}")
+
+        # ---- why a component fell off the local fast path -------------------
+        # check_resumable_locally() is a global AND over every key, so a single
+        # key missing from this rank's own file drags the whole component onto
+        # the reshard path -- and nothing in the log says which key. Reproduce
+        # that check here and name the offenders.
+        #
+        # Deliberately collective-free: an all_reduce here would deadlock if the
+        # import guard succeeded on some ranks and failed on others. Aggregate
+        # across ranks with grep instead.
+        _flex_storage_meta = {}
+
+        def flex_diagnose_component(name, sharded_state_dict):
+            storage_metadata = _flex_storage_meta.get(name)
+            if not storage_metadata:
+                return
+            try:
+                from dataclasses import replace as _dc_replace
+
+                from paddle.distributed.flex_checkpoint.dcp.metadata import (
+                    LocalTensorIndex,
+                )
+                from paddle.distributed.flex_checkpoint.dcp.utils import (
+                    extract_tensor_metadata,
+                )
+            except (ImportError, ModuleNotFoundError) as exc:
+                logger.info(f"[flex-load] rank={_flex_rank} diag={name} skipped: {exc}")
+                return
+
+            own_file = f"{_flex_rank}_0.distcp"
+            index_to_files = {}
+            own_indices = set()
+            for index, fname in storage_metadata.items():
+                plain = _dc_replace(index, replica_id=None)
+                index_to_files.setdefault(plain, set()).add(fname)
+                if fname == own_file:
+                    own_indices.add(plain)
+
+            missing = []
+            needed_files = set()
+            n_checked = 0
+            for key, value in sharded_state_dict.items():
+                _, ltm = extract_tensor_metadata(value)
+                if ltm is None:
+                    continue
+                n_checked += 1
+                plain = LocalTensorIndex(
+                    tensor_key=key,
+                    global_offset=ltm.global_offset,
+                    is_flattened=ltm.is_flattened,
+                    flattened_range=ltm.flattened_range,
+                    local_shape=ltm.local_shape,
+                    replica_id=None,
+                )
+                if plain in own_indices:
+                    needed_files.add(own_file)
+                else:
+                    missing.append(key)
+                    needed_files |= index_to_files.get(plain, set())
+
+            # an index with a single candidate file is exactly the case that
+            # replicate_saved_into_local cannot fix on the load side
+            single_replica = sum(1 for files in index_to_files.values() if len(files) == 1)
+            logger.info(
+                f"[flex-load] rank={_flex_rank} diag={name} "
+                f"local_readable={'YES' if not missing else 'NO'} "
+                f"checked={n_checked} missing_from_own_file={len(missing)} "
+                f"distinct_files_to_read={len(needed_files)} "
+                f"index_entries={len(index_to_files)} single_replica_indices={single_replica} "
+                f"own_file_exists={os.path.isfile(os.path.join(_flex_component_paths[name], own_file))}"
+            )
+            if missing:
+                logger.info(f"[flex-load] rank={_flex_rank} diag={name} first_missing_keys={missing[:5]}")
+
         model_sharded_state_dict = self.model.sharded_state_dict()
         master_weights_path = os.path.join(resume_from_checkpoint, MASTER_WEIGHT_DIC)
         opt_states_path = os.path.join(resume_from_checkpoint, OPTIMIZER_STATE_DIC)
@@ -1291,20 +1413,33 @@ class Trainer:
             return
 
         state_dict_metadata = {}
+        _flex_component_paths = {
+            "model_state": model_states_path,
+            "opt_state": opt_states_path,
+            "master_weight": master_weights_path,
+        }
         metadata_paths = [
             os.path.join(model_states_path, get_metadata_file_name(model_states_path)),
             os.path.join(opt_states_path, get_metadata_file_name(opt_states_path)),
             os.path.join(master_weights_path, get_metadata_file_name(master_weights_path)),
         ]
 
-        for metadata_file in metadata_paths:
-            if not os.path.exists(metadata_file):
-                raise FileNotFoundError(f"Metadata file not found: {metadata_file}")
-            metadata = paddle.load(metadata_file)
-            state_dict_metadata.update(metadata.state_dict_metadata)
+        with flex_phase("metadata_load", extra=f" files={len(metadata_paths)}"):
+            for metadata_file in metadata_paths:
+                if not os.path.exists(metadata_file):
+                    raise FileNotFoundError(f"Metadata file not found: {metadata_file}")
+                metadata = paddle.load(metadata_file)
+                state_dict_metadata.update(metadata.state_dict_metadata)
+                # keep storage_metadata so the diagnosis does not have to re-read
+                # the file (model_state's can be hundreds of MiB)
+                for _cname, _cpath in _flex_component_paths.items():
+                    if os.path.dirname(metadata_file) == _cpath:
+                        _flex_storage_meta[_cname] = getattr(metadata, "storage_metadata", None)
+            logger.info(f"[flex-load] rank={_flex_rank} state_dict_metadata keys={len(state_dict_metadata)}")
 
         if not self.args.sharded_model_from_ema:
-            init_optimizer(self.optimizer, model_sharded_state_dict, state_dict_metadata)
+            with flex_phase("init_optimizer"):
+                init_optimizer(self.optimizer, model_sharded_state_dict, state_dict_metadata)
 
             # ===== EMA State Resharding for ZCC (right after optimizer init) =====
             # Non-ZCC handles reshard internally in EMABufferFcBased._load()
@@ -1331,14 +1466,19 @@ class Trainer:
                     else:
                         logger.info("[EMA Reshard] Same strategy, subprocess will load EMA directly from file")
 
-            optimizer_sharded_state_dict = self.optimizer.sharded_state_dict(model_sharded_state_dict)
-            opt_states = {}
-            master_weights = {}
-            for k, v in optimizer_sharded_state_dict.items():
-                if k.endswith(".w_0"):
-                    master_weights[k] = v
-                else:
-                    opt_states[k] = v
+            with flex_phase("optimizer_sharded_state_dict"):
+                optimizer_sharded_state_dict = self.optimizer.sharded_state_dict(model_sharded_state_dict)
+                opt_states = {}
+                master_weights = {}
+                for k, v in optimizer_sharded_state_dict.items():
+                    if k.endswith(".w_0"):
+                        master_weights[k] = v
+                    else:
+                        opt_states[k] = v
+                logger.info(
+                    f"[flex-load] rank={_flex_rank} master_weight_keys={len(master_weights)} "
+                    f"opt_state_keys={len(opt_states)}"
+                )
 
             # use filtered AOA for master_weight (excludes FP32-only params)
             master_weight_aoa = getattr(self.args, "aoa_config_master_weight", None) or self.args.aoa_config
@@ -1348,9 +1488,11 @@ class Trainer:
                 logger.info("[AOAConfig] generate master_weight_aoa by _gen_ckpt_convert_aoa !")
                 master_weight_aoa = self.model._gen_ckpt_convert_aoa(self.model.config)
 
-            dist.load_state_dict(
-                master_weights,
-                master_weights_path,
+            flex_diagnose_component("master_weight", master_weights)
+            with flex_phase("master_weight_load", extra=f" keys={len(master_weights)}"):
+                dist.load_state_dict(
+                    master_weights,
+                    master_weights_path,
                 aoa_config=master_weight_aoa,
                 offload=self.args.load_via_cpu,
                 comm_method=flex_ckpt_comm_method,
@@ -1365,9 +1507,11 @@ class Trainer:
                     logger.info("[AOAConfig] generate opt_stat_aoa by _gen_ckpt_convert_aoa !")
                     opt_stat_aoa = self.model._gen_ckpt_convert_aoa(self.model.config, target="opt_state")
 
-                dist.load_state_dict(
-                    opt_states,
-                    opt_states_path,
+                flex_diagnose_component("opt_state", opt_states)
+                with flex_phase("opt_state_load", extra=f" keys={len(opt_states)}"):
+                    dist.load_state_dict(
+                        opt_states,
+                        opt_states_path,
                     aoa_config=opt_stat_aoa,
                     offload=self.args.load_via_cpu,
                     comm_method=flex_ckpt_comm_method,
@@ -1452,9 +1596,11 @@ class Trainer:
             else:
                 aoa_config = self.args.aoa_config
 
-            dist.load_state_dict(
-                model_sharded_state_dict,
-                model_states_path,
+            flex_diagnose_component("model_state", model_sharded_state_dict)
+            with flex_phase("model_state_load", extra=f" keys={len(model_sharded_state_dict)}"):
+                dist.load_state_dict(
+                    model_sharded_state_dict,
+                    model_states_path,
                 aoa_config=aoa_config,
                 offload=self.args.load_via_cpu,
                 comm_method=flex_ckpt_comm_method,
@@ -1462,9 +1608,13 @@ class Trainer:
             )
 
         if enable_bf16_opt:
-            opt_state_dict = self.optimizer.state_dict()
+            with flex_phase("optimizer_state_dict"):
+                opt_state_dict = self.optimizer.state_dict()
 
             def _assign_master_weights_to_model(master_weights):
+                flex_fence()
+                _t_assign = time.time()
+                _n_written = 0
                 model_state_dict = self.model.state_dict()
                 for key, param in model_state_dict.items():
                     if param.name in master_weights and param.dtype == paddle.bfloat16:
@@ -1478,16 +1628,41 @@ class Trainer:
                         ), f"got {param.shape} vs {master_weights[param.name].shape}"
                         master_weight = paddle.reshape(master_weights[param.name], param.shape)
                         paddle.assign(paddle.cast(to_device(master_weight), paddle.bfloat16), model_state_dict[key])
+                        _n_written += 1
+                flex_fence()
+                _dt_assign = time.time() - _t_assign
+                _flex_nested_stats["assign_to_model"] = _flex_nested_stats.get("assign_to_model", 0.0) + _dt_assign
+                logger.info(
+                    f"[flex-load] rank={_flex_rank} phase=assign_to_model "
+                    f"seconds={_dt_assign:.3f} params_written={_n_written}"
+                )
 
             def recover_params_from_master_weight(opt_state_dict, group):
                 master_weights = opt_state_dict.get("master_weights", {})
                 tmp = OrderedDict()
                 master_weights, tmp = (tmp, master_weights)
                 # cast to bf16 and move to cpu
+                #
+                # Timed separately because the block containing it also holds
+                # optimizer.state_dict(), GroupGetter and split_opt_state, so the
+                # copy could never be told apart from them. src_on_device records
+                # whether the sources really were on device: with the optimizer
+                # offloaded to pinned host memory the trip runs the other way.
+                flex_fence()
+                _t_cast = time.time()
+                _cast_on_device = 0
                 for k, v in tmp.items():
                     name = v.name
+                    if isinstance(v, paddle.Tensor) and not v.place.is_cpu_place():
+                        _cast_on_device += 1
                     master_weights[k] = paddle.cast(to_device(v), paddle.bfloat16).cpu()
                     master_weights[k].name = name
+                flex_fence()
+                logger.info(
+                    f"[flex-load] rank={_flex_rank} phase=master_weight_cast_to_host "
+                    f"seconds={time.time() - _t_cast:.3f} tensors={len(master_weights)} "
+                    f"src_on_device={_cast_on_device} group_nranks={group.nranks}"
+                )
 
                 structure_name_map = {k: v.name for (k, v) in self.model.state_dict().items()}
 
@@ -1503,6 +1678,7 @@ class Trainer:
                             mw_2d[k] = v
                         else:
                             mw_1d[k] = v
+                    logger.info(f"[flex-load] rank={_flex_rank} split_2d_1d mw_2d={len(mw_2d)} mw_1d={len(mw_1d)}")
 
                     all_master_weights = OrderedDict()
                     restored_2d = _restore_master_weights_single(
@@ -1540,15 +1716,23 @@ class Trainer:
 
                 _assign_master_weights_to_model(master_weights)
 
+            _t_recover = time.time()
             with paddle.no_grad():
                 if paddle.distributed.is_initialized():
-                    group_getter = GroupGetter(self.model)
-                    opt_state_dict = split_opt_state(opt_state_dict, group_getter)
-                    for gid in group_getter.get_group_ids():
+                    with flex_phase("group_getter_and_split_opt_state"):
+                        group_getter = GroupGetter(self.model)
+                        opt_state_dict = split_opt_state(opt_state_dict, group_getter)
+                    for _pass_idx, gid in enumerate(group_getter.get_group_ids()):
                         sub_opt_state_dict = opt_state_dict.get(gid, {})
                         group = group_getter.get_group_by_id(gid)
                         if self.args.bf16:
-                            recover_params_from_master_weight(sub_opt_state_dict, group)
+                            with flex_phase(
+                                f"recover_pass{_pass_idx}",
+                                nested=True,
+                                extra=f" group_nranks={group.nranks} "
+                                f"tensors={len(sub_opt_state_dict.get('master_weights', {}))}",
+                            ):
+                                recover_params_from_master_weight(sub_opt_state_dict, group)
                 else:
                     master_weights = opt_state_dict["master_weights"]
                     model_state_dict = self.model.state_dict()
@@ -1564,6 +1748,14 @@ class Trainer:
                             paddle.assign(
                                 paddle.cast(to_device(master_weight), paddle.bfloat16), model_state_dict[key]
                             )
+
+            # Covers both group passes: cast to bf16, the 2D/1D split, the
+            # reshard rounds and the writeback.
+            _dt = time.time() - _t_recover
+            _flex_phase_stats["bf16_master_weight_recovery"] = _dt
+            logger.info(f"[flex-load] rank={_flex_rank} phase=bf16_master_weight_recovery seconds={_dt:.3f}")
+
+        flex_phase_summary()
 
     def _is_fc_format_ema(self, ema_state_path):
         """Check if EMA state is in FC format by looking for .metadata file."""

--- a/paddleformers/trainer/trainer_utils.py
+++ b/paddleformers/trainer/trainer_utils.py
@@ -1838,15 +1838,52 @@ def _get_muon_2d_param_names(muon_opt):
 
 
 def _restore_master_weights_single(master_weights, model, optimizer, group, structure_name_map, restore_func):
+    # Six steps, only two of which communicate, but the others are not free:
+    # pack_keys() forces every value to host (a real device-to-host copy when the
+    # source is still on device) and restore_func() for ShardingV2 runs
+    # even_distribute(), i.e. more all_gather rounds. Without this breakdown the
+    # whole thing is one opaque block.
+    _on_gpu = str(paddle.get_device()).startswith("gpu")
+
+    def _fence():
+        # pack_keys() and restore_func() launch copies and concat kernels; a bare
+        # host timer would push their execution into the next step.
+        if _on_gpu:
+            paddle.device.synchronize()
+
+    _fence()
+    t0 = time.time()
     nms = reshard_util.NodeModelState(group=group)
     nms_tmp = reshard_util.NodeModelState(group=group)
     nms_tmp.add_master_weights(master_weights)
+    _fence()
+    t_add = time.time()
     nms_tmp.pack_keys(structure_name_map)
+    _fence()
+    t_pack = time.time()
     nms.merge_from(nms_tmp, max(group.rank, 0))
     del nms_tmp
+    _fence()
+    t_merge = time.time()
     nms = restore_func(nms, model, optimizer)
+    _fence()
+    t_restore = time.time()
     nms.unpack_keys()
-    return reshard_util.all_gather_state_dict(nms.master_weights, lambda x: True, group)
+    _fence()
+    t_unpack = time.time()
+    res = reshard_util.all_gather_state_dict(nms.master_weights, lambda x: True, group)
+    _fence()
+    t_gather = time.time()
+    logger.info(
+        f"[mw-restore] rank={max(group.rank, 0)} "
+        f"restore={getattr(restore_func, '__module__', '?').split('.')[-1]} "
+        f"in_tensors={len(master_weights)} out_tensors={len(res)} nranks={group.nranks} "
+        f"total={t_gather - t0:.3f}s | add_master={t_add - t0:.3f}s "
+        f"pack_keys(host_copy)={t_pack - t_add:.3f}s merge_from={t_merge - t_pack:.3f}s "
+        f"restore_func={t_restore - t_merge:.3f}s unpack_keys={t_unpack - t_restore:.3f}s "
+        f"all_gather={t_gather - t_unpack:.3f}s"
+    )
+    return res
 
 
 def recover_params_from_master_weight(ema_state_dict, model, optimizer, group):

--- a/tests/trainer/test_flex_load_instrumentation.py
+++ b/tests/trainer/test_flex_load_instrumentation.py
@@ -1,0 +1,201 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Scope checks for the flex-checkpoint load instrumentation.
+
+The timing helpers and the local-resumability diagnosis are closures defined
+inside ``Trainer._load_flex_checkpoint``. Nothing guarantees at import time that
+a helper and its call sites stay in the same function body: moving one of them
+into a neighbouring method still compiles and only fails at run time with
+``NameError``, which needs a live distributed job to surface.
+
+These tests parse trainer.py and assert the invariant statically, so no GPU and
+no distributed init are required.
+"""
+
+import ast
+import inspect
+import os
+import unittest
+
+import paddleformers.trainer.trainer as trainer_module
+import paddleformers.trainer.trainer_utils as trainer_utils_module
+
+# closures and locals that the instrumentation introduces; every one of them must
+# be created inside _load_flex_checkpoint and used nowhere else
+INSTRUMENTATION_NAMES = {
+    "flex_phase",
+    "flex_phase_summary",
+    "flex_fence",
+    "flex_diagnose_component",
+    "_flex_phase_stats",
+    "_flex_nested_stats",
+    "_flex_rank",
+    "_flex_on_gpu",
+    "_flex_storage_meta",
+    "_flex_component_paths",
+    "_t_recover",
+    "_t_cast",
+    "_cast_on_device",
+    "_t_assign",
+    "_n_written",
+}
+
+# what each timed phase is expected to wrap, as a substring of the first
+# statement inside the with-block
+EXPECTED_PHASE_TARGETS = {
+    "metadata_load": "for metadata_file in metadata_paths:",
+    "init_optimizer": "init_optimizer(self.optimizer",
+    "optimizer_sharded_state_dict": "optimizer_sharded_state_dict = self.optimizer.sharded_state_dict(",
+    "master_weight_load": "dist.load_state_dict(",
+    "opt_state_load": "dist.load_state_dict(",
+    "model_state_load": "dist.load_state_dict(",
+    "optimizer_state_dict": "opt_state_dict = self.optimizer.state_dict()",
+    "group_getter_and_split_opt_state": "group_getter = GroupGetter(self.model)",
+}
+
+
+def _load(module):
+    path = inspect.getsourcefile(module)
+    with open(path, encoding="utf-8") as handle:
+        source = handle.read()
+    return path, source, ast.parse(source)
+
+
+def _find_function(tree, name):
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    return None
+
+
+class TestFlexLoadInstrumentationScope(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.path, cls.source, cls.tree = _load(trainer_module)
+        cls.lines = cls.source.split("\n")
+        cls.func = _find_function(cls.tree, "_load_flex_checkpoint")
+        assert cls.func is not None, f"_load_flex_checkpoint not found in {cls.path}"
+
+    def _bound_names(self):
+        bound = set()
+        for node in ast.walk(self.func):
+            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+                bound.add(node.id)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                bound.add(node.name)
+        return bound
+
+    def test_every_helper_is_defined_inside_the_method(self):
+        """A helper that drifts into another method still compiles; catch it here."""
+        bound = self._bound_names()
+        used = {n.id for n in ast.walk(self.func) if isinstance(n, ast.Name)}
+        expected = INSTRUMENTATION_NAMES & used
+        self.assertTrue(expected, "no instrumentation names found - did the naming change?")
+        missing = sorted(expected - bound)
+        self.assertEqual(missing, [], f"used but never bound inside _load_flex_checkpoint: {missing}")
+
+    def test_no_instrumentation_name_leaks_outside_the_method(self):
+        span = range(self.func.lineno, (self.func.end_lineno or self.func.lineno) + 1)
+        outside = [
+            (n.id, n.lineno)
+            for n in ast.walk(self.tree)
+            if isinstance(n, ast.Name) and n.id in INSTRUMENTATION_NAMES and n.lineno not in span
+        ]
+        self.assertEqual(outside, [], f"instrumentation used outside _load_flex_checkpoint: {outside}")
+
+    def test_each_phase_wraps_the_expected_statement(self):
+        """Guards against a with-block landing on the wrong call of the same shape.
+
+        dist.load_state_dict( appears several times in this file; a timer that
+        wraps the EMA load instead of the model_state load would still be inside
+        the method and would still run.
+        """
+        seen = {}
+        for node in ast.walk(self.func):
+            if not isinstance(node, ast.With):
+                continue
+            for item in node.items:
+                call = item.context_expr
+                if not (isinstance(call, ast.Call) and getattr(call.func, "id", None) == "flex_phase"):
+                    continue
+                if not (call.args and isinstance(call.args[0], ast.Constant)):
+                    continue  # f-string name (recover_pass{N}), checked separately
+                name = call.args[0].value
+                first = self.lines[node.body[0].lineno - 1].strip()
+                seen[name] = first
+        for name, expected in EXPECTED_PHASE_TARGETS.items():
+            self.assertIn(name, seen, f"phase {name!r} is gone")
+            self.assertIn(expected, seen[name], f"phase {name!r} wraps {seen[name]!r}, expected {expected!r}")
+
+    def test_diagnosis_precedes_the_matching_load(self):
+        pairs = []
+        for node in ast.walk(self.func):
+            if (
+                isinstance(node, ast.Expr)
+                and isinstance(node.value, ast.Call)
+                and getattr(node.value.func, "id", None) == "flex_diagnose_component"
+                and node.value.args
+                and isinstance(node.value.args[0], ast.Constant)
+            ):
+                pairs.append((node.value.args[0].value, node.lineno))
+        self.assertEqual(
+            sorted(name for name, _ in pairs),
+            ["master_weight", "model_state", "opt_state"],
+            f"unexpected diagnosis call sites: {pairs}",
+        )
+        for name, lineno in pairs:
+            following = " ".join(self.lines[lineno : lineno + 3])
+            self.assertIn(f'flex_phase("{name}_load"', following, f"{name} diagnosis is not next to its load")
+
+    def test_diagnosis_is_guarded_and_collective_free(self):
+        """It touches paddle.distributed internals and must not add collectives."""
+        diag = _find_function(self.func, "flex_diagnose_component")
+        self.assertIsNotNone(diag, "flex_diagnose_component not found")
+        self.assertTrue(
+            any(isinstance(n, ast.Try) for n in ast.walk(diag)),
+            "the paddle.distributed imports must stay inside try/except",
+        )
+        segment = "\n".join(self.lines[diag.lineno - 1 : (diag.end_lineno or diag.lineno)])
+        for collective in ("all_reduce", "all_gather", "barrier", "broadcast"):
+            self.assertNotIn(
+                collective,
+                segment,
+                f"{collective} in the diagnosis would deadlock when the import guard "
+                f"succeeds on some ranks only",
+            )
+
+
+class TestRestoreMasterWeightsInstrumentation(unittest.TestCase):
+    def test_six_step_timing_is_present_and_fenced(self):
+        path, source, tree = _load(trainer_utils_module)
+        func = _find_function(tree, "_restore_master_weights_single")
+        self.assertIsNotNone(func, f"_restore_master_weights_single not found in {path}")
+        bound = {n.id for n in ast.walk(func) if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Store)}
+        for name in ("t0", "t_add", "t_pack", "t_merge", "t_restore", "t_unpack", "t_gather"):
+            self.assertIn(name, bound, f"timing point {name} is missing")
+        fence = _find_function(func, "_fence")
+        self.assertIsNotNone(fence, "_fence helper is missing")
+        segment = "\n".join(source.split("\n")[func.lineno - 1 : (func.end_lineno or func.lineno)])
+        self.assertGreaterEqual(
+            segment.count("_fence()"),
+            7,
+            "each of the six steps plus the entry needs a fence, otherwise a step's "
+            "device work is charged to the next one",
+        )
+        self.assertIn("[mw-restore]", segment, "the summary log line is missing")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
### PR types
Others (observability)

### PR changes
Others

### Description

Loading a flex checkpoint is currently one opaque block. `dist.load_state_dict()`
either reports `resumable locally, skipping reshard.` and reads only this rank's
own `.distcp`, or it silently degrades to fetching shards across the cluster —
and the log does not say which key caused the degradation. Attributing the
window meant diffing timestamps of unrelated log lines, which cannot separate
reading a component from the metadata / optimizer-init work in front of it.

This PR adds observability only. There is no behaviour change: no control flow,
no data path and no saved/loaded content is altered.

**1. Phase timings in `Trainer._load_flex_checkpoint`**

Each phase is fenced with a device synchronize on both ends. The phases enqueue
H2D copies, cast kernels and NCCL work asynchronously, so a bare host timer
would charge one phase's execution to whichever later phase happens to block
first. One synchronize per phase (~10 per load) is negligible next to seconds of
payload.

Phases: `metadata_load`, `init_optimizer`, `optimizer_sharded_state_dict`,
`master_weight_load`, `opt_state_load`, `load_scheduler`, `model_state_load`,
`optimizer_state_dict`, `group_getter_and_split_opt_state`,
`bf16_master_weight_recovery`, plus nested `recover_pass{N}` and
`assign_to_model`. Nested phases are accumulated separately so `TOTAL` stays a
real sum rather than double counting.

**2. `src_on_device` on the cast-to-host step**

`master_weight_cast_to_host` reports how many fp32 sources were actually on
device. When the optimizer is offloaded to pinned host memory the copy runs the
other way round, which changes how the number should be read.

**3. `flex_diagnose_component()` — why a component fell off the fast path**

`check_resumable_locally()` is a global AND over every key, so one key missing
from a rank's own file drags the whole component onto the reshard path, and
nothing in the log says which key. This reproduces that check at the call site
and reports `local_readable`, `missing_from_own_file`, `first_missing_keys`,
`distinct_files_to_read` (read amplification) and `single_replica_indices`.

It reuses the already-loaded metadata rather than re-reading it (model_state's
metadata can be hundreds of MiB), is wrapped in `try/except` around the
`paddle.distributed.flex_checkpoint` internals so a future refactor there cannot
break loading, and is deliberately collective-free — an `all_reduce` would
deadlock if the import guard succeeded on some ranks and failed on others.
Aggregate across ranks with `grep` instead.

**4. Six-step breakdown in `_restore_master_weights_single`**

Only two of the six steps communicate, but the others are not free either:
`pack_keys()` forces every value to host and `restore_func()` for ShardingV2
runs `even_distribute()`. Each step is fenced.

All lines are logged per rank with the rank id: this window is gated by
collectives, so the useful signal is usually the spread across ranks (one slow
reader stalls everyone) rather than rank 0 alone.

```
grep -hE '\[flex-load\]|\[mw-restore\]' output/paddle_distributed_logs/workerlog.*
```

### Validation

Developed and exercised on an internal branch (8 nodes x 8 GPUs, MuonSharding,
ZCC + flex checkpoint). The output localised a 24 s load window as: the two
`dist.load_state_dict` calls 45%, collective arrival skew 14%, host-side staging
copies 14%, H2D 11%, with the actual NCCL transfer at 3%. Three suspects were
ruled out by the new numbers (`optimizer.state_dict()`, `GroupGetter` +
`split_opt_state`, and `pack_keys()` — all ~0 s even with fences), and the
per-phase accounting is self-consistent (each parent phase equals the sum of its
children to within the logging overhead).

On `develop` this was verified statically only: `py_compile`, `ast.parse`,
line length against `.flake8` / `pyproject.toml` (119), and symbol-level review.
**It has not been run against a real checkpoint on this branch** — the internal
branch carries extra reshard machinery around `dist.load_state_dict` that
`develop` does not have, so an end-to-end run here would not have been
representative. Happy to add sample output from a `develop`-based run if
reviewers prefer that before merging.
