### PR TITLE
Add symmetric GEMM options for Muon trainer

### DIFF
--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -3739,6 +3739,7 @@ class Trainer:
                 "ns_steps": args.muon_ns_steps,
                 "ns_coeff_type": args.muon_ns_coeff_type,
                 "ns_coeffs": args.muon_ns_coeffs,
+                "use_symmetric_gemm": args.muon_use_symmetric_gemm,
             }
             optimizer_cls = Muon
             optimizer_kwargs.update(muon_kwargs)

--- a/paddleformers/trainer/training_args.py
+++ b/paddleformers/trainer/training_args.py
@@ -1702,6 +1702,18 @@ class TrainingArguments:
             )
         },
     )
+    muon_use_symmetric_gemm: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Whether to compute the two symmetric matmuls of each Newton-Schulz step with "
+                "quack's SYRK-style gemm_symmetric kernel, which only evaluates the lower triangle "
+                "and mirrors it back. Requires bfloat16/float16 Newton-Schulz matmuls, an importable "
+                "quack, and compute capability 9.x/10.x/11.x. "
+                "Default: False. Only used when optim=muon."
+            )
+        },
+    )
     sd_sharding_comm_overlap: bool = field(
         default=False,
         metadata={


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others

### Description
<!-- Describe what this PR does -->
Expose the symmetric-GEMM fast path from PaddlePaddle/Paddle#79694 as trainer arguments and forward them to Muon:

  - muon_use_symmetric_gemm (default False)
  - muon_symmetric_gemm_min_short_edge (default 1024)
  - muon_symmetric_gemm_min_step_flops (default 2e11)

The first two matmuls of every Newton-Schulz step produce symmetric outputs, so a SYRK-style kernel only has to evaluate the lower triangle and mirror it back, saving 1/4 (tall-skinny) ~ 1/3 (square) of the per-step FLOPs. The two thresholds are required as a gate: the kernel needs a large enough short edge to fill the GPU and a large enough step to amortise its launch overhead, otherwise it loses to cuBLAS on the small fragments a real job also contains.

Kept off by default because it additionally requires an importable quack, bfloat16/float16 Newton-Schulz matmuls and compute capability 9.x/10.x/11.x.