### PR TITLE
[Deps] Update PaddleFleet to f75a5c50908

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,7 @@ try:
         install_requires=REQUIRED_PACKAGES,
         entry_points={"console_scripts": get_console_scripts()},
         extras_require={
-            "paddlefleet": ["paddlefleet==0.4.0.post20260901+81602f63ca3"],
+            "paddlefleet": ["paddlefleet==0.4.0.post20260903+f75a5c50908"],
         },
         python_requires=">=3.8",
         classifiers=[


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Description
Update the optional PaddleFleet dependency from `paddlefleet==0.4.0.post20260901+81602f63ca3` to `paddlefleet==0.4.0.post20260903+f75a5c50908`.

The target package is built from PaddleFleet `release/0.4` commit `f75a5c5090821507ac065e1c1b77d30eb172ca8e`.

### Validation

- Confirmed PaddleFleet `release/0.4` resolves to the target commit.
- Confirmed the official cu129 nightly index contains the target wheel, and the exact wheel URL is accessible.
- `python3 -m py_compile setup.py`
- `git diff --check`
