### PR TITLE
[CI] Speed up PR document type check

### DIFF
--- a/.github/workflows/fleet-model-test.yml
+++ b/.github/workflows/fleet-model-test.yml
@@ -52,13 +52,10 @@ jobs:
     outputs:
       is_md_only: ${{ steps.check_files.outputs.is_md_only }}
     steps:
-      - name: Cleanup
-        run: |
-          rm -rf * .[^.]*
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 2
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
@@ -67,7 +64,7 @@ jobs:
         if: |
           github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'fleet-models-ci')
         run: |
-          changed_files=$(git diff origin/${{ github.event.pull_request.base.ref }}...HEAD --name-only)
+          changed_files=$(git diff HEAD^1 HEAD --name-only)
           echo "Changed files: $changed_files"
           all_count=0
           md_count=0


### PR DESCRIPTION
#### Before submitting

- [x] Lint code. YAML syntax and whitespace checks pass.
- [x] Add test cases into `tests` folder. Not applicable to this workflow-only change.

### PR types

Performance optimization

### PR changes

Others

### Description

The `check_documents_type` job only needs the pull request merge commit and its base parent, but it currently deletes the workspace and performs an unlimited-history checkout. For a repository with more than 542,000 objects, that full fetch can make a lightweight gate spend many minutes in checkout.

This change:

- relies on the default cleanup performed by `actions/checkout` instead of deleting the workspace first;
- changes `fetch-depth` from `0` to `2`;
- compares `HEAD^1` with `HEAD` to obtain the files introduced by the PR merge commit.

Validation:

- `git diff --check` passes;
- the workflow file parses as valid YAML;
- a depth-2 fetch of `refs/pull/4969/merge` contains both parents, and `git diff HEAD^1 HEAD --name-only` reports the expected PR file (`setup.py`).

This is the `release/1.3` counterpart of https://github.com/PaddlePaddle/PaddleFormers/pull/4972.

Related slow run: https://github.com/PaddlePaddle/PaddleFormers/actions/runs/33766918673/job/100687177321?pr=4969