### PR TITLE
optimize EMAStateAssembler

### DIFF
--- a/paddleformers/trainer/trainer_callback.py
+++ b/paddleformers/trainer/trainer_callback.py
@@ -1221,7 +1221,7 @@ class EMAStateAssemblerCallback(TrainerCallback):
 
     def on_step_end(self, args, state, control, **kwargs):
         start = time.time()
-        self.ema_state_assembler.run()
+        self.ema_state_assembler.run(state.global_step)
         duration = time.time() - start
         logger.info(f"[EMAStateAssembler] Assembling EMA state took {duration:.3f} seconds.")
 

--- a/paddleformers/trainer/trainer_utils.py
+++ b/paddleformers/trainer/trainer_utils.py
@@ -1982,30 +1982,23 @@ class EMAStateAssembler:
         self.expected_next_save_ckpt_step = self.latest_processed_checkpoint_step + save_hf_steps
         self.pending_hf_step = None
 
-    def run(self, global_step, last_step=False):
+    def run(self, global_step=None):
         if self.save_hf_steps <= 0:
             logger.info("[EMAStateAssembler] save_hf_steps is not positive. Skipping.")
             return
 
-        if not last_step and not self._begin_EMAHFProcess(global_step):
+        # global_step is None means it's last step
+        if global_step is not None and not self._begin_EMAHFProcess(global_step):
             return
 
         next_step, next_ckpt_dir = self._find_checkpoint(mode="next")
         if next_step is None:
             next_step = -1
-        next_steps = []
-        dist.all_gather_object(next_steps, next_step)
+        local_handled = next_step != -1 and next_ckpt_dir is not None and self._is_already_handled(next_ckpt_dir)
+        gathered = []
+        dist.all_gather_object(gathered, (next_step, local_handled))
+        next_steps = [step for step, _ in gathered]
         if -1 in next_steps:
-            # At this point, some trainers no longer have any checkpoints to process. Each trainer checks whether it has any checkpoints left to process.
-            if next_step != -1 and next_ckpt_dir is not None and self._is_already_handled(next_ckpt_dir):
-                self.latest_processed_checkpoint_step = next_step
-                self._update_expected_next_save_ckpt_step()
-                self._close_EMAHFProcess(next_step)
-                logger.info(
-                    f"[EMAStateAssembler] [Rank {self.rank}] Checkpoint at step {next_step} has "
-                    "already been handled. Skipping."
-                )
-                return
             logger.info(
                 f"[EMAStateAssembler][Rank {self.rank}] No unprocessed checkpoint found in {self.output_dir} "
                 f"in current training step. Latest processed checkpoint step is {self.latest_processed_checkpoint_step}. Skipping."
@@ -2014,19 +2007,28 @@ class EMAStateAssembler:
 
         # At this point, each trainer has a checkpoint to process, but the step counts are not consistent.
         if len(set(next_steps)) != 1:
+            target_step = max(next_steps)
+            # Only the lagging ranks move: they signal the checkpoint they skip so it stays loadable,
+            # then line up with the leading ranks, which already sit right before target_step. Every
+            # rank finds target_step on the next call.
+            if next_step < target_step:
+                self._handle_naive_checkpoint(next_step, next_ckpt_dir)
+                self.latest_processed_checkpoint_step = next_step
+                self._update_expected_next_save_ckpt_step()
             logger.warning(
-                f"[EMAStateAssembler][Rank {self.rank}] Multiple checkpoints detected. "
-                f"Selected checkpoint path: {next_ckpt_dir}. Skipping processing for this checkpoint."
+                f"[EMAStateAssembler][Rank {self.rank}] Inconsistent checkpoint steps {next_steps}. "
+                f"All ranks will process step {target_step} next."
             )
             return
-        # If the checkpoint has already been processed, skip it.
-        if self._is_already_handled(next_ckpt_dir):
+
+        if any(handled for _, handled in gathered):
+            self._handle_naive_checkpoint(next_step, next_ckpt_dir)
             self.latest_processed_checkpoint_step = next_step
             self._update_expected_next_save_ckpt_step()
             self._close_EMAHFProcess(next_step)
-            logger.info(
-                f"[EMAStateAssembler] [Rank {self.rank}] Checkpoint at step {next_step} has "
-                "already been handled. Skipping."
+            logger.warning(
+                f"[EMAStateAssembler][Rank {self.rank}] Checkpoint at step {next_step} was partially "
+                "handled before; completed its signal and skipped the EMA merge."
             )
             return
 

--- a/paddleformers/trainer/trainer_utils.py
+++ b/paddleformers/trainer/trainer_utils.py
@@ -2005,7 +2005,13 @@ class EMAStateAssembler:
             )
             return
 
-        # At this point, each trainer has a checkpoint to process, but the step counts are not consistent.
+        # The two branches below only exist for recovery. Ranks normally reach this point in
+        # lockstep: same global_step, same checkpoint dir, hence the same next_step and the same
+        # signal state. A machine interruption can break that -- ranks end up on different steps,
+        # or a checkpoint is left with only part of the ranks' signals written. Such a checkpoint
+        # can never be merged again, since merging needs every rank to take part, so it is given
+        # up on and all ranks realign onto the newest checkpoint.
+
         if len(set(next_steps)) != 1:
             target_step = max(next_steps)
             # Only the lagging ranks move: they signal the checkpoint they skip so it stays loadable,
@@ -2022,7 +2028,10 @@ class EMAStateAssembler:
             return
 
         if any(handled for _, handled in gathered):
-            self._handle_naive_checkpoint(next_step, next_ckpt_dir)
+            # Ranks that already hold saved_signal have no TMP left; calling into
+            # _handle_naive_checkpoint there would only emit a misleading warning.
+            if not local_handled:
+                self._handle_naive_checkpoint(next_step, next_ckpt_dir)
             self.latest_processed_checkpoint_step = next_step
             self._update_expected_next_save_ckpt_step()
             self._close_EMAHFProcess(next_step)

--- a/paddleformers/trainer/trainer_utils.py
+++ b/paddleformers/trainer/trainer_utils.py
@@ -1979,11 +1979,15 @@ class EMAStateAssembler:
             self.expert_id_offset = (n_routed_experts // moe_group.nranks) * moe_group.rank
 
         self._set_latest_processed_checkpoint_step(start_step)
-        self.expected_next_save_ckpt_step = self.latest_processed_checkpoint_step + save_steps
+        self.expected_next_save_ckpt_step = self.latest_processed_checkpoint_step + save_hf_steps
+        self.pending_hf_step = None
 
-    def run(self):
-        if self.save_hf_steps < 0:
-            logger.info("[EMAStateAssembler] save_hf_steps is negative. Skipping.")
+    def run(self, global_step, last_step=False):
+        if self.save_hf_steps <= 0:
+            logger.info("[EMAStateAssembler] save_hf_steps is not positive. Skipping.")
+            return
+
+        if not last_step and not self._begin_EMAHFProcess(global_step):
             return
 
         next_step, next_ckpt_dir = self._find_checkpoint(mode="next")
@@ -1993,22 +1997,15 @@ class EMAStateAssembler:
         dist.all_gather_object(next_steps, next_step)
         if -1 in next_steps:
             # At this point, some trainers no longer have any checkpoints to process. Each trainer checks whether it has any checkpoints left to process.
-            if next_step != -1 and next_ckpt_dir is not None:
-                # There are still checkpoints available locally for processing.
-                if self._is_already_handled(next_ckpt_dir):
-                    # Already processed, skip. It may enter here during the first warm start.
-                    self.latest_processed_checkpoint_step = next_step
-                    self._update_expected_next_save_ckpt_step()
-                    logger.info(
-                        f"[EMAStateAssembler] [Rank {self.rank}] Checkpoint at step {next_step} has "
-                        "already been handled. Skipping."
-                    )
-                    return
-                # Not yet processed, check if EMA state needs to be merged.
-                is_hf_save_step = next_step % self.save_hf_steps == 0
-                if not is_hf_save_step:
-                    self._handle_naive_checkpoint(next_step, next_ckpt_dir)
-                    return
+            if next_step != -1 and next_ckpt_dir is not None and self._is_already_handled(next_ckpt_dir):
+                self.latest_processed_checkpoint_step = next_step
+                self._update_expected_next_save_ckpt_step()
+                self._close_EMAHFProcess(next_step)
+                logger.info(
+                    f"[EMAStateAssembler] [Rank {self.rank}] Checkpoint at step {next_step} has "
+                    "already been handled. Skipping."
+                )
+                return
             logger.info(
                 f"[EMAStateAssembler][Rank {self.rank}] No unprocessed checkpoint found in {self.output_dir} "
                 f"in current training step. Latest processed checkpoint step is {self.latest_processed_checkpoint_step}. Skipping."
@@ -2017,20 +2014,6 @@ class EMAStateAssembler:
 
         # At this point, each trainer has a checkpoint to process, but the step counts are not consistent.
         if len(set(next_steps)) != 1:
-            # If the checkpoint does not need to be used for merging EMA state, then try to process it.
-            is_hf_save_step = next_step % self.save_hf_steps == 0
-            if not is_hf_save_step and next_ckpt_dir is not None:
-                if self._is_already_handled(next_ckpt_dir):
-                    self.latest_processed_checkpoint_step = next_step
-                    self._update_expected_next_save_ckpt_step()
-                    logger.info(
-                        f"[EMAStateAssembler] [Rank {self.rank}] Checkpoint at step {next_step} has "
-                        "already been handled. Skipping."
-                    )
-                    return
-                self._handle_naive_checkpoint(next_step, next_ckpt_dir)
-                return
-
             logger.warning(
                 f"[EMAStateAssembler][Rank {self.rank}] Multiple checkpoints detected. "
                 f"Selected checkpoint path: {next_ckpt_dir}. Skipping processing for this checkpoint."
@@ -2040,24 +2023,30 @@ class EMAStateAssembler:
         if self._is_already_handled(next_ckpt_dir):
             self.latest_processed_checkpoint_step = next_step
             self._update_expected_next_save_ckpt_step()
+            self._close_EMAHFProcess(next_step)
             logger.info(
                 f"[EMAStateAssembler] [Rank {self.rank}] Checkpoint at step {next_step} has "
                 "already been handled. Skipping."
             )
             return
 
-        is_hf_save_step = next_step % self.save_hf_steps == 0
-
-        if is_hf_save_step:
-            self._handle_checkpoint_with_ema(next_step, next_ckpt_dir)
-        else:
-            self._handle_naive_checkpoint(next_step, next_ckpt_dir)
+        if self._handle_checkpoint_with_ema(next_step, next_ckpt_dir):
+            self._close_EMAHFProcess(next_step)
 
     def _update_expected_next_save_ckpt_step(self):
-        self.expected_next_save_ckpt_step = self.latest_processed_checkpoint_step + self.save_steps
+        self.expected_next_save_ckpt_step = self.latest_processed_checkpoint_step + self.save_hf_steps
         logger.info(
             f"[EMAStateAssembler] [Rank {self.rank}] Update the expected next save ckpt step to {self.expected_next_save_ckpt_step}!"
         )
+
+    def _begin_EMAHFProcess(self, global_step):
+        if global_step % self.save_hf_steps == 0:
+            self.pending_hf_step = global_step
+        return self.pending_hf_step is not None
+
+    def _close_EMAHFProcess(self, consumed_step):
+        if self.pending_hf_step is not None and consumed_step >= self.pending_hf_step:
+            self.pending_hf_step = None
 
     def _set_latest_processed_checkpoint_step(self, start_step):
 
@@ -2080,7 +2069,7 @@ class EMAStateAssembler:
                             target_step = step
                             target_ckpt_path = item
                     elif mode == "next":
-                        if step > self.latest_processed_checkpoint_step:
+                        if step > self.latest_processed_checkpoint_step and step % self.save_hf_steps == 0:
                             if (target_step is None) or (step < target_step):
                                 target_step = step
                                 target_ckpt_path = item
@@ -2119,7 +2108,8 @@ class EMAStateAssembler:
         self.latest_processed_checkpoint_step = step
         self._update_expected_next_save_ckpt_step()
 
-    def _handle_checkpoint_with_ema(self, step: int, checkpoint_dir: Path):
+    def _handle_checkpoint_with_ema(self, step: int, checkpoint_dir: Path) -> bool:
+        """Return True when this checkpoint is done being processed, False when still waiting."""
         if self._check_all_ranks_saved(checkpoint_dir):
             logger.info(
                 f"[EMAStateAssembler] [Rank {self.rank}] All ranks ready. Proceeding with EMA state assembly for step {step}."
@@ -2130,16 +2120,18 @@ class EMAStateAssembler:
                 logger.warning(
                     f"[EMAStateAssembler] [Rank {self.rank}] EMA state file not found at {ema_state_path}, skipping and updating signal. "
                 )
-                return
+                return True
             ema_sharded_state_dict = self._build_ema_sharded_state_dict(self._load_ema_state_dict(ema_state_path))
             self._mark_as_handled(checkpoint_dir, step)
             self._save_full_ema_states(step, ema_sharded_state_dict)
             del ema_sharded_state_dict
             logger.info(f"[EMAStateAssembler] [Rank {self.rank}] Finished merging EMA states and updated signal.")
+            return True
         else:
             logger.info(
                 f"[EMAStateAssembler] [Rank {self.rank}] Waiting for other ranks to finish saving checkpoint at step {step}."
             )
+            return False
 
     def _handle_naive_checkpoint(self, step: int, checkpoint_dir: Path):
         logger.info(f"[EMAStateAssembler] [Rank {self.rank}] Processing a no need merge EMA checkpoint.")

--- a/paddleformers/trainer/utils/zero_cost_checkpoint.py
+++ b/paddleformers/trainer/utils/zero_cost_checkpoint.py
@@ -1448,7 +1448,8 @@ class ZeroCostCheckpointWorker:
 
         self._dump_args_and_state(output_dir)
 
-        if self.save_hf_steps > 0 and self.ema_coef is not None and saved_signal_type == "tmp":
+        is_hf_step = self.save_hf_steps > 0 and self.global_step.value % self.save_hf_steps == 0
+        if is_hf_step and self.ema_coef is not None and saved_signal_type == "tmp":
             saved_signal_prefix = "save_signal_TMP"
         else:
             saved_signal_prefix = "saved_signal"


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
【问题描述】：解决原本代码在zcc情况下开启ema后在每个step君会出现的性能下降问题

【产生原因】：
1. zcc下不同rank的ckpt的落盘速度不一样，所以每个rank落盘完成之后会在文件写一个signal信号
2. ema hf_ckpt的ema权重依赖于zcc落盘中的数据，所以在开启后这个signal信号由EMAStateAssembler来写
3. 每个step，EMAStateAssembler会看落盘的ckpt，如果到了hf_ckpt的step且所有的rank的signal信号都拿到了就会开始ema hf_ckpt的落盘
4. 所以目前EMAStateAssembler每个step都会看看zcc落盘完成了没，然后通信一次
5. 这里的通信等待会导致耗时，在线上大集群约0.6-1.2s

【pr所做修改】：
1. 在普通的save step中，signal就不要由EMAStateAssembler来写了，还给zcc来写
2. hf_step才开启EMAStateAssembler，EMAStateAssembler查看ckpt是否落盘，当落盘后就开始写ema hf_ckpt，写完后就关闭，直到下次hf_step在开启。具体来说
a. 增加了`_begin_EMAHFProcess` 和`_close_EMAHFProcess` 两个函数，在hf_step开启EMAStateAssembler，写完ema hf_ckpt后关闭EMAStateAssembler

【运行结果】：hf_step=20 save_step=20
1. 在普通的step，EMAStateAssembler不做任何操作
```
Random set seed :35, data_step:70
[INFO] 2026-09-07 10:10:13,264 [trainer_callback.py: 1184]:    [EMAStateAssembler] Assembling EMA state took 0.000 seconds.
Random set seed :36, data_step:72
[INFO] 2026-09-07 10:10:15,708 [trainer_callback.py: 1184]:    [EMAStateAssembler] Assembling EMA state took 0.000 seconds.
Random set seed :37, data_step:74
[INFO] 2026-09-07 10:10:18,144 [trainer_callback.py: 1184]:    [EMAStateAssembler] Assembling EMA state took 0.000 seconds.
Random set seed :38, data_step:76
[INFO] 2026-09-07 10:10:20,617 [trainer_callback.py: 1184]:    [EMAStateAssembler] Assembling EMA state took 0.000 seconds.
```
2. 在 hf_step时，开始查看
```
Random set seed :39, data_step:78
[INFO] 2026-09-07 10:10:23,086 [trainer_utils.py: 1992]:    [EMAStateAssembler][Rank 0] No unprocessed checkpoint found in output/dsv4_flash in current training step. Latest processed checkpoint step is 20. Skipping.
[INFO] 2026-09-07 10:10:23,087 [trainer_callback.py: 1184]:    [EMAStateAssembler] Assembling EMA state took 0.002 seconds.
Random set seed :40, data_step:80
[INFO] 2026-09-07 10:10:44,373 [trainer_utils.py: 2132]:    [EMAStateAssembler] [Rank 0] Waiting for other ranks to finish saving checkpoint at step 40.
[INFO] 2026-09-07 10:10:44,378 [trainer_callback.py: 1184]:    [EMAStateAssembler] Assembling EMA state took 0.008 seconds.
Random set seed :41, data_step:82
[INFO] 2026-09-07 10:10:47,067 [trainer_utils.py: 2132]:    [EMAStateAssembler] [Rank 0] Waiting for other ranks to finish saving checkpoint at step 40.
[INFO] 2026-09-07 10:10:47,067 [trainer_callback.py: 1184]:    [EMAStateAssembler] Assembling EMA state took 0.008 seconds.
Random set seed :42, data_step:84
[INFO] 2026-09-07 10:10:49,594 [trainer_utils.py: 2132]:    [EMAStateAssembler] [Rank 0] Waiting for other ranks to finish saving checkpoint at step 40.
[INFO] 2026-09-07 10:10:49,594 [trainer_callback.py: 1184]:    [EMAStateAssembler] Assembling EMA state took 0.007 seconds.
Random set seed :43, data_step:86
[INFO] 2026-09-07 10:10:52,135 [trainer_utils.py: 2132]:    [EMAStateAssembler] [Rank 0] Waiting for other ranks to finish saving checkpoint at step 40.
[INFO] 2026-09-07 10:10:52,135 [trainer_callback.py: 1184]:    [EMAStateAssembler] Assembling EMA state took 0.029 seconds.
Random set seed :44, data_step:88
[INFO] 2026-09-07 10:10:54,775 [trainer_utils.py: 2132]:    [EMAStateAssembler] [Rank 0] Waiting for other ranks to finish saving checkpoint at step 40.
[INFO] 2026-09-07 10:10:54,775 [trainer_callback.py: 1184]:    [EMAStateAssembler] Assembling EMA state took 0.005 seconds.
[INFO] 2026-09-07 10:11:08,879 [zero_cost_checkpoint.py: 1305]:    [ZCC Worker0] Dumping to persistent device done: ./output/dsv4_flash/checkpoint-40
Random set seed :45, data_step:90
[INFO] 2026-09-07 10:11:12,561 [trainer_utils.py: 2115]:    [EMAStateAssembler] [Rank 0] All ranks ready. Proceeding with EMA state assembly for step 40.
[INFO] 2026-09-07 10:11:12,561 [trainer_utils.py: 2162]:    [EMAStateAssembler] [Rank 0] Loading EMA state from output/dsv4_flash/checkpoint-40/ema_state/0_0.distcp.
[INFO] 2026-09-07 10:11:53,516 [trainer_utils.py: 2039]:    [EMAStateAssembler] [Rank 0] Update the expected next save ckpt step to 60!
[INFO] 2026-09-07 10:11:53,518 [trainer_utils.py: 2319]:    [EMAStateAssembler] [Rank 0] Saving full EMA states to output/dsv4_flash/ema_hf_checkpoint-40.
[INFO] 2026-09-07 10:12:11,053 [trainer_utils.py: 2129]:    [EMAStateAssembler] [Rank 0] Finished merging EMA states and updated signal.
[INFO] 2026-09-07 10:12:11,053 [trainer_callback.py: 1184]:    [EMAStateAssembler] Assembling EMA state took 58.505 seconds.
```
3. 结束落盘后恢复到关闭状态
```
Random set seed :46, data_step:92
[INFO] 2026-09-07 10:12:14,298 [trainer_callback.py: 1184]:    [EMAStateAssembler] Assembling EMA state took 0.000 seconds.
Random set seed :47, data_step:94
[INFO] 2026-09-07 10:12:16,816 [trainer_callback.py: 1184]:    [EMAStateAssembler] Assembling EMA state took 0.000 seconds.
Random set seed :48, data_step:96
[INFO] 2026-09-07 10:12:19,354 [trainer_callback.py: 1184]:    [EMAStateAssembler] Assembling EMA state took 0.000 seconds.
```