### PR TITLE
[Deps] Update PaddleFleet to 6d69f843df9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,7 @@ try:
         install_requires=REQUIRED_PACKAGES,
         entry_points={"console_scripts": get_console_scripts()},
         extras_require={
-            "paddlefleet": ["paddlefleet==0.4.0.post20260903+f75a5c50908"],
+            "paddlefleet": ["paddlefleet==0.4.0.post20260905+6d69f843df9"],
         },
         python_requires=">=3.8",
         classifiers=[


### PR DESCRIPTION
### PR types

Others

### PR changes

Others

### Description

Update the optional PaddleFleet dependency from `paddlefleet==0.4.0.post20260903+f75a5c50908` to `paddlefleet==0.4.0.post20260905+6d69f843df9`.

The target package corresponds to PaddleFleet commit [`6d69f843df993bde2abf5fff5595c20a7aeea084`](https://github.com/PaddlePaddle/PaddleFleet/commit/6d69f843df993bde2abf5fff5595c20a7aeea084).

### Validation

- Confirmed the target SHA is a valid PaddleFleet commit.
- `python3 -m py_compile setup.py`
- AST-validated the exact `paddlefleet` requirement.
- `git diff --check`
- Confirmed this branch contains only the dependency pin change in `setup.py` and is based directly on `develop`.
