### PR TITLE
[release/1.3] Muon 2D: replicate on save, device gather on resume

### DIFF
--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -197,6 +197,7 @@ from .trainer_utils import (  # set_hyrbid_parallel_seed,
     _get_muon_2d_param_names,
     _insert_sync,
     _is_muon_sharding_optimizer,
+    _restore_master_weights_2d_on_device,
     _restore_master_weights_single,
     _unwrap_muon_sharding_optimizer,
     download_recovery_ckpt_from_pdc,
@@ -369,6 +370,7 @@ class Trainer:
         reshard_util.set_broadcast_max_chunk_bytes(
             int(getattr(self.args, "reshard_bucketed_broadcast_max_chunk_gb", 2.0) * (1024**3))
         )
+        reshard_util.set_device_gather(getattr(self.args, "reshard_master_weight_device_gather", False))
         self.is_in_train = False
         # self.do_grad_scaling = args.fp16
 
@@ -1466,32 +1468,47 @@ class Trainer:
                 model_state_dict = self.model.state_dict()
                 for key, param in model_state_dict.items():
                     if param.name in master_weights and param.dtype == paddle.bfloat16:
+                        value = master_weights[param.name]
                         logger.debug(
                             f"key {key}, convert master weights {param.name} "
-                            f"shape {master_weights[param.name].shape} to param "
+                            f"shape {value.shape} to param "
                             f"{param.name} shape{param.shape}"
                         )
-                        assert (
-                            param.shape == master_weights[param.name].shape
-                        ), f"got {param.shape} vs {master_weights[param.name].shape}"
-                        master_weight = paddle.reshape(master_weights[param.name], param.shape)
+                        assert param.shape == value.shape, f"got {param.shape} vs {value.shape}"
+                        if isinstance(value, reshard_util.AssignedMasterWeight):
+                            # Already written straight into this parameter by the
+                            # device gather, while the buffer was still on device.
+                            # Keep walking the loop anyway so this stays the single
+                            # place that checks every parameter got a master weight
+                            # of the right shape.
+                            continue
+                        master_weight = paddle.reshape(value, param.shape)
                         paddle.assign(paddle.cast(to_device(master_weight), paddle.bfloat16), model_state_dict[key])
 
             def recover_params_from_master_weight(opt_state_dict, group):
                 master_weights = opt_state_dict.get("master_weights", {})
                 tmp = OrderedDict()
                 master_weights, tmp = (tmp, master_weights)
-                # cast to bf16 and move to cpu
+
+                muon_opt = _unwrap_muon_sharding_optimizer(self.optimizer)
+                param_2d_names = _get_muon_2d_param_names(muon_opt) if muon_opt is not None else set()
+
+                # Cast to bf16. 2D Muon parameters stay on device: each is owned
+                # whole by one rank, so nothing has to be reassembled on host and
+                # _restore_master_weights_2d_on_device can gather them in place.
+                # 1D parameters go through ShardingV2's redistribute-and-
+                # concatenate, which is host-resident, so they move to host here.
                 for k, v in tmp.items():
                     name = v.name
-                    master_weights[k] = paddle.cast(to_device(v), paddle.bfloat16).cpu()
+                    if k in param_2d_names and reshard_util.use_device_gather():
+                        master_weights[k] = paddle.cast(to_device(v), paddle.bfloat16)
+                    else:
+                        master_weights[k] = paddle.cast(to_device(v), paddle.bfloat16).cpu()
                     master_weights[k].name = name
 
                 structure_name_map = {k: v.name for (k, v) in self.model.state_dict().items()}
 
-                muon_opt = _unwrap_muon_sharding_optimizer(self.optimizer)
                 if muon_opt is not None:
-                    param_2d_names = _get_muon_2d_param_names(muon_opt)
                     logger.debug(f"Muon recovery: {len(param_2d_names)} 2D params detected")
 
                     mw_2d = OrderedDict()
@@ -1503,14 +1520,23 @@ class Trainer:
                             mw_1d[k] = v
 
                     all_master_weights = OrderedDict()
-                    restored_2d = _restore_master_weights_single(
-                        mw_2d,
-                        self.model,
-                        self.optimizer,
-                        group,
-                        structure_name_map,
-                        reshard_util.sharding_v1.restore,
-                    )
+                    # Destinations for the device gather to write into, so the
+                    # gathered 2D union never needs host storage. Passed as an
+                    # argument rather than module state: a leaked sink would make a
+                    # later reshard write into parameters from this load.
+                    device_param_sink = {
+                        p.name: p for p in self.model.state_dict().values() if p.dtype == paddle.bfloat16
+                    }
+                    restored_2d = _restore_master_weights_2d_on_device(mw_2d, group, device_param_sink)
+                    if restored_2d is None:  # reshard_master_weight_device_gather=False
+                        restored_2d = _restore_master_weights_single(
+                            mw_2d,
+                            self.model,
+                            self.optimizer,
+                            group,
+                            structure_name_map,
+                            reshard_util.sharding_v1.restore,
+                        )
                     all_master_weights.update(restored_2d)
 
                     restored_1d = _restore_master_weights_single(

--- a/paddleformers/trainer/trainer_utils.py
+++ b/paddleformers/trainer/trainer_utils.py
@@ -1823,6 +1823,30 @@ def _get_muon_2d_param_names(muon_opt):
     return names
 
 
+def _restore_master_weights_2d_on_device(master_weights, group, param_sink):
+    """Restore 2D Muon master weights without ever touching host memory.
+
+    ``sharding_v1.restore`` only calls ``drop_rank()``, and the NodeModelState
+    round trip around it (pack_keys -> merge_from -> drop_rank -> unpack_keys)
+    maps a parameter name back to itself. The one thing it really does is force
+    every value to host via the ``.cpu()`` calls in pack_keys, which is exactly
+    what we are trying to avoid here, so bypass the container and gather
+    directly.
+
+    Only 2D parameters qualify: each is owned whole by one rank, so a bucket
+    slice is a complete parameter and can be written straight into its bf16
+    parameter. 1D parameters are element-wise slices that ShardingV2 has to
+    redistribute and concatenate first, and that machinery is host-resident, so
+    they stay on the original path.
+
+    Returns None when the switch is off, so the caller falls back to the host
+    path without duplicating the decision.
+    """
+    if not reshard_util.use_device_gather():
+        return None
+    return reshard_util.all_gather_on_device(master_weights, group, param_sink=param_sink)
+
+
 def _restore_master_weights_single(master_weights, model, optimizer, group, structure_name_map, restore_func):
     nms = reshard_util.NodeModelState(group=group)
     nms_tmp = reshard_util.NodeModelState(group=group)

--- a/paddleformers/trainer/training_args.py
+++ b/paddleformers/trainer/training_args.py
@@ -769,6 +769,22 @@ class TrainingArguments:
         },
     )
 
+    reshard_master_weight_device_gather: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "When rebuilding bf16 parameters from fp32 master weights on checkpoint resume, gather the "
+                "2D (whole-parameter-per-rank) Muon master weights entirely in device memory and write them "
+                "straight into their bf16 parameters, instead of staging every byte through host memory. "
+                "Only the 2D branch qualifies: each 2D parameter is owned whole by one rank, so a broadcast "
+                "bucket slice is already a complete parameter. 1D master weights are element-wise slices "
+                "that ShardingV2 must redistribute and concatenate on host first, so they keep the host "
+                "path regardless of this flag. Costs a little device memory (this rank's own contribution "
+                "stays resident until it is packed). Default False (host path)."
+            )
+        },
+    )
+
     tensor_model_parallel_size: int = field(
         default=-1,
         metadata={

--- a/paddleformers/trainer/utils/reshard/__init__.py
+++ b/paddleformers/trainer/utils/reshard/__init__.py
@@ -16,7 +16,9 @@ from . import pp_reshard, sharding_v1, sharding_v2
 from .common import (
     SHARDING_STRATEGY_V1,
     SHARDING_STRATEGY_V2,
+    AssignedMasterWeight,
     NodeModelState,
+    all_gather_on_device,
     all_gather_state_dict,
     convert_opt_name_to_tname,
     get_moe_sharding_group,
@@ -27,7 +29,9 @@ from .common import (
     merge_opt_state,
     set_broadcast_max_chunk_bytes,
     set_bucketed_broadcast,
+    set_device_gather,
     split_model_state,
     split_opt_state,
     split_structure_name_mapping,
+    use_device_gather,
 )

--- a/paddleformers/trainer/utils/reshard/common.py
+++ b/paddleformers/trainer/utils/reshard/common.py
@@ -841,6 +841,197 @@ def set_broadcast_max_chunk_bytes(nbytes):
     _broadcast_max_chunk_bytes = max(nbytes, _STATE_DICT_BROADCAST_BUCKET_SIZE_BYTES)
 
 
+class AssignedMasterWeight:
+    """Marker put into the gathered dict in place of a host copy.
+
+    It means "this master weight was already written into its bf16 model
+    parameter while the gather buffer was still resident on device, so there is
+    nothing left to copy". Only metadata is carried so the caller can keep
+    running its shape / coverage checks over the returned dict unchanged.
+    """
+
+    __slots__ = ("shape", "dtype")
+
+    def __init__(self, shape, dtype):
+        self.shape = list(shape)
+        self.dtype = dtype
+
+    def __repr__(self):
+        return f"AssignedMasterWeight(shape={self.shape}, dtype={self.dtype})"
+
+
+# ---------------------------------------------------------------------------
+# Device-resident all-gather, used only by the master-weight -> bf16 parameter
+# restore path.
+#
+# The bucketed host path below moves every byte across PCIe four times: the
+# caller casts to bf16 and copies to host, pack stages the bucket on host and
+# uploads it, unpack downloads the broadcast result, and the caller uploads it
+# again to write the parameter. Only the middle step (the broadcast) needs the
+# data on device, and the two ends (fp32 master weight, bf16 parameter) are
+# already on device -- so the host is a detour, not a destination.
+#
+# This function keeps sources, buckets and destinations in device memory:
+#
+#   source (device)  -> bucket (device, D2D) -> NCCL -> bucket -> parameter (D2D)
+#
+# What it does NOT change: the broadcast itself, the deterministic global
+# ordering, and the chunk budget that bounds how much is resident at once.
+#
+# Two deliberate differences from the host path:
+#
+# * Buckets are cut at the chunk budget instead of 128 MiB. The 128 MiB limit
+#   existed to amortise one host-to-device upload per bucket; with no upload
+#   left, a smaller bucket only buys more NCCL operations.
+#
+# * The result is written straight into the destination parameter, so the
+#   gathered union never needs storage of its own. Keys without a matching
+#   parameter fall back to a device tensor of their own.
+#
+# Cost: this rank's own contribution stays resident until it is packed, which
+# the host path did not pay for. Bounded by what this rank owns.
+# ---------------------------------------------------------------------------
+
+
+# Driven by TrainingArguments.reshard_master_weight_device_gather, applied via
+# set_device_gather() in Trainer.__init__ -- same wiring as
+# set_broadcast_max_chunk_bytes() above, so the flag does not have to be
+# threaded through the restore call chain. Default False keeps the host path.
+_USE_DEVICE_GATHER = False
+
+
+def set_device_gather(enabled):
+    global _USE_DEVICE_GATHER
+    _USE_DEVICE_GATHER = bool(enabled)
+
+
+def use_device_gather():
+    return _USE_DEVICE_GATHER
+
+
+def _device_destination(key, shape, dtype, param_sink):
+    """The parameter this gathered tensor belongs in, or None.
+
+    Name, shape and dtype must all agree; anything else is treated as "no
+    destination" so a mismatch degrades into an extra tensor rather than a
+    silently corrupted parameter.
+    """
+    param = param_sink.get(key)
+    if param is None:
+        return None
+    if str(param.dtype).split(".")[-1] != dtype:
+        return None
+    if list(param.shape) != list(shape):
+        return None
+    return param
+
+
+def _fill_bucket_from_device(bucket, state_dict):
+    """Concatenate this rank's tensors into one contiguous device buffer."""
+    tensor = paddle.empty([bucket["numel"]], dtype=bucket["dtype"])
+    for k, _shape, begin, end in bucket["items"]:
+        source = state_dict.pop(k)
+        # __setitem__ maps to set_value, which writes through to tensor's
+        # storage. paddle.assign(src, tensor[begin:end]) would assign into a
+        # temporary view instead and silently drop the write.
+        tensor[begin:end] = source.reshape([-1])
+        del source
+    return tensor
+
+
+def _scatter_bucket_on_device(bucket, tensor, destinations, gathered):
+    """Move each tensor out of the broadcast buffer to where it belongs."""
+    for k, shape, begin, end in bucket["items"]:
+        piece = tensor[begin:end].reshape(shape)
+        destination = destinations.get(k)
+        if destination is None:
+            # No parameter to land in, and the bucket is freed at the end of
+            # this chunk, so this needs storage of its own.
+            gathered[k] = piece.clone()
+        else:
+            paddle.assign(piece, destination)
+            gathered[k] = AssignedMasterWeight(shape, bucket["dtype"])
+
+
+def all_gather_on_device(state_dict, group, param_sink=None, max_chunk_bytes=None):
+    """All-gather that never touches host memory.
+
+    Same contract as ``all_gather_state_dict(state_dict, lambda k: True,
+    group)``: every rank contributes the entries it owns, every rank receives
+    the union, and ``state_dict`` is consumed on the way. Entries whose name,
+    shape and dtype match a parameter in ``param_sink`` are written into that
+    parameter and represented in the result by an AssignedMasterWeight marker,
+    so the gathered union needs no host storage at all. Entries with no match
+    get a device tensor of their own.
+
+    All values must already be device tensors; passing host tensors is a bug in
+    the caller rather than something to paper over, so it asserts.
+    """
+    group_rank = max(group.rank, 0)
+    param_sink = param_sink if param_sink else {}
+    if max_chunk_bytes is None:
+        max_chunk_bytes = _broadcast_max_chunk_bytes
+
+    # 1. Describe what this rank owns. Unlike the host path this does not touch
+    #    the data, so nothing is copied and nothing is freed here.
+    local_meta = {}
+    for k, v in state_dict.items():
+        assert isinstance(v, paddle.Tensor), f"{k}: expected a Tensor, got {type(v)}"
+        assert not v.place.is_cpu_place(), f"{k}: on host, all_gather_on_device expects device tensors"
+        local_meta[k] = (str(v.dtype).split(".")[-1], list(v.shape), group_rank)
+
+    # 2. Exchange descriptions -- Python objects, not tensor payloads -- and
+    #    agree on one global order. Every rank must build the same buckets in
+    #    the same sequence or the broadcasts would not line up.
+    total_meta = {}
+    for part in all_gather_simple_object(local_meta, group):
+        for k, meta in part.items():
+            assert k not in total_meta, f"{k} is owned by more than one rank"
+            total_meta[k] = meta
+    meta_list = sorted(total_meta.items(), key=lambda kv: (kv[1][2], kv[0]))
+
+    # 3. Resolve destinations up front so packing and scattering agree.
+    destinations = {}
+    for k, (dtype, shape, _rank) in meta_list:
+        destination = _device_destination(k, shape, dtype, param_sink)
+        if destination is not None:
+            destinations[k] = destination
+
+    gathered = {}
+    buckets, empty_items = _build_state_dict_broadcast_buckets(meta_list, max_chunk_bytes)
+    for k, (dtype, shape, rank) in empty_items:
+        if rank == group_rank:
+            assert k in state_dict
+            del state_dict[k]
+        gathered[k] = paddle.empty(shape, dtype=dtype)
+
+    for chunk in _iter_state_dict_bucket_chunks(buckets, _STATE_DICT_BROADCAST_CHUNK_SIZE, max_chunk_bytes):
+        gpu_buckets = []
+        for bucket in chunk:
+            if bucket["rank"] == group_rank:
+                tensor = _fill_bucket_from_device(bucket, state_dict)
+            else:
+                tensor = paddle.empty([bucket["numel"]], dtype=bucket["dtype"])
+            gpu_buckets.append((bucket, tensor))
+
+        _broadcast_state_dict_chunk(gpu_buckets, group)
+
+        # The broadcast was enqueued on the calc stream with
+        # use_calc_stream=True, so these copies are already ordered after it.
+        for bucket, tensor in gpu_buckets:
+            _scatter_bucket_on_device(bucket, tensor, destinations, gathered)
+        # Release before packing the next chunk, otherwise both chunks would be
+        # resident and max_chunk_bytes would stop bounding anything. The scatter
+        # only enqueues, so wait for it before the buffers are dropped -- without
+        # this the host would run ahead allocating buckets for later chunks
+        # while earlier ones are still in flight.
+        del gpu_buckets
+        paddle.device.synchronize()
+
+    assert not state_dict, f"{len(state_dict)} source tensors were never packed"
+    return OrderedDict((k, gathered[k]) for k, _ in meta_list)
+
+
 def all_gather_state_dict(state_dict, filter_func, group):
     if _USE_BUCKETED_BROADCAST:
         return _all_gather_state_dict_bucketed(state_dict, filter_func, group)

--- a/paddleformers/trainer/utils/zero_cost_checkpoint.py
+++ b/paddleformers/trainer/utils/zero_cost_checkpoint.py
@@ -2383,7 +2383,25 @@ class ZeroCostCheckpointCallbackFcBased(ZeroCostCheckpointCallback):
             if static_name in local_2d_names:
                 filtered[k] = sw
             elif static_name in all_2d_names:
-                continue
+                # A 2D parameter owned by another rank is bit-identical on this rank --
+                # _broadcast_2d_params() broadcasts them after every optimizer step -- so
+                # keep it as a local replica when replicate_saved_into_local is on.
+                # Without it these keys are single-replica in the metadata, and
+                # check_resumable_locally is a global AND, so one such key drags the whole
+                # model_state off the local fast path and forces a reshard on resume.
+                #
+                # This stays cheap only because the master-weight deletion below removes
+                # every bf16 trainable 2D parameter again; the fp32 ones (no master weight)
+                # are the only ones that reach the file. Do not move or relax that loop.
+                #
+                # Correctness note: replicas are only safe because these params are staged
+                # into MuonPerParamStagingBuffer with real element offsets. Before that,
+                # each was CUDA-IPC-shared on its own and _share_tensor_ipc_meta() reported
+                # offset 0 for all of them, so every param sharing a device allocation was
+                # dumped with the content of whichever one sat at the allocation base.
+                if not self.args.replicate_saved_into_local:
+                    continue
+                filtered[k] = sw
             elif static_name in all_1d_names:
                 filtered[k] = sw
             else:

--- a/tests/trainer/test_all_gather_on_device.py
+++ b/tests/trainer/test_all_gather_on_device.py
@@ -1,0 +1,237 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for all_gather_on_device and the switch that selects it.
+
+Every collective in reshard/common.py short-circuits at ``nranks < 2``, so bucketing,
+packing, the writeback and the fallbacks can all be exercised in one process against a
+single-rank stub group.
+
+What is pinned down:
+  1. Bit-exact agreement with the bucketed host path it replaces.
+  2. No host tensor is produced or consumed -- host input is rejected, and results are
+     either markers (written into the parameter) or device tensors.
+  3. Values survive the bucket being freed, i.e. the writes really copy.
+  4. A key with no matching parameter, or a mismatched shape/dtype, gets its own device
+     tensor instead of corrupting a parameter.
+  5. The branch is selected by TrainingArguments, and returns None when off so the
+     caller falls back to the host path.
+
+Multi-rank equivalence (the broadcast actually lining up across ranks) is not covered
+here; it needs a distributed harness.
+"""
+
+import unittest
+
+import numpy as np
+import paddle
+
+from paddleformers.trainer.trainer_utils import _restore_master_weights_2d_on_device
+from paddleformers.trainer.training_args import TrainingArguments
+from paddleformers.trainer.utils.reshard import common as reshard_common
+from paddleformers.trainer.utils.reshard.common import (
+    AssignedMasterWeight,
+    all_gather_on_device,
+    all_gather_state_dict,
+    set_bucketed_broadcast,
+    set_device_gather,
+)
+
+
+class _SingleRankGroup:
+    nranks = 1
+    rank = 0
+    id = 0
+    ranks = [0]
+
+
+SHAPES = {
+    "p_a": [8, 16],
+    "p_b": [4, 32],
+    "p_c": [16, 8],
+    "p_vec": [64],
+    "p_big": [64, 64],
+}
+
+
+def _rand_bf16(shape, seed):
+    rng = np.random.RandomState(seed)
+    host = paddle.to_tensor(rng.uniform(-1, 1, shape).astype("float32"))
+    return paddle.cast(host, paddle.bfloat16)
+
+
+def _f32(tensor):
+    return paddle.cast(tensor, paddle.float32).numpy()
+
+
+class TestAllGatherOnDevice(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not paddle.is_compiled_with_cuda() or paddle.device.cuda.device_count() == 0:
+            raise unittest.SkipTest("all_gather_on_device is a device-only path")
+        paddle.set_device("gpu:0")
+
+    def setUp(self):
+        self.group = _SingleRankGroup()
+        self._old_bucket = reshard_common._STATE_DICT_BROADCAST_BUCKET_SIZE_BYTES
+        self._old_bucketed = reshard_common._USE_BUCKETED_BROADCAST
+        # small budget so the fixtures really produce several buckets and chunks
+        self.chunk = 4 * 1024
+
+    def tearDown(self):
+        reshard_common._STATE_DICT_BROADCAST_BUCKET_SIZE_BYTES = self._old_bucket
+        set_bucketed_broadcast(self._old_bucketed)
+
+    def _sources(self):
+        return {name: _rand_bf16(shape, seed) for seed, (name, shape) in enumerate(SHAPES.items())}
+
+    def _sink(self):
+        return {name: paddle.full(shape, -7.0, dtype=paddle.bfloat16) for name, shape in SHAPES.items()}
+
+    def _host_reference(self):
+        """Ground truth from the untouched bucketed host path."""
+        set_bucketed_broadcast(True)
+        reshard_common._STATE_DICT_BROADCAST_BUCKET_SIZE_BYTES = self.chunk
+        reshard_common.set_broadcast_max_chunk_bytes(self.chunk * 2)
+        out = all_gather_state_dict({k: v.cpu() for k, v in self._sources().items()}, lambda x: True, self.group)
+        return {k: _f32(v) for k, v in out.items()}
+
+    def test_matches_the_host_path_bitwise(self):
+        reference = self._host_reference()
+        sink = self._sink()
+        out = all_gather_on_device(dict(self._sources()), self.group, sink, max_chunk_bytes=self.chunk)
+
+        self.assertEqual(set(out.keys()), set(reference.keys()))
+        for name, shape in SHAPES.items():
+            self.assertIsInstance(out[name], AssignedMasterWeight, f"{name} did not land in its parameter")
+            self.assertEqual(out[name].shape, shape)
+            np.testing.assert_array_equal(_f32(sink[name]), reference[name], err_msg=name)
+
+    def test_no_parameter_is_left_unwritten(self):
+        sink = self._sink()
+        all_gather_on_device(dict(self._sources()), self.group, sink, max_chunk_bytes=self.chunk)
+        for name, param in sink.items():
+            self.assertFalse(bool(paddle.any(paddle.cast(param, paddle.float32) == -7.0)), name)
+
+    def test_values_survive_the_bucket_being_freed(self):
+        sink = self._sink()
+        all_gather_on_device(dict(self._sources()), self.group, sink, max_chunk_bytes=self.chunk)
+        snapshot = {name: _f32(p) for name, p in sink.items()}
+        for _ in range(8):  # churn the allocator so freed buckets get reused
+            scratch = paddle.full([1024 * 64], 1234.5, dtype=paddle.float32)
+            del scratch
+        for name, param in sink.items():
+            np.testing.assert_array_equal(_f32(param), snapshot[name], err_msg=name)
+
+    def test_everything_returned_is_on_device(self):
+        sink = self._sink()
+        sink.pop("p_b")  # force one key onto the standalone path
+        out = all_gather_on_device(dict(self._sources()), self.group, sink, max_chunk_bytes=self.chunk)
+        self.assertNotIsInstance(out["p_b"], AssignedMasterWeight)
+        self.assertFalse(out["p_b"].place.is_cpu_place(), "the fallback tensor must stay on device")
+
+    def test_source_consumed(self):
+        sources = dict(self._sources())
+        all_gather_on_device(sources, self.group, self._sink(), max_chunk_bytes=self.chunk)
+        self.assertEqual(len(sources), 0, "sources must be released as they are packed")
+
+    def test_host_input_is_rejected(self):
+        sources = {k: v.cpu() for k, v in self._sources().items()}
+        with self.assertRaises(AssertionError):
+            all_gather_on_device(sources, self.group, self._sink(), max_chunk_bytes=self.chunk)
+
+    def test_unknown_name_gets_its_own_tensor(self):
+        reference = self._host_reference()
+        sink = self._sink()
+        sink.pop("p_vec")
+        out = all_gather_on_device(dict(self._sources()), self.group, sink, max_chunk_bytes=self.chunk)
+        np.testing.assert_array_equal(_f32(out["p_vec"]), reference["p_vec"])
+        self.assertIsInstance(out["p_a"], AssignedMasterWeight)
+
+    def test_shape_mismatch_does_not_touch_the_parameter(self):
+        reference = self._host_reference()
+        sink = self._sink()
+        sink["p_vec"] = paddle.full([32], -7.0, dtype=paddle.bfloat16)  # wrong length
+        out = all_gather_on_device(dict(self._sources()), self.group, sink, max_chunk_bytes=self.chunk)
+        self.assertNotIsInstance(out["p_vec"], AssignedMasterWeight)
+        np.testing.assert_array_equal(_f32(out["p_vec"]), reference["p_vec"])
+        self.assertTrue(bool(paddle.all(paddle.cast(sink["p_vec"], paddle.float32) == -7.0)))
+
+    def test_dtype_mismatch_does_not_touch_the_parameter(self):
+        reference = self._host_reference()
+        sink = self._sink()
+        sink["p_big"] = paddle.full(SHAPES["p_big"], -7.0, dtype=paddle.float32)
+        out = all_gather_on_device(dict(self._sources()), self.group, sink, max_chunk_bytes=self.chunk)
+        self.assertNotIsInstance(out["p_big"], AssignedMasterWeight)
+        np.testing.assert_array_equal(_f32(out["p_big"]), reference["p_big"])
+        self.assertTrue(bool(paddle.all(sink["p_big"] == -7.0)))
+
+    def test_empty_sink_returns_plain_device_tensors(self):
+        reference = self._host_reference()
+        out = all_gather_on_device(dict(self._sources()), self.group, None, max_chunk_bytes=self.chunk)
+        for name, value in out.items():
+            self.assertNotIsInstance(value, AssignedMasterWeight)
+            self.assertFalse(value.place.is_cpu_place())
+            np.testing.assert_array_equal(_f32(value), reference[name], err_msg=name)
+
+    def test_bigger_buckets_mean_fewer_broadcasts(self):
+        """With no host upload left to amortise, coarser buckets cost strictly less."""
+        meta = [(k, ("bfloat16", v, 0)) for k, v in SHAPES.items()]
+        few, _ = reshard_common._build_state_dict_broadcast_buckets(meta, 1024 * 1024)
+        many, _ = reshard_common._build_state_dict_broadcast_buckets(meta, 1024)
+        self.assertLess(len(few), len(many))
+        self.assertEqual(len(few), 1, "one owner and one dtype should collapse into one bucket")
+
+
+class TestDeviceGatherSwitch(unittest.TestCase):
+    """The 2D branch is selected by config, and declines cleanly when off.
+
+    Device-free on purpose: this is about the wiring from TrainingArguments down to
+    _restore_master_weights_2d_on_device, which returns None whenever the switch is off
+    so the caller can fall back to the host path without duplicating the decision.
+    """
+
+    def setUp(self):
+        self._old = reshard_common._USE_DEVICE_GATHER
+
+    def tearDown(self):
+        set_device_gather(self._old)
+
+    def test_defaults_to_the_host_path(self):
+        self.assertFalse(TrainingArguments.reshard_master_weight_device_gather)
+
+    def test_setter_drives_the_switch(self):
+        set_device_gather(True)
+        self.assertTrue(reshard_common.use_device_gather())
+        set_device_gather(False)
+        self.assertFalse(reshard_common.use_device_gather())
+
+    def test_off_makes_the_2d_restore_decline(self):
+        set_device_gather(False)
+        self.assertIsNone(_restore_master_weights_2d_on_device({}, _SingleRankGroup(), {}))
+
+    def test_independent_of_the_bucketed_broadcast_switch(self):
+        """all_gather_on_device does not go through the all_gather_state_dict dispatcher."""
+        old = reshard_common._USE_BUCKETED_BROADCAST
+        try:
+            set_device_gather(True)
+            for bucketed in (False, True):
+                set_bucketed_broadcast(bucketed)
+                self.assertTrue(reshard_common.use_device_gather())
+        finally:
+            set_bucketed_broadcast(old)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/trainer/test_muon_manipulate_sharded_state_dict.py
+++ b/tests/trainer/test_muon_manipulate_sharded_state_dict.py
@@ -1,0 +1,199 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ZeroCostCheckpointCallbackFcBased._muon_manipulate_sharded_state_dict.
+
+Single-process, no GPU, no distributed init: the method is called unbound with light
+fakes standing in for model / MuonShardingOptimizer / TrainingArguments. It only ever
+reads ``sw.local_tensor.name``, so the fakes can stay this thin.
+
+What is pinned down here:
+  1. replicate_saved_into_local=False reproduces the pre-change behaviour byte for byte
+     (2D params owned by another rank are dropped).
+  2. replicate_saved_into_local=True keeps them, but the master-weight deletion loop
+     still removes every bf16 trainable 2D param, so the only thing that actually
+     reaches the file is the natively-fp32 2D params (mHC mapping_proj etc.).
+  3. No bf16 2D param survives on any rank. This is what bounds the extra write
+     volume; a regression here would mean writing the full bf16 2D set per rank.
+  4. With the switch on, the saved fp32 2D set no longer depends on Muon's greedy
+     ownership, which is what turns one candidate replica into N.
+"""
+
+import unittest
+from collections import OrderedDict
+
+import paddle
+
+from paddleformers.trainer.utils.zero_cost_checkpoint import (
+    ZeroCostCheckpointCallbackFcBased,
+)
+
+_MANIPULATE = ZeroCostCheckpointCallbackFcBased._muon_manipulate_sharded_state_dict
+
+
+class _FakeTensor:
+    def __init__(self, name, dtype):
+        self.name = name
+        self.dtype = dtype
+
+
+class _FakeShardedWeight:
+    def __init__(self, name, dtype):
+        self.local_tensor = _FakeTensor(name, dtype)
+
+
+class _FakeModel:
+    """Returns sharded_state_dict() keyed by structure name, unsorted on purpose."""
+
+    def __init__(self, entries):
+        self._entries = entries
+
+    def sharded_state_dict(self):
+        return {f"struct.{name}": _FakeShardedWeight(name, dtype) for name, dtype in self._entries}
+
+
+class _FakeGroup:
+    def __init__(self, nranks):
+        self.nranks = nranks
+
+
+class _FakeHcg:
+    def __init__(self, nranks):
+        self._group = _FakeGroup(nranks)
+
+    def get_sharding_parallel_group(self):
+        return self._group
+
+
+class _FakeInnerOpt:
+    def __init__(self, master_weight_names, multi_precision=True):
+        self._multi_precision = multi_precision
+        self._master_weights = {name: object() for name in master_weight_names}
+
+
+class _FakeOptimizer:
+    def __init__(self, local_2d, all_2d, all_1d, master_weight_names, sharding_rank=0, nranks=1):
+        self._sharding_rank = sharding_rank
+        self._local_2d = [_FakeTensor(n, paddle.bfloat16) for n in local_2d]
+        self._params_2d_by_color = {0: [_FakeTensor(n, paddle.bfloat16) for n in all_2d]}
+        self._params_1d = [_FakeTensor(n, paddle.bfloat16) for n in all_1d]
+        self._inner_opt = _FakeInnerOpt(master_weight_names)
+        self._hcg = _FakeHcg(nranks)
+
+
+class _FakeArgs:
+    def __init__(self, replicate_saved_into_local):
+        self.replicate_saved_into_local = replicate_saved_into_local
+
+
+class _FakeSelf:
+    def __init__(self, replicate_saved_into_local):
+        self.args = _FakeArgs(replicate_saved_into_local)
+
+
+class TestMuonManipulateShardedStateDict(unittest.TestCase):
+    """The scenario mirrors a large MoE Muon job in miniature."""
+
+    def setUp(self):
+        # owned_bf16 : 2D Muon param this rank owns, bf16 -> has a master weight
+        # other_bf16 : 2D Muon param another rank owns, bf16 -> has a master weight
+        # owned_fp32 : 2D Muon param this rank owns, natively fp32 -> no master weight
+        # other_fp32 : 2D Muon param another rank owns, natively fp32 -> no master weight
+        #              (this is the mapping_proj.weight / hc_head_fn class of params)
+        # oned_bf16  : 1D param, always saved
+        # buffer_fp32: neither 2D nor 1D -> falls to the final else-branch
+        self.entries = [
+            ("owned_bf16", paddle.bfloat16),
+            ("other_bf16", paddle.bfloat16),
+            ("owned_fp32", paddle.float32),
+            ("other_fp32", paddle.float32),
+            ("oned_bf16", paddle.bfloat16),
+            ("buffer_fp32", paddle.float32),
+        ]
+        self.local_2d = ["owned_bf16", "owned_fp32"]
+        self.all_2d = ["owned_bf16", "other_bf16", "owned_fp32", "other_fp32"]
+        self.all_1d = ["oned_bf16"]
+        # only the bf16 trainable params have an fp32 master weight
+        self.master_weight_names = ["owned_bf16", "other_bf16", "oned_bf16"]
+
+    def _run(self, replicate, sharding_rank=0, nranks=1):
+        model = _FakeModel(self.entries)
+        optimizer = _FakeOptimizer(
+            self.local_2d,
+            self.all_2d,
+            self.all_1d,
+            self.master_weight_names,
+            sharding_rank=sharding_rank,
+            nranks=nranks,
+        )
+        out = _MANIPULATE(_FakeSelf(replicate), model, optimizer)
+        self.assertIsInstance(out, OrderedDict)
+        return {sw.local_tensor.name for sw in out.values()}
+
+    def test_replicate_off_matches_legacy_behaviour(self):
+        """Switch off => 2D params owned elsewhere are dropped, as the old `continue` did."""
+        names = self._run(replicate=False, sharding_rank=0)
+        self.assertEqual(names, {"owned_fp32", "buffer_fp32"})
+        # owned_bf16 / oned_bf16 removed by the master-weight deletion loop
+        self.assertNotIn("owned_bf16", names)
+        self.assertNotIn("oned_bf16", names)
+        # the key that used to have a single replica across the whole job
+        self.assertNotIn("other_fp32", names)
+
+    def test_replicate_off_non_zero_sharding_rank(self):
+        """Non-rank-0 with the switch off must not pick up the else-branch buffer."""
+        names = self._run(replicate=False, sharding_rank=3)
+        self.assertEqual(names, {"owned_fp32"})
+
+    def test_replicate_on_adds_only_fp32_2d_params(self):
+        """Switch on => the previously single-replica fp32 2D param is saved locally too."""
+        names = self._run(replicate=True, sharding_rank=0)
+        self.assertEqual(names, {"owned_fp32", "other_fp32", "buffer_fp32"})
+
+    def test_replicate_on_still_drops_every_bf16_2d_param(self):
+        """Write-volume guard: no bf16 2D param may survive."""
+        names = self._run(replicate=True, sharding_rank=7)
+        for name, dtype in self.entries:
+            if dtype == paddle.bfloat16:
+                self.assertNotIn(name, names, f"{name} must not be saved")
+        self.assertEqual(names, {"owned_fp32", "other_fp32", "buffer_fp32"})
+
+    def test_replicate_on_delta_is_exactly_the_non_owned_fp32_2d_params(self):
+        """The point of the change, stated as a set difference."""
+        off = self._run(replicate=False, sharding_rank=5)
+        on = self._run(replicate=True, sharding_rank=5)
+        self.assertEqual(on - off, {"other_fp32", "buffer_fp32"})
+        self.assertEqual(off - on, set())
+
+    def test_every_rank_saves_the_same_fp32_2d_params(self):
+        """With the switch on, the fp32 2D set no longer depends on Muon's greedy ownership."""
+        per_rank = []
+        for rank in range(4):
+            # rotate ownership to emulate greedy bin-packing assigning owners differently
+            self.local_2d = [["owned_bf16", "owned_fp32"], ["other_bf16"], ["other_fp32"], []][rank]
+            per_rank.append({n for n in self._run(replicate=True, sharding_rank=rank) if "fp32" in n})
+        for names in per_rank:
+            self.assertEqual(names, {"owned_fp32", "other_fp32", "buffer_fp32"})
+
+    def test_multi_precision_off_keeps_everything(self):
+        """No master weights at all => deletion loop is skipped, nothing is removed."""
+        model = _FakeModel(self.entries)
+        optimizer = _FakeOptimizer(self.local_2d, self.all_2d, self.all_1d, [])
+        optimizer._inner_opt._multi_precision = False
+        names = {sw.local_tensor.name for sw in _MANIPULATE(_FakeSelf(True), model, optimizer).values()}
+        self.assertEqual(names, {n for n, _ in self.entries})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
#### Before submitting

- [x] Lint code. `black==22.8.0`、`isort==5.11.5`、`flake8` 对全部改动文件通过。
- [x] Add test cases into `tests` folder. 新增 `tests/trainer/test_muon_manipulate_sharded_state_dict.py`（7 例）和 `tests/trainer/test_all_gather_on_device.py`（15 例）。

### PR types

Performance optimization

### PR changes

APIs

### Description

两项相互独立的改动，都只作用于 Muon + flex_checkpoint 场景。
---

## 一、保存时保留非本卡持有的 2D 参数副本

**为什么改**

**`_muon_manipulate_sharded_state_dict()` 原先丢弃所有不由本卡持有 master weight 的 2D 参数，这些键在元数据里因此只有单一副本。** 而 `check_resumable_locally` 是全局与操作，只要存在一个单副本的键，整个 `model_state` 就被判定为不可本地恢复，**续训时被迫走reshard路径。**

这些参数在每张卡上逐位相同（`_broadcast_2d_params()` 在每个优化器步后都会广播），本来就可以作为本地副本保留。

**改了什么**

`replicate_saved_into_local` 打开时针对于master weight 的 2D 参数 不再丢弃，保留为本地副本。

**效果与代价**

`model_state` 可走本地恢复路径，续训不再因此触发重分片。

额外写盘只限**没有 master weight 的原生 fp32 2D 参数**（例如 mHC 的 `mapping_proj.weight 每个checkpoint增加1.04GB`）——其后的 master weight 删除循环仍会清除每一个带 master weight 的 bf16 2D 参数，增量占整个 checkpoint 的比例很小。


---

## 二、续训时在显存内重建 2D 参数的 bf16 值

新增reshard_master_weight_device_gather 开关，开启时可以在master weight 转bf16时进行reshard部分的pack
通信 unpack 全部在显存上进行。省去了 d2h h2d的copy，于此同时增大了每次broadcast的消息大小。 

**为什么改**

checkpoint 只保存 fp32 master weight，加载后需要重建 bf16 参数。现有实现让每个字节跨 PCIe 四次：转 bf16 后下主机、打包时上传、广播后下载、写回时再上传。第三次和第四次之间只有切片和 reshape，没有任何计算，是纯粹的往返；而这条路径的起点和终点本来都在显存。

对 2D 参数，中间的 `NodeModelState` 容器也是空转：`sharding_v1.restore` 只调用 `drop_rank()`，键从参数名换成三元组、贴上 rank 标签、再撕掉、再换回参数名，绕一圈回到原点，张量未被触碰。容器唯一的实际作用是 `pack_keys()` 里的 `.cpu()` 强制把数据搬到主机，恰恰是要避免的动作。

**改了什么**

新增 `all_gather_on_device()`，源、缓冲区、目标全部留在显存，结果直接写入目标参数，汇总结果不再需要独立存储。与 `all_gather_state_dict()` 契约一致，且不改变广播原语、全局确定性顺序和限制单次驻留量的分块预算。

两处有意为之的差异：分桶按分块预算切而不再按 128 MiB（128 MiB 的意义是摊薄每桶一次主机上传，上传消失后切细只增加 NCCL 操作数）；`_device_destination()` 要求参数名、形状、数据类型三者全部匹配，不符则退化为独立张量而非静默写坏参数，已写入的条目用 `AssignedMasterWeight` 标记表示，调用方得以照旧遍历每个参数并执行形状断言。

2D 分支通过新增开关 `reshard_master_weight_device_gather` 接入，默认关闭。

**1D 参数不受此开关影响。** 1D 的 master weight 是融合缓冲区按元素等分后的切片，没有任何一张卡持有完整参数，同一参数名会在多张卡上以不同形状存在；`sharding_v2.restore` 必须先跨卡重新分派、拼接、去掉补齐部分才能得到完整参数，在此之前不存在可写入模型参数的对象。这套机制主机驻留，无法照搬。

**效果与代价**

2D 分支的三次主机往返全部消除，重建阶段耗时显著下降，写回阶段不再为已就地写好的参数执行上传和类型转换。

代价是 2D 的 bf16 源数据在打包前驻留显存，规模等于本卡持有的 master weight 折算成 bf16 的大小；该阶段不是进程显存峰值所在（峰值在更早的优化器状态与模型权重加载阶段），实测进程峰值显存无变化。

续训后第一个优化器步的 loss 与关闭开关时逐位相同，多次运行可复现。


Merged in dev: #4987

