### PR TITLE
optimize hf_checkpoint_v2

### DIFF
--- a/paddleformers/trainer/trainer_utils.py
+++ b/paddleformers/trainer/trainer_utils.py
@@ -1776,7 +1776,7 @@ class HFFormatFullParamSaver:
             local_world_size = int(os.environ.get("PADDLE_LOCAL_SIZE", 8))
             self.num_saver_ranks = min(local_world_size, self.num_saver_ranks)
 
-    def save_checkpoint(self, path, max_shard_size="16GB"):
+    def save_checkpoint(self, path, max_shard_size="2GB"):
         total_saved_size = save_full_param(
             itr=self.get_full_param_iter(),
             save_dir=path,

--- a/paddleformers/trainer/trainer_utils.py
+++ b/paddleformers/trainer/trainer_utils.py
@@ -1776,7 +1776,7 @@ class HFFormatFullParamSaver:
             local_world_size = int(os.environ.get("PADDLE_LOCAL_SIZE", 8))
             self.num_saver_ranks = min(local_world_size, self.num_saver_ranks)
 
-    def save_checkpoint(self, path, max_shard_size="2GB"):
+    def save_checkpoint(self, path, max_shard_size="4GB"):
         total_saved_size = save_full_param(
             itr=self.get_full_param_iter(),
             save_dir=path,

--- a/paddleformers/transformers/model_utils.py
+++ b/paddleformers/transformers/model_utils.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import concurrent.futures
 import contextlib
 import copy
+import ctypes
 import gc
 import inspect
 import json
@@ -46,10 +47,15 @@ from huggingface_hub import (
 )
 from huggingface_hub.utils import EntryNotFoundError
 from paddle import Tensor
+from paddle.base import core
 from paddle.distributed.fleet.meta_parallel import LocalSharedLayerDesc
 from paddle.distributed.fleet.meta_parallel.parallel_layers import (
     PipelineLayer,
     SharedLayerDesc,
+)
+from paddle.incubate.tensor.manipulation import (
+    async_offload_with_offset,
+    create_async_load,
 )
 from paddle.nn import Embedding, Layer
 
@@ -3973,6 +3979,33 @@ def clean_model_class_name(class_name, suffixes_to_strip: Union[str, List[str]] 
     return re.sub(pattern, "", class_name)
 
 
+_PINNED_ARENA = None
+_PINNED_ARENA_CAPACITY = 0
+_ASYNC_LOADER = None
+
+
+def _get_pinned_arena(nbytes):
+    """Return a process-level (per-rank) pinned uint8 arena of at least ``nbytes`` and a
+    shared async loader, both reused across checkpoints.
+
+    NOTE: The arena is a single shared buffer. Checkpoint saves that use it MUST NOT
+    overlap in time -- if two saves run concurrently they will write into the same
+    arena region and corrupt each other's data. Callers rely on checkpoints being
+    serialized (one save fully finishes, including the final cpu_wait + save_file,
+    before the next begins) so the buffer can be safely reused.
+    """
+    global _PINNED_ARENA, _PINNED_ARENA_CAPACITY, _ASYNC_LOADER
+    if _PINNED_ARENA is None or _PINNED_ARENA_CAPACITY < nbytes:
+        arena = core.eager.Tensor()
+        arena.get_tensor()._set_dims([nbytes])
+        arena.get_tensor()._mutable_data(paddle.CUDAPinnedPlace(), core.VarDesc.VarType.UINT8)
+        _PINNED_ARENA = arena
+        _PINNED_ARENA_CAPACITY = nbytes
+    if _ASYNC_LOADER is None:
+        _ASYNC_LOADER = create_async_load()
+    return _PINNED_ARENA, _ASYNC_LOADER
+
+
 def save_full_param(
     itr: Iterator[tuple[str, Tensor]],
     save_dir: str,
@@ -3984,6 +4017,14 @@ def save_full_param(
     """
     Saves model weights from an iterator into shards, supporting max shard size
     and a limited number of saver ranks.
+
+    On GPU, weights are offloaded asynchronously via a reused pinned-memory arena:
+    each param is DMA-copied D2H into a byte offset of a page-locked buffer on a
+    dedicated loader stream (no per-param host sync), a zero-copy alias into that
+    buffer is handed to save_file, and the shard waits once (cpu_wait on the last
+    copy) before writing to disk. This overlaps the copies and avoids the slow
+    synchronous pageable path. On non-GPU devices (XPU/CPU) the arena is skipped
+    and every param falls back to a synchronous param.cpu() copy.
 
     Only ranks less than `num_saver_ranks` will perform disk I/O. All other ranks
     will iterate through the data to maintain synchronization but will not save.
@@ -4015,14 +4056,43 @@ def save_full_param(
 
     os.makedirs(save_dir, exist_ok=True)
 
+    use_pinned_arena = paddle.get_device().startswith("gpu")
+    if use_pinned_arena:
+        arena_cpu, async_loader = _get_pinned_arena(max_shard_size_bytes)
+    else:
+        arena_cpu, async_loader = None, None
+
     current_shard_state_dict = {}
     current_shard_size_bytes = 0
     sub_shard_index = 0
+    arena_offset = 0
+    shard_tasks = []
+    shard_src_refs = []
+
+    def get_param(byte_start, nbytes, dtype, shape):
+        # Wrap the pinned arena bytes as a CPUPlace zero-copy alias so save_file
+        # sees is_cpu_place()==True and skips its internal per-param .cpu().
+        base_ptr = arena_cpu.get_tensor()._ptr() + byte_start
+        np_u8 = np.ctypeslib.as_array(ctypes.cast(base_ptr, ctypes.POINTER(ctypes.c_ubyte)), shape=(nbytes,))
+        alias_u8 = core.eager.Tensor(value=np_u8, place=core.CPUPlace(), zero_copy=True)
+        alias = alias_u8.view(dtype)
+        alias.get_tensor()._set_dims(shape)
+        alias._keep_alive = (arena_cpu, np_u8, alias_u8)
+        return alias
 
     def _save_current_shard():
         nonlocal sub_shard_index, current_shard_state_dict, current_shard_size_bytes
+        nonlocal arena_offset, shard_tasks, shard_src_refs
         if not current_shard_state_dict:
             return
+
+        # Wait for all async D2H copies of this shard to land in the arena.
+        # cuda_wait for all but the last, cpu_wait on the last (same ordered stream).
+        if shard_tasks:
+            last_task = shard_tasks.pop(-1)
+            for task in shard_tasks:
+                task.cuda_wait()
+            last_task.cpu_wait()
 
         # Filename includes the main shard number (rank) and the sub-shard index
         cur_rank = paddle.distributed.get_rank()
@@ -4042,20 +4112,43 @@ def save_full_param(
         sub_shard_index += 1
         current_shard_state_dict = {}
         current_shard_size_bytes = 0
+        arena_offset = 0
+        shard_tasks = []
+        shard_src_refs = []
 
     logger.info(f"[Rank {rank}/{moe_sharding_world_size}] Starting to process the weight iterator...")
 
     total_size = 0
 
     for i, (param_key, param) in enumerate(itr):
-        param_size_bytes = param.numel() * param.element_size()
-        total_size += param_size_bytes.item()
+        param_size_bytes = param.size * param.itemsize
+        total_size += param_size_bytes
         if i % num_saver_ranks == rank:
             logger.info(f"[Rank {rank}/{moe_sharding_world_size}] Assigned to store parameter {param_key}")
             if current_shard_size_bytes > 0 and (current_shard_size_bytes + param_size_bytes > max_shard_size_bytes):
                 _save_current_shard()
-            # Move tensor to CPU since we only need to save it, not compute with it
-            current_shard_state_dict[param_key] = param.cpu()
+
+            if not use_pinned_arena or param_size_bytes > max_shard_size_bytes:
+                # Non-GPU device, or a single param larger than the arena: synchronous copy.
+                current_shard_state_dict[param_key] = param.cpu()
+            else:
+                # Async D2H copy into the arena, plus a zero-copy alias for save_file.
+                src = param.flatten().view(paddle.uint8)
+                task = async_offload_with_offset(
+                    src_tensor=src,
+                    dst_tensor=arena_cpu,
+                    src_offset=0,
+                    dst_offset=arena_offset,
+                    offload_size=param_size_bytes,
+                    async_loader=async_loader,
+                )
+                shard_tasks.append(task)
+                shard_src_refs.append(src)
+                current_shard_state_dict[param_key] = get_param(
+                    arena_offset, param_size_bytes, param.dtype, list(param.shape)
+                )
+                arena_offset += param_size_bytes
+
             current_shard_size_bytes += param_size_bytes
 
             if current_shard_size_bytes >= max_shard_size_bytes:

--- a/paddleformers/transformers/model_utils.py
+++ b/paddleformers/transformers/model_utils.py
@@ -4273,7 +4273,7 @@ class HFFormatFullParamSaver:
             local_world_size = int(os.environ.get("PADDLE_LOCAL_SIZE", 8))
             self.num_saver_ranks = min(local_world_size, self.num_saver_ranks)
 
-    def save_checkpoint(self, path, max_shard_size="2GB", save_peft=False):
+    def save_checkpoint(self, path, max_shard_size="4GB", save_peft=False):
         total_saved_size = save_full_param(
             itr=self.get_full_param_iter(),
             save_dir=path,

--- a/paddleformers/transformers/model_utils.py
+++ b/paddleformers/transformers/model_utils.py
@@ -4029,12 +4029,11 @@ def save_full_param(
 
     os.makedirs(save_dir, exist_ok=True)
 
-    use_pinned_arena = paddle.get_device().startswith("gpu")
+    use_pinned_arena = paddle.get_device().startswith("gpu") and max_shard_size_bytes < 5 * 1024**3
     if use_pinned_arena:
-        # Scoped to this save, so nothing stays page-locked between checkpoints. A few-GB
-        # arena is carved out of Paddle's already-warm pinned pool for free, while a much
-        # larger max_shard_size would fall through to a direct cudaHostAlloc costing
-        # seconds per rank.
+        # Keep the pinned staging buffer bounded. Larger shards use synchronous CPU
+        # copies so max_shard_size remains the file-sharding limit without allocating
+        # an equally large pinned arena.
         arena_cpu = core.eager.Tensor()
         arena_cpu.get_tensor()._set_dims([max_shard_size_bytes])
         arena_cpu.get_tensor()._mutable_data(paddle.CUDAPinnedPlace(), core.VarDesc.VarType.UINT8)

--- a/paddleformers/transformers/model_utils.py
+++ b/paddleformers/transformers/model_utils.py
@@ -3979,33 +3979,6 @@ def clean_model_class_name(class_name, suffixes_to_strip: Union[str, List[str]] 
     return re.sub(pattern, "", class_name)
 
 
-_PINNED_ARENA = None
-_PINNED_ARENA_CAPACITY = 0
-_ASYNC_LOADER = None
-
-
-def _get_pinned_arena(nbytes):
-    """Return a process-level (per-rank) pinned uint8 arena of at least ``nbytes`` and a
-    shared async loader, both reused across checkpoints.
-
-    NOTE: The arena is a single shared buffer. Checkpoint saves that use it MUST NOT
-    overlap in time -- if two saves run concurrently they will write into the same
-    arena region and corrupt each other's data. Callers rely on checkpoints being
-    serialized (one save fully finishes, including the final cpu_wait + save_file,
-    before the next begins) so the buffer can be safely reused.
-    """
-    global _PINNED_ARENA, _PINNED_ARENA_CAPACITY, _ASYNC_LOADER
-    if _PINNED_ARENA is None or _PINNED_ARENA_CAPACITY < nbytes:
-        arena = core.eager.Tensor()
-        arena.get_tensor()._set_dims([nbytes])
-        arena.get_tensor()._mutable_data(paddle.CUDAPinnedPlace(), core.VarDesc.VarType.UINT8)
-        _PINNED_ARENA = arena
-        _PINNED_ARENA_CAPACITY = nbytes
-    if _ASYNC_LOADER is None:
-        _ASYNC_LOADER = create_async_load()
-    return _PINNED_ARENA, _ASYNC_LOADER
-
-
 def save_full_param(
     itr: Iterator[tuple[str, Tensor]],
     save_dir: str,
@@ -4018,13 +3991,14 @@ def save_full_param(
     Saves model weights from an iterator into shards, supporting max shard size
     and a limited number of saver ranks.
 
-    On GPU, weights are offloaded asynchronously via a reused pinned-memory arena:
+    On GPU, weights are offloaded asynchronously via a per-save pinned-memory arena:
     each param is DMA-copied D2H into a byte offset of a page-locked buffer on a
     dedicated loader stream (no per-param host sync), a zero-copy alias into that
     buffer is handed to save_file, and the shard waits once (cpu_wait on the last
     copy) before writing to disk. This overlaps the copies and avoids the slow
-    synchronous pageable path. On non-GPU devices (XPU/CPU) the arena is skipped
-    and every param falls back to a synchronous param.cpu() copy.
+    synchronous pageable path. The arena is dropped when this function returns, so
+    nothing stays page-locked between checkpoints. On non-GPU devices (XPU/CPU) the
+    arena is skipped and every param falls back to a synchronous param.cpu() copy.
 
     Only ranks less than `num_saver_ranks` will perform disk I/O. All other ranks
     will iterate through the data to maintain synchronization but will not save.
@@ -4039,7 +4013,6 @@ def save_full_param(
         max_shard_size (str): The maximum size for each shard file, e.g., "500MB", "2GB".
         num_saver_ranks (int): The number of ranks (starting from 0) that will save files.
     """
-
     # 1. Non-saver ranks simply consume the iterator to stay in sync.
     if rank >= num_saver_ranks:
         logger.info(f"[Rank {rank}/{moe_sharding_world_size}] (Non-saver) Consuming iterator for synchronization...")
@@ -4058,7 +4031,14 @@ def save_full_param(
 
     use_pinned_arena = paddle.get_device().startswith("gpu")
     if use_pinned_arena:
-        arena_cpu, async_loader = _get_pinned_arena(max_shard_size_bytes)
+        # Scoped to this save, so nothing stays page-locked between checkpoints. A few-GB
+        # arena is carved out of Paddle's already-warm pinned pool for free, while a much
+        # larger max_shard_size would fall through to a direct cudaHostAlloc costing
+        # seconds per rank.
+        arena_cpu = core.eager.Tensor()
+        arena_cpu.get_tensor()._set_dims([max_shard_size_bytes])
+        arena_cpu.get_tensor()._mutable_data(paddle.CUDAPinnedPlace(), core.VarDesc.VarType.UINT8)
+        async_loader = create_async_load()
     else:
         arena_cpu, async_loader = None, None
 
@@ -4293,7 +4273,7 @@ class HFFormatFullParamSaver:
             local_world_size = int(os.environ.get("PADDLE_LOCAL_SIZE", 8))
             self.num_saver_ranks = min(local_world_size, self.num_saver_ranks)
 
-    def save_checkpoint(self, path, max_shard_size="16GB", save_peft=False):
+    def save_checkpoint(self, path, max_shard_size="2GB", save_peft=False):
         total_saved_size = save_full_param(
             itr=self.get_full_param_iter(),
             save_dir=path,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleFormers/pull/ -->
#### Before submitting

- [ ] Lint code. If there are lint issues, please format the code first.

```shell
# Install and register `pre-commit` in the project folder
pip install pre-commit && pre-commit install

# Process previous code files separately
pre-commit run --file XXXX.py
```

- [ ] Add test cases into `tests` folder. If there are codecov issues, please add tests cases first.

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
pr :https://github.com/PaddlePaddle/PaddleFormers/pull/4897 修改的方式是在内存开辟了16G*8卡=128G的pinned memory，并且用不释放，影响到了整体模型的训练的性能
当前pr每卡只申请了4G的pinned memory，且在保存函数中进行申请，超出函数后自动释放，不再锁定内存。

【结果差别】
- 最终生成的hf-checkpoint的safetensor文件的单个大小上线变为4GB，之前的上限是16GB（其实都很难达到）
- 性能基本一致，由于申请的pinned memory是直接来自于paddle的内存池的，后续申请也无需申请时间，之前的代码重复的16GB申请是要话费大量时间申请的
- 当有调用点强制使用大max_shard_size来对函数进行调用时（超过5GB），回退到原本的执行路径而不使用pinned memory，以此来避免对训练性能产生影响

本优化方案的性能：
<img width="2450" height="282" alt="image" src="https://github.com/user-attachments/assets/b4c3c455-6c27-468d-8bdb-7c2b91c5a483" />
16G优化的性能：
<img width="1626" height="210" alt="image" src="https://github.com/user-attachments/assets/607a9bc1-755e-475a-8c95-fadfca7cd7a8" />
性能略有下降，但是差不多