### PR TITLE
[Deps] Update PaddleFleet to 8a8b7e70495

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,7 @@ try:
         install_requires=REQUIRED_PACKAGES,
         entry_points={"console_scripts": get_console_scripts()},
         extras_require={
-            "paddlefleet": ["paddlefleet==0.4.0.post20260905+6d69f843df9"],
+            "paddlefleet": ["paddlefleet==0.4.0.post20260908+8a8b7e70495"],
         },
         python_requires=">=3.8",
         classifiers=[


### PR DESCRIPTION
### PR types

Others

### PR changes

Others

### Description

Update the optional PaddleFleet dependency on `develop` to the package built from PaddleFleet `release/0.4` commit `8a8b7e70495d34bd40cebf81ca15db9482eb338f`.

- Dependency: `paddlefleet==0.4.0.post20260908+8a8b7e70495`
- This PR changes only the dependency pin in `setup.py`.
- Validation: `python3 -m py_compile setup.py` and `git diff --check`.