### PR TITLE
[Observability] Add opt-in startup span hooks to Trainer 

### DIFF
--- a/paddleformers/trainer/startup_profile.py
+++ b/paddleformers/trainer/startup_profile.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Opt-in span hooks for profiling the startup path (launch -> first loss).
+
+Why this exists
+---------------
+The cold-start path of a large pretraining job (flex-checkpoint load, optimizer
+build, first pipeline step) can take minutes, and the interesting sub-phases live
+*inside* ``Trainer``. Downstream trainers therefore need timing anchors here, but
+PaddleFormers must not grow a dependency on any particular profiler.
+
+So this module only declares *where* the anchors are. It records nothing on its
+own and has no default output. A downstream framework opts in by registering one
+callable::
+
+    from paddleformers.trainer.startup_profile import set_span_provider
+    set_span_provider(my_profiler.span)   # span(name, collective=..., **extra)
+
+The provider must return a context manager. Until one is registered -- i.e. for
+every standalone PaddleFormers user -- :func:`span` returns a shared no-op object,
+so the cost is one module-global load plus one ``is None`` test per call and no
+allocation. That matters because a couple of the anchors sit in the per-step
+pipeline path, not just in one-shot startup code.
+
+Anything the provider raises is *not* caught here. Profiling code is expected to
+swallow its own errors; hiding exceptions at this boundary would also hide bugs in
+the instrumented body.
+"""
+
+__all__ = ["set_span_provider", "get_span_provider", "span"]
+
+
+class _NullSpan:
+    """Zero-cost stand-in used when no provider is registered."""
+
+    __slots__ = ()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def note(self, **kwargs):
+        """Accept (and drop) the annotations a real span would attach."""
+        return self
+
+
+_NULL_SPAN = _NullSpan()
+
+_span_provider = None
+
+
+def set_span_provider(provider):
+    """Register the callable that turns a span name into a context manager.
+
+    Args:
+        provider: ``callable(name: str, collective: bool = False, **extra)`` that
+            returns a context manager, or ``None`` to uninstall.
+
+    Returns:
+        The previously registered provider, so callers can restore it (useful in
+        tests).
+    """
+    global _span_provider
+    previous, _span_provider = _span_provider, provider
+    return previous
+
+
+def get_span_provider():
+    """Return the registered provider, or ``None`` if profiling is off."""
+    return _span_provider
+
+
+def span(name, collective=False, **extra):
+    """Time the wrapped block, if and only if a provider is registered.
+
+    Args:
+        name: Span name. Providers are expected to nest it under the enclosing
+            span, so keep it local (``"read_metadata"``, not a full path).
+        collective: Whether the block contains collective communication. Lets a
+            provider add device syncs and separate real communication time from
+            waiting for the slowest rank.
+        **extra: Free-form annotations forwarded to the provider.
+    """
+    if _span_provider is None:
+        return _NULL_SPAN
+    return _span_provider(name, collective=collective, **extra)

--- a/paddleformers/trainer/trainer.py
+++ b/paddleformers/trainer/trainer.py
@@ -171,6 +171,7 @@ from ..utils.tools import paddle_device
 from .argparser import strtobool
 from .integrations import get_reporting_integration_callbacks
 from .plugins.timer import RuntimeTimer, get_timers, set_timers
+from .startup_profile import span as _sprof_span
 from .trainer_callback import (
     CallbackHandler,
     DefaultFlowCallback,
@@ -1226,7 +1227,8 @@ class Trainer:
             assert len(metadata_files) == 1, f"Found multiple metadata files in {path}"
             return metadata_files[0]
 
-        model_sharded_state_dict = self.model.sharded_state_dict()
+        with _sprof_span("sharded_state_dict"):
+            model_sharded_state_dict = self.model.sharded_state_dict()
         master_weights_path = os.path.join(resume_from_checkpoint, MASTER_WEIGHT_DIC)
         opt_states_path = os.path.join(resume_from_checkpoint, OPTIMIZER_STATE_DIC)
         model_states_path = os.path.join(resume_from_checkpoint, MODEL_STATE_DIC)
@@ -1322,14 +1324,16 @@ class Trainer:
             os.path.join(master_weights_path, get_metadata_file_name(master_weights_path)),
         ]
 
-        for metadata_file in metadata_paths:
-            if not os.path.exists(metadata_file):
-                raise FileNotFoundError(f"Metadata file not found: {metadata_file}")
-            metadata = paddle.load(metadata_file)
-            state_dict_metadata.update(metadata.state_dict_metadata)
+        with _sprof_span("read_metadata"):
+            for metadata_file in metadata_paths:
+                if not os.path.exists(metadata_file):
+                    raise FileNotFoundError(f"Metadata file not found: {metadata_file}")
+                metadata = paddle.load(metadata_file)
+                state_dict_metadata.update(metadata.state_dict_metadata)
 
         if not self.args.sharded_model_from_ema:
-            init_optimizer(self.optimizer, model_sharded_state_dict, state_dict_metadata)
+            with _sprof_span("init_optimizer"):
+                init_optimizer(self.optimizer, model_sharded_state_dict, state_dict_metadata)
 
             # ===== EMA State Resharding for ZCC (right after optimizer init) =====
             # Non-ZCC handles reshard internally in EMABufferFcBased._load()
@@ -1356,7 +1360,8 @@ class Trainer:
                     else:
                         logger.info("[EMA Reshard] Same strategy, subprocess will load EMA directly from file")
 
-            optimizer_sharded_state_dict = self.optimizer.sharded_state_dict(model_sharded_state_dict)
+            with _sprof_span("opt_sharded_state_dict"):
+                optimizer_sharded_state_dict = self.optimizer.sharded_state_dict(model_sharded_state_dict)
             opt_states = {}
             master_weights = {}
             for k, v in optimizer_sharded_state_dict.items():
@@ -1373,14 +1378,18 @@ class Trainer:
                 logger.info("[AOAConfig] generate master_weight_aoa by _gen_ckpt_convert_aoa !")
                 master_weight_aoa = self.model._gen_ckpt_convert_aoa(self.model.config)
 
-            dist.load_state_dict(
-                master_weights,
-                master_weights_path,
-                aoa_config=master_weight_aoa,
-                offload=self.args.load_via_cpu,
-                comm_method=flex_ckpt_comm_method,
-                worker_groups=worker_groups,
-            )
+            # The three loads below are opaque from here -- the work happens inside
+            # FlexCheckpoint -- so each span carries the number of tensors it was
+            # asked for, which is what turns the duration into a per-tensor cost.
+            with _sprof_span("load_master_weight", collective=True, n=len(master_weights)):
+                dist.load_state_dict(
+                    master_weights,
+                    master_weights_path,
+                    aoa_config=master_weight_aoa,
+                    offload=self.args.load_via_cpu,
+                    comm_method=flex_ckpt_comm_method,
+                    worker_groups=worker_groups,
+                )
 
             if not self.args.ignore_load_lr_and_optim:
                 opt_stat_aoa = self.args.aoa_config
@@ -1390,14 +1399,15 @@ class Trainer:
                     logger.info("[AOAConfig] generate opt_stat_aoa by _gen_ckpt_convert_aoa !")
                     opt_stat_aoa = self.model._gen_ckpt_convert_aoa(self.model.config, target="opt_state")
 
-                dist.load_state_dict(
-                    opt_states,
-                    opt_states_path,
-                    aoa_config=opt_stat_aoa,
-                    offload=self.args.load_via_cpu,
-                    comm_method=flex_ckpt_comm_method,
-                    worker_groups=worker_groups,
-                )
+                with _sprof_span("load_opt_state", collective=True, n=len(opt_states)):
+                    dist.load_state_dict(
+                        opt_states,
+                        opt_states_path,
+                        aoa_config=opt_stat_aoa,
+                        offload=self.args.load_via_cpu,
+                        comm_method=flex_ckpt_comm_method,
+                        worker_groups=worker_groups,
+                    )
                 self._load_scheduler(resume_from_checkpoint)
 
             if self.args.tensorwise_offload_optimizer:
@@ -1477,17 +1487,19 @@ class Trainer:
             else:
                 aoa_config = self.args.aoa_config
 
-            dist.load_state_dict(
-                model_sharded_state_dict,
-                model_states_path,
-                aoa_config=aoa_config,
-                offload=self.args.load_via_cpu,
-                comm_method=flex_ckpt_comm_method,
-                worker_groups=worker_groups,
-            )
+            with _sprof_span("load_model_state", collective=True, n=len(model_sharded_state_dict)):
+                dist.load_state_dict(
+                    model_sharded_state_dict,
+                    model_states_path,
+                    aoa_config=aoa_config,
+                    offload=self.args.load_via_cpu,
+                    comm_method=flex_ckpt_comm_method,
+                    worker_groups=worker_groups,
+                )
 
         if enable_bf16_opt:
-            opt_state_dict = self.optimizer.state_dict()
+            with _sprof_span("opt_state_dict"):
+                opt_state_dict = self.optimizer.state_dict()
 
             def _assign_master_weights_to_model(master_weights):
                 model_state_dict = self.model.state_dict()
@@ -1523,13 +1535,18 @@ class Trainer:
                 # _restore_master_weights_2d_on_device can gather them in place.
                 # 1D parameters go through ShardingV2's redistribute-and-
                 # concatenate, which is host-resident, so they move to host here.
-                for k, v in tmp.items():
-                    name = v.name
-                    if k in param_2d_names and reshard_util.use_device_gather():
-                        master_weights[k] = paddle.cast(to_device(v), paddle.bfloat16)
-                    else:
-                        master_weights[k] = paddle.cast(to_device(v), paddle.bfloat16).cpu()
-                    master_weights[k].name = name
+                #
+                # Timed separately from the restores below: this loop is pure
+                # cast + device-to-host copy, so a large number here means the
+                # D2H traffic dominates, not the reshard collectives.
+                with _sprof_span("mw_cast_bf16", n=len(tmp), n_2d=len(param_2d_names)):
+                    for k, v in tmp.items():
+                        name = v.name
+                        if k in param_2d_names and reshard_util.use_device_gather():
+                            master_weights[k] = paddle.cast(to_device(v), paddle.bfloat16)
+                        else:
+                            master_weights[k] = paddle.cast(to_device(v), paddle.bfloat16).cpu()
+                        master_weights[k].name = name
 
                 structure_name_map = {k: v.name for (k, v) in self.model.state_dict().items()}
 
@@ -1552,26 +1569,34 @@ class Trainer:
                     device_param_sink = {
                         p.name: p for p in self.model.state_dict().values() if p.dtype == paddle.bfloat16
                     }
-                    restored_2d = _restore_master_weights_2d_on_device(mw_2d, group, device_param_sink)
-                    if restored_2d is None:  # reshard_master_weight_device_gather=False
-                        restored_2d = _restore_master_weights_single(
-                            mw_2d,
+                    # 2D and 1D are separate spans because they use different reshard
+                    # paths -- device gather vs ShardingV2's host-resident
+                    # redistribute-and-concatenate -- and in practice one of the two
+                    # dominates. `restore_2d_host` names the fallback explicitly so a
+                    # report shows which path actually ran.
+                    with _sprof_span("restore_2d", collective=True, n=len(mw_2d)):
+                        restored_2d = _restore_master_weights_2d_on_device(mw_2d, group, device_param_sink)
+                        if restored_2d is None:  # reshard_master_weight_device_gather=False
+                            with _sprof_span("restore_2d_host", collective=True):
+                                restored_2d = _restore_master_weights_single(
+                                    mw_2d,
+                                    self.model,
+                                    self.optimizer,
+                                    group,
+                                    structure_name_map,
+                                    reshard_util.sharding_v1.restore,
+                                )
+                    all_master_weights.update(restored_2d)
+
+                    with _sprof_span("restore_1d", collective=True, n=len(mw_1d)):
+                        restored_1d = _restore_master_weights_single(
+                            mw_1d,
                             self.model,
                             self.optimizer,
                             group,
                             structure_name_map,
-                            reshard_util.sharding_v1.restore,
+                            reshard_util.sharding_v2.restore,
                         )
-                    all_master_weights.update(restored_2d)
-
-                    restored_1d = _restore_master_weights_single(
-                        mw_1d,
-                        self.model,
-                        self.optimizer,
-                        group,
-                        structure_name_map,
-                        reshard_util.sharding_v2.restore,
-                    )
                     all_master_weights.update(restored_1d)
 
                     master_weights = all_master_weights
@@ -1583,16 +1608,26 @@ class Trainer:
                         if sharding_strategy == SHARDING_STRATEGY_V1
                         else reshard_util.sharding_v2.restore
                     )
-                    master_weights = _restore_master_weights_single(
-                        master_weights, self.model, self.optimizer, group, structure_name_map, restore_func
-                    )
+                    with _sprof_span("restore_master_weights", collective=True, n=len(master_weights)):
+                        master_weights = _restore_master_weights_single(
+                            master_weights, self.model, self.optimizer, group, structure_name_map, restore_func
+                        )
 
-                _assign_master_weights_to_model(master_weights)
+                # Final fp32 -> bf16 assign into the model parameters. Anything the
+                # device gather already wrote in place is skipped here, so a large
+                # number means the host path carried most of the parameters.
+                with _sprof_span("assign_to_model", n=len(master_weights)):
+                    _assign_master_weights_to_model(master_weights)
 
-            with paddle.no_grad():
+            # fp32 master weight -> bf16 parameter write-back. Broken down inside
+            # into the split, the cast and the per-sharding-group restores, because
+            # on a large job this block dominates the whole checkpoint load and a
+            # single number does not say which of those three to attack.
+            with _sprof_span("master_weight_writeback", collective=True), paddle.no_grad():
                 if paddle.distributed.is_initialized():
                     group_getter = GroupGetter(self.model)
-                    opt_state_dict = split_opt_state(opt_state_dict, group_getter)
+                    with _sprof_span("split_opt_state"):
+                        opt_state_dict = split_opt_state(opt_state_dict, group_getter)
                     for gid in group_getter.get_group_ids():
                         sub_opt_state_dict = opt_state_dict.get(gid, {})
                         group = group_getter.get_group_by_id(gid)
@@ -4431,12 +4466,20 @@ class Trainer:
                 inputs, self.optimizer, self.lr_scheduler
             )  # None, None => [optimizer, lr_scheduler]
 
-        if PipelineDatasetPreprocessor is None or self.args.use_dualpipev:
-            inputs = _dataset_process_function()
-        else:
-            inputs = PipelineDatasetPreprocessor(_dataset_process_function)
+        # With gradient_accumulation_steps > 1 the early micro-steps only push data
+        # into _pp_data_buffer and return above, so the whole cost of the first
+        # pipeline step lands on the last call, in these two blocks. Splitting them
+        # tells data preparation apart from pipeline scheduling.
+        with _sprof_span("pp_dataset_prepare"):
+            if PipelineDatasetPreprocessor is None or self.args.use_dualpipev:
+                inputs = _dataset_process_function()
+            else:
+                # Lazy branch: the real work happens inside forward_backward_pipeline,
+                # so this span reads near zero. Do not conclude that data preparation
+                # is free.
+                inputs = PipelineDatasetPreprocessor(_dataset_process_function)
 
-        with self.autocast_smart_context_manager():
+        with self.autocast_smart_context_manager(), _sprof_span("pp_forward_backward", collective=True):
             loss = model.forward_backward_pipeline(inputs, self.scaler if self.do_grad_scaling else None)
 
         # MTP magic send: reset per-depth counters after each optimizer step

--- a/tests/trainer/test_startup_profile.py
+++ b/tests/trainer/test_startup_profile.py
@@ -1,0 +1,139 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the opt-in startup span hooks.
+
+The point of ``startup_profile`` is that it changes nothing until somebody opts in,
+and that opting in cannot break the instrumented code. So what is pinned down here:
+
+  1. With no provider registered, ``span`` is a no-op context manager that yields the
+     same shared object every time -- no allocation, and no output.
+  2. The no-op span still tolerates ``note(...)``, so instrumented code can annotate
+     spans unconditionally.
+  3. A registered provider receives the span name, the ``collective`` flag and any
+     extra annotations, and its context manager brackets the body.
+  4. Registration is reversible: ``set_span_provider`` returns the previous provider,
+     and setting ``None`` restores no-op behaviour.
+  5. ``span`` does not swallow exceptions -- neither the body's nor the provider's.
+  6. ``trainer.py`` uses the indirection rather than importing a concrete profiler,
+     which is what keeps PaddleFormers standalone.
+"""
+
+import contextlib
+import inspect
+import unittest
+
+from paddleformers.trainer import startup_profile
+
+
+class SpyProvider:
+    """Records every span it is asked to open, and when each one entered/exited."""
+
+    def __init__(self):
+        self.calls = []
+        self.events = []
+
+    def __call__(self, name, collective=False, **extra):
+        self.calls.append((name, collective, extra))
+        return self._cm(name)
+
+    @contextlib.contextmanager
+    def _cm(self, name):
+        self.events.append(("enter", name))
+        try:
+            yield name
+        finally:
+            self.events.append(("exit", name))
+
+
+class TestStartupProfile(unittest.TestCase):
+    def setUp(self):
+        # Never leak a provider into other tests: the registry is module global.
+        self._saved = startup_profile.set_span_provider(None)
+        self.addCleanup(startup_profile.set_span_provider, self._saved)
+
+    def test_noop_by_default(self):
+        self.assertIsNone(startup_profile.get_span_provider())
+        first = startup_profile.span("a")
+        second = startup_profile.span("b", collective=True, n_params=3)
+        # Same singleton => calling span() when profiling is off allocates nothing.
+        self.assertIs(first, second)
+        with startup_profile.span("a") as s:
+            self.assertIs(s, first)
+            # Annotating a disabled span must not raise, and must stay chainable.
+            self.assertIs(s.note(k=1), s)
+
+    def test_provider_receives_name_flags_and_extras(self):
+        spy = SpyProvider()
+        startup_profile.set_span_provider(spy)
+        with startup_profile.span("read_metadata") as s:
+            self.assertEqual(s, "read_metadata")
+        with startup_profile.span("load_master_weight", collective=True, n=7):
+            pass
+        self.assertEqual(
+            spy.calls,
+            [("read_metadata", False, {}), ("load_master_weight", True, {"n": 7})],
+        )
+        # The body really runs inside the provider's context manager.
+        self.assertEqual(
+            spy.events,
+            [
+                ("enter", "read_metadata"),
+                ("exit", "read_metadata"),
+                ("enter", "load_master_weight"),
+                ("exit", "load_master_weight"),
+            ],
+        )
+
+    def test_registration_is_reversible(self):
+        spy = SpyProvider()
+        self.assertIsNone(startup_profile.set_span_provider(spy))
+        self.assertIs(startup_profile.get_span_provider(), spy)
+        self.assertIs(startup_profile.set_span_provider(None), spy)
+        self.assertIsNone(startup_profile.get_span_provider())
+        with startup_profile.span("after_uninstall"):
+            pass
+        self.assertEqual(spy.calls, [])
+
+    def test_body_exception_propagates_and_span_is_closed(self):
+        spy = SpyProvider()
+        startup_profile.set_span_provider(spy)
+        with self.assertRaises(ValueError):
+            with startup_profile.span("boom"):
+                raise ValueError("from body")
+        self.assertEqual(spy.events, [("enter", "boom"), ("exit", "boom")])
+
+    def test_provider_exception_is_not_hidden(self):
+        def broken(name, collective=False, **extra):
+            raise RuntimeError("bad provider")
+
+        startup_profile.set_span_provider(broken)
+        # Profiling code is expected to swallow its own errors; hiding them here would
+        # also hide bugs in the instrumented body.
+        with self.assertRaises(RuntimeError):
+            with startup_profile.span("x"):
+                pass
+
+    def test_trainer_does_not_depend_on_a_concrete_profiler(self):
+        from paddleformers.trainer import trainer as trainer_mod
+
+        self.assertIs(trainer_mod._sprof_span, startup_profile.span)
+        source = inspect.getsource(trainer_mod)
+        self.assertNotIn("startup_profiler", source)
+        # Spans are only reachable through the indirection.
+        self.assertIn("from .startup_profile import span as _sprof_span", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 这是 #4994 的 cherry-pick（`git cherry-pick -x`），base 换成 `develop`，无冲突，代码与 #4994 逐字相同。

## 背景

大规模预训练冷启动时，从进程起来到首个 loss 打出来往往要几分钟，而这段时间里最耗时的几个子阶段全部埋在 `Trainer` 内部，从外面看不见：

- flex-checkpoint 加载是 `_load_flex_checkpoint` 一个不透明的调用；
- `gradient_accumulation_steps > 1` 时，前几个 micro-step 只是往 `_pp_data_buffer` 里塞数据就 return 了，首个 pipeline step 的全部开销都落在最后一次 `training_pipeline_step` 调用上。

在调用方计时只能得到一个总数，没法判断是数据准备慢、metadata 读慢、还是 master weight 写回慢。

## 本 PR 做了什么

**只加计时锚点，不加任何 profiler。**

新增 `paddleformers/trainer/startup_profile.py`，提供 `span(name, collective=False, **extra)` 和一个 `set_span_provider()` 注册入口。PaddleFormers 自己不记录任何数据、没有默认输出；下游框架通过注册一个「span 名 → context manager」的 callable 来接管：

```python
from paddleformers.trainer.startup_profile import set_span_provider
set_span_provider(my_profiler.span)
```

没有注册 provider 时（也就是所有独立使用 PaddleFormers 的场景），`span()` 返回一个共享的 no-op 单例，代价是一次模块全局变量读取加一次 `is None` 判断，**不产生任何对象分配**。这一点是必要的：其中两个锚点位于每步都会走到的 pipeline 路径上，不只是一次性的启动代码。

### 锚点位置

`_load_flex_checkpoint`（9 个）：
`sharded_state_dict`、`read_metadata`、`init_optimizer`、`opt_sharded_state_dict`、`load_master_weight`、`load_opt_state`、`load_model_state`、`opt_state_dict`、`master_weight_writeback`

`master_weight_writeback` 内部（6 个）：
`split_opt_state`、`mw_cast_bf16`、`restore_2d`（走主机兜底时再套一层 `restore_2d_host`）、`restore_1d`、`restore_master_weights`（非 Muon 分支）、`assign_to_model`

`training_pipeline_step`（2 个）：
`pp_dataset_prepare`、`pp_forward_backward`

含集合通信的块标了 `collective=True`，这样 provider 可以在前后各做一次 device sync，把真实通信耗时和「等最慢 rank」拆开；其余不带这个标记。

写回这一段之所以要拆到底：实测它就是耗时的大头 —— 43 层 MoE 模型 64 卡续训时，它占了整个 checkpoint 加载的约四分之三，而一个总数说不清该去优化 D2H 的 cast、reshard 的集合通信，还是最后的 assign。`restore_2d_host` 单独起名是为了让报表直接看出走的是 device gather 还是主机兜底。

三个 `dist.load_state_dict` 保持单个 span —— 真正的实现在 FlexCheckpoint 内部，在 PaddleFormers 这一层切不开 —— 但各自加了张量个数的注解，这样耗时可以换算成每张量成本，也能看出 AOA 过滤有没有改变要加载的集合。

### 有意不做的事

不落盘、不读环境变量、不打日志。这些都属于注册 provider 的那一方，放进框架里只会变成一份没人要的默认行为。

`span()` 也**不吞异常** —— provider 抛的异常照样往上传。打点代码本来就该自己咽下自己的错误；在这个边界上兜底会顺手把被计时代码里的 bug 也藏掉。

## 兼容性

- 默认行为逐位不变：没有 provider 时 `with span(...)` 只是把原来的语句块包了一层 no-op，控制流和数值都不变。
- 不新增依赖、不新增配置项、不改任何公开 API 的签名。
- `trainer.py` 里的改动全部是把已有语句块缩进到 `with` 里，加上一行 import。

## 测试

新增 `tests/trainer/test_startup_profile.py`（6 个 case），把契约钉死：

1. 默认 no-op，且两次调用返回同一个单例（= 关闭时不分配对象）；no-op span 仍然接受 `note(...)`，下游可以无条件标注。
2. provider 能收到 span 名、`collective` 标记和额外注解，且它的 context manager 真的包住了被计时的代码块（用 enter/exit 事件序列断言）。
3. 注册可逆：`set_span_provider` 返回上一个 provider，置 `None` 后回到 no-op。
4. 被计时代码块抛异常时异常照常传播，且 span 正常关闭。
5. provider 自己抛异常不会被吞掉。
6. `trainer.py` 只通过这层间接访问 span（源码检查断言不含任何具体 profiler 的 import），保证 PaddleFormers 仍能独立 import。

```
$ python -m pytest tests/trainer/test_startup_profile.py -q
......                                                          [100%]
```

## 实际效果

在 8 机 64 卡 ERNIE5 MoE 上跑通，这些锚点定位到的东西（供参考，不属于本 PR 范围）：`master_weight_writeback` 占 flex-checkpoint 加载的 75%；`pp_dataset_prepare` 接近 0，说明首步慢在流水线调度而非数据准备。
