### PR TITLE
[Models] Add HyperBody decoder model

### DIFF
--- a/paddleformers/transformers/__init__.py
+++ b/paddleformers/transformers/__init__.py
@@ -394,6 +394,8 @@ import_structure = {
     "minicpm4_1": [],
     "deepseek_v4.configuration": ["DeepseekV4Config"],
     "deepseek_v4": ["DeepseekV4ForCausalLMPipe", "DeepseekV4ForCausalLM"],
+    "hyperbody_decoder.configuration": ["HyperBodyDecoderConfig"],
+    "hyperbody_decoder": ["HyperBodyDecoderForCausalLM", "HyperBodyDecoderForCausalLMPipe"],
     "glm4v_moe.image_processor": ["Glm4vImageProcessor"],
     "glm4v_moe.image_processor_fast": ["Glm4vImageProcessorFast"],
     "auto": ["AutoModelForCausalLM"],
@@ -536,6 +538,7 @@ if TYPE_CHECKING:
     from .minicpm import *
     from .minicpm4_1 import *
     from .deepseek_v4 import *
+    from .hyperbody_decoder import *
     from .gpt_oss import *
     from .minicpm3 import *
     from .granite import *

--- a/paddleformers/transformers/auto/configuration.py
+++ b/paddleformers/transformers/auto/configuration.py
@@ -62,6 +62,7 @@ CONFIG_MAPPING_NAMES = OrderedDict(
         ("minicpm", "MiniCPMConfig"),
         ("minicpm4_1", "MiniCPM4_1Config"),
         ("deepseek_v4", "DeepseekV4Config"),
+        ("hyperbody_decoder", "HyperBodyDecoderConfig"),
         ("gpt_oss", "GptOssConfig"),
         ("minicpm3", "MiniCPM3Config"),
         ("phi3", "Phi3Config"),

--- a/paddleformers/transformers/auto/configuration.py
+++ b/paddleformers/transformers/auto/configuration.py
@@ -91,6 +91,7 @@ MODEL_NAMES_MAPPING = OrderedDict(
     [
         ("deepseek_v2", "DeepseekV2"),
         ("deepseek_v3", "DeepseekV3"),
+        ("hyperbody_decoder", "HyperBodyDecoderForCausalLM"),
         ("paligemma", "PaliGemma2"),
         ("paligemma2", "PaliGemma2"),
         ("diff_transformer", "DiffTransformer"),

--- a/paddleformers/transformers/auto/modeling.py
+++ b/paddleformers/transformers/auto/modeling.py
@@ -81,6 +81,7 @@ MAPPING_NAMES = OrderedDict(
         ("MiniCPM", "minicpm"),
         ("MiniCPM4_1", "minicpm4_1"),
         ("DeepseekV4", "deepseek_v4"),
+        ("HyperBodyDecoder", "hyperbody_decoder"),
         ("GptOss", "gpt_oss"),
         ("MiniCPM3", "minicpm3"),
         ("Granite", "granite"),

--- a/paddleformers/transformers/hyperbody_decoder/__init__.py
+++ b/paddleformers/transformers/hyperbody_decoder/__init__.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""HyperBody decoder（LLM 主干）。
+
+用 ``_LazyModule``（与 ``deepseek_v4/__init__.py`` 同形）而不是直接 import：
+``transformers/__init__.py`` 会把本包登记进 import_structure，
+真正 import ``modeling`` 会连带拉起 ``paddlefleet``，那是几秒级的开销，
+不该在 ``import paddleformers`` 时就付。
+"""
+import sys
+from typing import TYPE_CHECKING
+
+from ...utils.lazy_import import _LazyModule
+
+import_structure = {
+    "configuration": ["HyperBodyDecoderConfig"],
+    "modeling": [
+        "HyperBodyDecoderForCausalLM",
+        "HyperBodyDecoderForCausalLMPipe",
+    ],
+}
+
+if TYPE_CHECKING:
+    from .configuration import *
+    from .modeling import *
+else:
+    sys.modules[__name__] = _LazyModule(
+        __name__,
+        globals()["__file__"],
+        import_structure,
+        module_spec=__spec__,
+    )

--- a/paddleformers/transformers/hyperbody_decoder/__init__.py
+++ b/paddleformers/transformers/hyperbody_decoder/__init__.py
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""HyperBody decoder（LLM 主干）。
+"""HyperBody decoder (LLM backbone).
 
-用 ``_LazyModule``（与 ``deepseek_v4/__init__.py`` 同形）而不是直接 import：
-``transformers/__init__.py`` 会把本包登记进 import_structure，
-真正 import ``modeling`` 会连带拉起 ``paddlefleet``，那是几秒级的开销，
-不该在 ``import paddleformers`` 时就付。
+Uses ``_LazyModule`` rather than a direct import: ``transformers/__init__.py``
+registers this package into import_structure, and actually importing ``modeling``
+would drag in ``paddlefleet``, which is a few-seconds cost that should not be paid at
+``import paddleformers`` time.
 """
 import sys
 from typing import TYPE_CHECKING

--- a/paddleformers/transformers/hyperbody_decoder/configuration.py
+++ b/paddleformers/transformers/hyperbody_decoder/configuration.py
@@ -12,77 +12,66 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""HyperBody decoder 的 HF-style config —— **几何与数值开关的单一真源**。
+"""HF-style config for the HyperBody decoder -- the **single source of truth for geometry and numeric switches**.
 
-## 分工（与参考实现 ``fleet_formers`` 的 hyperencoder 同构）
+## Split of responsibilities
 
-| 侧 | 职责 |
+| Side | Responsibility |
 |---|---|
-| **本文件（PaddleFormers）** | 几何常量 + ``HyperBodyDecoderConfig``：``config.json`` 的落地形状，喂 ``AutoConfig`` / ``AutoModelForCausalLM`` |
-| ``modeling.py``（PaddleFormers） | HF-style config → ``GPTConfig`` 的转换（``HyperBodyDecoderModelProvider``）+ 组网装配 |
-| ``paddlefleet.models.hyperbody_decoder`` | 只提供组件：12 层 backbone 的 ``LayerSpec`` 列表 |
+| **This file (PaddleFormers)** | Geometry constants + ``HyperBodyDecoderConfig``: the on-disk shape of ``config.json``, fed to ``AutoConfig`` / ``AutoModelForCausalLM`` |
+| ``modeling.py`` (PaddleFormers) | HF-style config -> ``GPTConfig`` conversion (``HyperBodyDecoderModelProvider``) + model assembly |
+| ``paddlefleet.models.hyperbody_decoder`` | Provides components only: the ``LayerSpec`` list for the backbone |
 
-Megatron 侧的真源是 ``_make_language_config``
-（``hyperbody/megatron_bridge_patch/recipes/hyperbody/hyperbody.py:61-147``）
-以及紧随其后的 ``_build_model_specs``（提供 ``vocab_size``）。
-下面每个字段都标了对应的源侧行号。
+The "HF-style config -> GPTConfig" step is done by ``AutoConfig`` -> this class ->
+``HyperBodyDecoderModelProvider.from_config``, all landing in PaddleFormers.
 
-参考实现把 ``build_hyperencoder_config() -> GPTConfig`` 放在
-``transformers/hyperencoder/configuration.py``，即「HF-style → GPTConfig」这件事
-归 formers。decoder 走 ``paddleformers-cli``，这条转换由
-``AutoConfig`` → 本类 → ``HyperBodyDecoderModelProvider.from_config`` 完成，
-落点同样在 formers；fleet 侧因此**不再有** ``decoder_config.py``。
+## Fields with no Paddle-side counterpart
 
-## 源侧有、Paddle 侧无对应字段的四项
-
-* ``persist_layer_norm=True`` —— Paddle 的 norm 没有这个开关。
-* ``moe_router_dtype="fp32"`` —— Paddle 侧 router 已强制 fp32（前提是不开
-  ``use_accuracy_compatible``）。
-* ``moe_router_pre_softmax=True`` —— Paddle 路由天生 pre-softmax，配
+* ``persist_layer_norm`` -- Paddle's norm has no such switch.
+* ``moe_router_dtype="fp32"`` -- Paddle's router already forces fp32 (as long as
+  ``use_accuracy_compatible`` is off).
+* ``moe_router_pre_softmax`` -- Paddle routing is natively pre-softmax; pairing
   ``scoring_func="softmax"`` + ``topk_method="greedy"`` + ``norm_topk_prob=False``
-  即等价。
-* ``attention_backend=AttnBackend.flash`` —— Paddle 侧对应 ``_attn_implementation``。
+  is equivalent.
+* attention backend -- corresponds to ``_attn_implementation`` on the Paddle side.
 
-## 三处 decoder 与 encoder 真实不同（不是笔误）
+## WARNING: which fields get overwritten by the CLI (must know when writing yaml)
 
-* ``moe_expert_fusion=True``（源侧 ``moe_grouped_gemm=True``），encoder 是 ``False``。
-* ``masked_softmax_fusion=True``，encoder 是 ``False``。
-* 因果 vs 双向：decoder 不需要 encoder 那套 ``AttnMaskType.no_mask``
-  + ``_attn_implementation="eager"`` 的绕行。
+The ``paddleformers-cli`` chain is:
 
-## ⚠️ 哪些字段会被 CLI 覆盖掉（写 yaml 时必须知道）
-
-``paddleformers-cli`` 的链路是：
-
-1. ``AutoConfig.from_pretrained`` → 走本类 ``__init__``；
-2. ``PretrainedConfig.__init__`` 里的 ``set_expected_keys``（``configuration_utils.py:889``）
-   把 ``LlmMetaConfig._get_init()`` 的**每一个** key 按它自己的默认值写到 config 上 ——
-   所以本类 ``__init__`` 里先 ``self.x = ...`` 再 ``super().__init__()`` 的字段，
-   凡属于 llm_meta 的都会被打回默认值。**对策：塞进 ``super().__init__(**)`` 的 kwargs**，
-   ``set_expected_keys`` 会优先取 kwargs（``:206-207``）。
+1. ``AutoConfig.from_pretrained`` -> goes through this class's ``__init__``;
+2. ``set_expected_keys`` inside ``PretrainedConfig.__init__``
+   (``configuration_utils.py:889``) writes **every** key of
+   ``LlmMetaConfig._get_init()`` onto config with its own default -- so any field
+   set as ``self.x = ...`` before ``super().__init__()`` in this class's ``__init__``
+   gets reset to default if it belongs to llm_meta. **Fix: put it into the
+   ``super().__init__(**)`` kwargs**, since ``set_expected_keys`` prefers kwargs
+   (``:206-207``).
 3. ``LlmMetaConfig.set_llm_config(model_config, training_args)``
-   （``cli/train/sft/workflow.py:283``）再来一遍，这次值取自 ``SFTConfig``
-   —— 而 ``SFTConfig`` 被 ``@llmmetaclass`` 装饰（``cli/train/sft/sft_config.py:28``），
-   llm_meta 的字段在它上面全是 dataclass field。**这一步 config.json 拦不住**。
+   (``cli/train/sft/workflow.py:283``) runs again, this time taking values from
+   ``SFTConfig`` -- and ``SFTConfig`` is decorated by ``@llmmetaclass``
+   (``cli/train/sft/sft_config.py:28``), so llm_meta fields on it are all dataclass
+   fields. **config.json cannot block this step.**
 
-因此下面这几个源侧取值与 llm_meta 默认值**不一致**的字段，
-必须同时写进 yaml，否则会被悄悄改掉：
+Therefore the following fields, whose intended values **differ** from llm_meta
+defaults, must also be written into the yaml, otherwise they get silently changed:
 
-| 字段 | 源侧 | llm_meta 默认 |
+| Field | Intended | llm_meta default |
 |---|---|---|
 | ``moe_expert_fusion`` | ``True`` | ``False`` |
 | ``router_aux_loss_coef`` | ``0.001`` | ``0.0`` |
-| ``fp32_residual_connection`` | ``False``（Megatron 默认，源侧没设） | ``True`` |
+| ``fp32_residual_connection`` | ``False`` | ``True`` |
 
-``yaml/hyperbody_decoder_*.yaml`` 里这三条都显式写了，别删。
+All three are explicitly written in ``yaml/hyperbody_decoder_*.yaml``; do not delete them.
 
-不属于 llm_meta、因此**本类说了算**的关键字段：``masked_softmax_fusion``、
-``bias_activation_fusion``、``bias_dropout_fusion``、``cross_entropy_loss_fusion``、
-``attention_softmax_in_fp32``、``calculate_per_token_loss``、``rms_norm_eps``、
-``rope_theta``、``rotary_percent``、``head_dim``、``moe_layer_freq``、
-``n_shared_experts``、``moe_intermediate_size``、``scoring_func``、``topk_method``、
-``norm_topk_prob``、``routed_scaling_factor``、``n_group``、``topk_group``、
-``use_cpu_initialization``、``use_accuracy_compatible``、``bf16``。
+Key fields that are NOT llm_meta and are therefore **owned by this class**:
+``masked_softmax_fusion``, ``bias_activation_fusion``, ``bias_dropout_fusion``,
+``cross_entropy_loss_fusion``, ``attention_softmax_in_fp32``,
+``calculate_per_token_loss``, ``rms_norm_eps``, ``rope_theta``, ``rotary_percent``,
+``head_dim``, ``moe_layer_freq``, ``n_shared_experts``, ``moe_intermediate_size``,
+``scoring_func``, ``topk_method``, ``norm_topk_prob``, ``routed_scaling_factor``,
+``n_group``, ``topk_group``, ``use_cpu_initialization``, ``use_accuracy_compatible``,
+``bf16``.
 """
 
 from __future__ import annotations
@@ -105,29 +94,29 @@ __all__ = [
     "check_hyperbody_decoder_divisibility",
 ]
 
-# 源侧 native_hyperbody_modality_submodules.py:41-46 的 special token。
-# decoder 侧只用到 CONTEXT_TOKEN：LLM 在 input_ids 里出现 <context> 的位置把
-# encoder 输出贴进 embedding 流（源侧 _build_model_specs :186-190）。
+# Special token: wherever <context> appears in input_ids, the LLM splices the
+# encoder output into the embedding stream. Only used in the full HyperBody
+# multimodal setup; unused when the decoder is trained standalone.
 CONTEXT_TOKEN = 128830
 
-HYPERBODY_DECODER_VOCAB_SIZE = 129280  # 源侧 :180 VOCAB_SIZE
-HYPERBODY_DECODER_HIDDEN_SIZE = 1280  # 源侧 :65
-HYPERBODY_DECODER_NUM_LAYERS = 12  # 源侧 :64
-HYPERBODY_DECODER_NUM_HEADS = 10  # 源侧 :66
-HYPERBODY_DECODER_FFN_HIDDEN = 6848  # 源侧 :71  只 layer 0 用
-HYPERBODY_DECODER_MOE_FFN_HIDDEN = 896  # 源侧 :97
-HYPERBODY_DECODER_NUM_MOE_EXPERTS = 64  # 源侧 :96
-HYPERBODY_DECODER_MOE_TOPK = 6  # 源侧 :98
-# 源侧 :99 给的是 moe_shared_expert_intermediate_size=1792，Paddle 侧用
-# n_shared_experts × moe_intermediate_size 表达：2 × 896 = 1792
+HYPERBODY_DECODER_VOCAB_SIZE = 129280
+HYPERBODY_DECODER_HIDDEN_SIZE = 1280
+HYPERBODY_DECODER_NUM_LAYERS = 12
+HYPERBODY_DECODER_NUM_HEADS = 10
+HYPERBODY_DECODER_FFN_HIDDEN = 6848  # dense FFN, layer 0 only
+HYPERBODY_DECODER_MOE_FFN_HIDDEN = 896
+HYPERBODY_DECODER_NUM_MOE_EXPERTS = 64
+HYPERBODY_DECODER_MOE_TOPK = 6
+# Shared-expert intermediate size 1792 is expressed as
+# n_shared_experts x moe_intermediate_size: 2 x 896 = 1792.
 HYPERBODY_DECODER_NUM_SHARED_EXPERTS = 2
 
 
 def build_moe_layer_freq(num_hidden_layers: int = HYPERBODY_DECODER_NUM_LAYERS) -> list[int]:
-    """逐层的 dense/MoE 0-1 表：``[0] + [1]*(L-1)``（源侧 ``:100``）。
+    """Per-layer dense/MoE 0-1 table: ``[0] + [1]*(L-1)`` (layer 0 dense, rest MoE).
 
-    ⚠️ 必须是 list。传 int 时 Paddle 走 ``i % N``（``gpt_layer_specs.py:803-807``），
-    Megatron 走另一套取模语义，两边必然错位 —— encoder 那份 config 也标了同一个坑。
+    WARNING: must be a list. Passing an int makes Paddle take ``i % N``
+    (``gpt_layer_specs.py:803-807``), which is not the intended per-layer semantics.
     """
     if num_hidden_layers < 1:
         raise ValueError(f"num_hidden_layers must be >= 1, got {num_hidden_layers}")
@@ -135,11 +124,11 @@ def build_moe_layer_freq(num_hidden_layers: int = HYPERBODY_DECODER_NUM_LAYERS) 
 
 
 def check_hyperbody_decoder_divisibility(config: "HyperBodyDecoderConfig") -> None:
-    """并行度可除性检查（照 encoder 那份 ``check_hyperencoder_divisibility``）。
+    """Parallelism divisibility check.
 
-    源侧自己不查（Megatron 在 ``TransformerConfig.__post_init__`` 里统一查），
-    这里提前查是为了在建模型**之前**报错，而不是等到某个 GEMM 形状对不上。
-    读 config 上的真实几何而不是模块常量 —— smoke 那份 config.json 是缩小几何。
+    Checked here early to fail **before** building the model, rather than waiting
+    until some GEMM shape does not line up. Reads the real geometry off config, not
+    the module constants -- a smoke config.json may use a shrunken geometry.
     """
     tp_size = max(getattr(config, "tensor_model_parallel_size", 1) or 1, 1)
     ep_size = max(getattr(config, "expert_model_parallel_size", 1) or 1, 1)
@@ -152,35 +141,35 @@ def check_hyperbody_decoder_divisibility(config: "HyperBodyDecoderConfig") -> No
 
 
 class HyperBodyDecoderConfig(PretrainedConfig):
-    r"""HyperBody 的 LLM 主干（DeepSeekV2-Lite MoE，12 层 / 64 experts / top-6）。
+    r"""HyperBody's LLM backbone (DeepSeekV2-Lite MoE, 12 layers / 64 experts / top-6).
 
-    默认值即源侧 ``_make_language_config`` 的取值，所以 ``config.json`` 只需要
-    ``{"model_type": "hyperbody_decoder", "architectures": [...]}`` 加上想改的字段。
+    ``config.json`` only needs ``{"model_type": "hyperbody_decoder", "architectures":
+    [...]}`` plus whatever fields you want to change from the defaults.
 
     Args:
-        moe_layer_freq: 逐层 dense/MoE 的 0-1 表。``None`` 时按
-            ``build_moe_layer_freq(num_hidden_layers)`` 生成 ``[0] + [1]*(L-1)``。
-            ⚠️ 传 int 会让 Paddle 走 ``i % N``（``gpt_layer_specs.py:803-807``），
-            与 Megatron 的取模语义不同，必然错位。
-        first_k_dense_replace: 只为了显式声明**必须是 ``None``** ——
-            ``TransformerConfig.__post_init__``（``:2275-2297``）在它与非 int 的
-            ``moe_layer_freq`` 同时给出时直接抛异常。
-        use_cpu_initialization: 源侧 ``:67`` 是 ``True``（Megatron 的 TP 不变初始化：
-            整张权重在 CPU 上建好再切），**这里刻意取 ``False``** —— 与 encoder
-            侧同一处取舍（``hyperencoder_fleet/CLAUDE.json`` 的
-            ``intentional_divergence``）。两个原因：
-            1. Paddle 的 cpu-init 路径在 bf16 下本身是坏的：
-               ``tensor_parallel/layers.py:1849`` 调
-               ``_initialize_affine_weight_cpu`` 时**没有转发 ``params_dtype``**，
-               master weight 停在该函数的 ``paddle.float32`` 默认值上，
-               到 ``:269`` 的 ``weight.copy_(cpu_weight)`` 就炸
-               ``dtype 16 != 10``（``VocabParallelEmbedding`` 那条路径转发了，
-               所以只有 Column/RowParallelLinear 触发）。
-            2. 反正对不上 torch 的 RNG，CPU 初始化换来的"TP 不变"对我们没有价值。
-            代价：必须在 fleet RNG tracker 就绪之后建模型 ——
-            分布式启动（``paddleformers-cli``）会做，裸脚本得自己先调
-            ``paddlefleet.tensor_parallel.random.model_parallel_cuda_manual_seed(seed)``，
-            否则报 ``cuda rng state model-parallel-rng is not added``。
+        moe_layer_freq: per-layer dense/MoE 0-1 table. When ``None``, generated by
+            ``build_moe_layer_freq(num_hidden_layers)`` as ``[0] + [1]*(L-1)``.
+            WARNING: passing an int makes Paddle take ``i % N``
+            (``gpt_layer_specs.py:803-807``), which is not the intended per-layer
+            semantics.
+        first_k_dense_replace: exists only to explicitly declare it **must be
+            ``None``** -- ``TransformerConfig.__post_init__`` (``:2275-2297``) raises
+            outright when it and a non-int ``moe_layer_freq`` are both given.
+        use_cpu_initialization: **deliberately ``False``**. Two reasons:
+            1. Paddle's cpu-init path is broken under bf16:
+               ``tensor_parallel/layers.py:1849`` calls
+               ``_initialize_affine_weight_cpu`` **without forwarding
+               ``params_dtype``**, so the master weight stays at that function's
+               ``paddle.float32`` default, and at ``:269`` the
+               ``weight.copy_(cpu_weight)`` blows up with ``dtype 16 != 10``
+               (``VocabParallelEmbedding``'s path forwards it, so only
+               Column/RowParallelLinear trigger it).
+            2. The "TP invariance" that CPU init buys is not needed here.
+            Cost: the model must be built after the fleet RNG tracker is ready --
+            distributed launch (``paddleformers-cli``) does this, but a bare script
+            must first call
+            ``paddlefleet.tensor_parallel.random.model_parallel_cuda_manual_seed(seed)``,
+            otherwise it reports ``cuda rng state model-parallel-rng is not added``.
     """
 
     model_type = "hyperbody_decoder"
@@ -188,7 +177,7 @@ class HyperBodyDecoderConfig(PretrainedConfig):
 
     def __init__(
         self,
-        # === 结构（源侧 :64-93）===
+        # === structure ===
         vocab_size: int = HYPERBODY_DECODER_VOCAB_SIZE,
         hidden_size: int = HYPERBODY_DECODER_HIDDEN_SIZE,
         num_hidden_layers: int = HYPERBODY_DECODER_NUM_LAYERS,
@@ -204,17 +193,17 @@ class HyperBodyDecoderConfig(PretrainedConfig):
         rms_norm_eps: float = 1e-6,
         initializer_range: float = 0.02,
         use_cache: bool = True,
-        # === 位置编码（源侧 :80-86）===
+        # === position embedding ===
         position_embedding_type: str = "rope",
         rope_theta: float = 10000,
         rotary_percent: float = 1.0,
         max_position_embeddings: int = 8192,
-        # === dropout / bias（源侧 :89-92）===
+        # === dropout / bias ===
         attention_dropout: float = 0.0,
         hidden_dropout_prob: float = 0.0,
         use_bias: bool = False,
         attention_bias: bool = False,
-        # === MoE（源侧 :96-116）===
+        # === MoE ===
         n_routed_experts: int = HYPERBODY_DECODER_NUM_MOE_EXPERTS,
         moe_intermediate_size: int = HYPERBODY_DECODER_MOE_FFN_HIDDEN,
         num_experts_per_tok: int = HYPERBODY_DECODER_MOE_TOPK,
@@ -233,22 +222,22 @@ class HyperBodyDecoderConfig(PretrainedConfig):
         moe_shared_expert_overlap: bool = True,
         routed_scaling_factor: float = 1.0,
         routed_scaling_factor_learnable: bool = False,
-        # === dtype / 数值（源侧 :119-125）===
+        # === dtype / numerics ===
         bf16: bool = True,
         attention_softmax_in_fp32: bool = False,
         fp32_residual_connection: bool = False,
         variable_seq_lengths: bool = True,
         calculate_per_token_loss: bool = False,
-        # === 融合开关（源侧 :128-133）===
+        # === fusion switches ===
         bias_activation_fusion: bool = True,
         masked_softmax_fusion: bool = True,
         bias_dropout_fusion: bool = True,
         apply_rope_fusion: bool = False,
         cross_entropy_loss_fusion: bool = False,
-        # === 初始化 ===
+        # === initialization ===
         use_cpu_initialization: bool = False,
         use_accuracy_compatible: bool = False,
-        # === 并行（运行期由 yaml 覆盖）===
+        # === parallelism (overridden at runtime by yaml) ===
         tensor_model_parallel_size: int = 1,
         pipeline_model_parallel_size: int = 1,
         virtual_pipeline_model_parallel_size: int = 1,
@@ -256,17 +245,17 @@ class HyperBodyDecoderConfig(PretrainedConfig):
         context_parallel_size: int = 1,
         sequence_parallel: bool = False,
         pp_seg_method: str = "layer:TransformerLayer|EmptyLayer",
-        # === 其它 ===
+        # === misc ===
         tie_word_embeddings: bool = False,
         hyperbody_context_token_id: int = CONTEXT_TOKEN,
         **kwargs,
     ):
-        # ---- 结构 ----
+        # ---- structure ----
         self.vocab_size = vocab_size
         self.hidden_size = hidden_size
         self.num_hidden_layers = num_hidden_layers
         self.num_attention_heads = num_attention_heads
-        # 源侧 :91 num_query_groups=10 == num_attention_heads ⇒ 纯 MHA，不是 GQA
+        # num_key_value_heads == num_attention_heads => pure MHA, not GQA
         self.num_key_value_heads = num_key_value_heads if num_key_value_heads is not None else num_attention_heads
         self.head_dim = head_dim if head_dim is not None else hidden_size // num_attention_heads
         self.intermediate_size = intermediate_size
@@ -275,12 +264,12 @@ class HyperBodyDecoderConfig(PretrainedConfig):
         self.initializer_range = initializer_range
         self.use_cache = use_cache
 
-        # ---- 位置编码 ----
+        # ---- position embedding ----
         self.rope_theta = rope_theta
         self.rotary_percent = rotary_percent
-        # 源侧 :85-86 把 seq_length 与 max_position_embeddings 设成同一个值。
-        # 走 CLI 时这三个都会被 data_args.max_seq_len 覆盖
-        # （cli/train/sft/workflow.py:338-339）。
+        # seq_length and max_position_embeddings share the same value. On the CLI
+        # path all three get overwritten by data_args.max_seq_len
+        # (cli/train/sft/workflow.py:338-339).
         self.max_position_embeddings = max_position_embeddings
         self.max_sequence_length = max_position_embeddings
         self.seq_length = max_position_embeddings
@@ -302,36 +291,37 @@ class HyperBodyDecoderConfig(PretrainedConfig):
         self.first_k_dense_replace = first_k_dense_replace
         self.n_group = n_group
         self.topk_group = topk_group
-        # :112 moe_router_pre_softmax=True 无对应字段 —— 下面三条即等价
+        # pre-softmax routing expressed via the three fields below
         self.scoring_func = scoring_func
         self.topk_method = topk_method
         self.norm_topk_prob = norm_topk_prob
         self.routed_scaling_factor = routed_scaling_factor
         self.routed_scaling_factor_learnable = routed_scaling_factor_learnable
 
-        # ---- dtype / 数值 ----
+        # ---- dtype / numerics ----
         self.bf16 = bf16
         self.attention_softmax_in_fp32 = attention_softmax_in_fp32
         self.variable_seq_lengths = variable_seq_lengths
         self.calculate_per_token_loss = calculate_per_token_loss
 
-        # ---- 融合开关（都不属于 llm_meta，本类说了算）----
+        # ---- fusion switches (none belong to llm_meta, so this class owns them) ----
         self.bias_activation_fusion = bias_activation_fusion
         self.masked_softmax_fusion = masked_softmax_fusion
         self.bias_dropout_fusion = bias_dropout_fusion
         self.cross_entropy_loss_fusion = cross_entropy_loss_fusion
 
-        # ---- 初始化 ----
+        # ---- initialization ----
         self.use_cpu_initialization = use_cpu_initialization
         self.use_accuracy_compatible = use_accuracy_compatible
 
         self.pp_seg_method = pp_seg_method
-        # HyperBody 专属：LLM 在 <context> 位置把 encoder 输出贴进 embedding 流
-        # （源侧 megatron_mimo_training_hyperbody.py:186-190）。decoder 单独训练时不用。
+        # HyperBody-specific: the LLM splices the encoder output into the embedding
+        # stream at the <context> position. Not used when the decoder is trained
+        # standalone.
         self.hyperbody_context_token_id = hyperbody_context_token_id
 
-        # ⚠️ 下面这些都属于 LlmMetaConfig，必须走 kwargs 才不会被
-        # set_expected_keys 打回默认值（见模块 docstring 第 2 步）。
+        # WARNING: the following all belong to LlmMetaConfig and must go through kwargs
+        # so they are not reset to defaults by set_expected_keys (see module docstring step 2).
         super().__init__(
             tie_word_embeddings=tie_word_embeddings,
             multi_latent_attention=multi_latent_attention,

--- a/paddleformers/transformers/hyperbody_decoder/configuration.py
+++ b/paddleformers/transformers/hyperbody_decoder/configuration.py
@@ -1,0 +1,356 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HyperBody decoder 的 HF-style config —— **几何与数值开关的单一真源**。
+
+## 分工（与参考实现 ``fleet_formers`` 的 hyperencoder 同构）
+
+| 侧 | 职责 |
+|---|---|
+| **本文件（PaddleFormers）** | 几何常量 + ``HyperBodyDecoderConfig``：``config.json`` 的落地形状，喂 ``AutoConfig`` / ``AutoModelForCausalLM`` |
+| ``modeling.py``（PaddleFormers） | HF-style config → ``GPTConfig`` 的转换（``HyperBodyDecoderModelProvider``）+ 组网装配 |
+| ``paddlefleet.models.hyperbody_decoder`` | 只提供组件：12 层 backbone 的 ``LayerSpec`` 列表 |
+
+Megatron 侧的真源是 ``_make_language_config``
+（``hyperbody/megatron_bridge_patch/recipes/hyperbody/hyperbody.py:61-147``）
+以及紧随其后的 ``_build_model_specs``（提供 ``vocab_size``）。
+下面每个字段都标了对应的源侧行号。
+
+参考实现把 ``build_hyperencoder_config() -> GPTConfig`` 放在
+``transformers/hyperencoder/configuration.py``，即「HF-style → GPTConfig」这件事
+归 formers。decoder 走 ``paddleformers-cli``，这条转换由
+``AutoConfig`` → 本类 → ``HyperBodyDecoderModelProvider.from_config`` 完成，
+落点同样在 formers；fleet 侧因此**不再有** ``decoder_config.py``。
+
+## 源侧有、Paddle 侧无对应字段的四项
+
+* ``persist_layer_norm=True`` —— Paddle 的 norm 没有这个开关。
+* ``moe_router_dtype="fp32"`` —— Paddle 侧 router 已强制 fp32（前提是不开
+  ``use_accuracy_compatible``）。
+* ``moe_router_pre_softmax=True`` —— Paddle 路由天生 pre-softmax，配
+  ``scoring_func="softmax"`` + ``topk_method="greedy"`` + ``norm_topk_prob=False``
+  即等价。
+* ``attention_backend=AttnBackend.flash`` —— Paddle 侧对应 ``_attn_implementation``。
+
+## 三处 decoder 与 encoder 真实不同（不是笔误）
+
+* ``moe_expert_fusion=True``（源侧 ``moe_grouped_gemm=True``），encoder 是 ``False``。
+* ``masked_softmax_fusion=True``，encoder 是 ``False``。
+* 因果 vs 双向：decoder 不需要 encoder 那套 ``AttnMaskType.no_mask``
+  + ``_attn_implementation="eager"`` 的绕行。
+
+## ⚠️ 哪些字段会被 CLI 覆盖掉（写 yaml 时必须知道）
+
+``paddleformers-cli`` 的链路是：
+
+1. ``AutoConfig.from_pretrained`` → 走本类 ``__init__``；
+2. ``PretrainedConfig.__init__`` 里的 ``set_expected_keys``（``configuration_utils.py:889``）
+   把 ``LlmMetaConfig._get_init()`` 的**每一个** key 按它自己的默认值写到 config 上 ——
+   所以本类 ``__init__`` 里先 ``self.x = ...`` 再 ``super().__init__()`` 的字段，
+   凡属于 llm_meta 的都会被打回默认值。**对策：塞进 ``super().__init__(**)`` 的 kwargs**，
+   ``set_expected_keys`` 会优先取 kwargs（``:206-207``）。
+3. ``LlmMetaConfig.set_llm_config(model_config, training_args)``
+   （``cli/train/sft/workflow.py:283``）再来一遍，这次值取自 ``SFTConfig``
+   —— 而 ``SFTConfig`` 被 ``@llmmetaclass`` 装饰（``cli/train/sft/sft_config.py:28``），
+   llm_meta 的字段在它上面全是 dataclass field。**这一步 config.json 拦不住**。
+
+因此下面这几个源侧取值与 llm_meta 默认值**不一致**的字段，
+必须同时写进 yaml，否则会被悄悄改掉：
+
+| 字段 | 源侧 | llm_meta 默认 |
+|---|---|---|
+| ``moe_expert_fusion`` | ``True`` | ``False`` |
+| ``router_aux_loss_coef`` | ``0.001`` | ``0.0`` |
+| ``fp32_residual_connection`` | ``False``（Megatron 默认，源侧没设） | ``True`` |
+
+``yaml/hyperbody_decoder_*.yaml`` 里这三条都显式写了，别删。
+
+不属于 llm_meta、因此**本类说了算**的关键字段：``masked_softmax_fusion``、
+``bias_activation_fusion``、``bias_dropout_fusion``、``cross_entropy_loss_fusion``、
+``attention_softmax_in_fp32``、``calculate_per_token_loss``、``rms_norm_eps``、
+``rope_theta``、``rotary_percent``、``head_dim``、``moe_layer_freq``、
+``n_shared_experts``、``moe_intermediate_size``、``scoring_func``、``topk_method``、
+``norm_topk_prob``、``routed_scaling_factor``、``n_group``、``topk_group``、
+``use_cpu_initialization``、``use_accuracy_compatible``、``bf16``。
+"""
+
+from __future__ import annotations
+
+from ..configuration_utils import PretrainedConfig
+
+__all__ = [
+    "HyperBodyDecoderConfig",
+    "CONTEXT_TOKEN",
+    "HYPERBODY_DECODER_VOCAB_SIZE",
+    "HYPERBODY_DECODER_HIDDEN_SIZE",
+    "HYPERBODY_DECODER_NUM_LAYERS",
+    "HYPERBODY_DECODER_NUM_HEADS",
+    "HYPERBODY_DECODER_FFN_HIDDEN",
+    "HYPERBODY_DECODER_MOE_FFN_HIDDEN",
+    "HYPERBODY_DECODER_NUM_MOE_EXPERTS",
+    "HYPERBODY_DECODER_MOE_TOPK",
+    "HYPERBODY_DECODER_NUM_SHARED_EXPERTS",
+    "build_moe_layer_freq",
+    "check_hyperbody_decoder_divisibility",
+]
+
+# 源侧 native_hyperbody_modality_submodules.py:41-46 的 special token。
+# decoder 侧只用到 CONTEXT_TOKEN：LLM 在 input_ids 里出现 <context> 的位置把
+# encoder 输出贴进 embedding 流（源侧 _build_model_specs :186-190）。
+CONTEXT_TOKEN = 128830
+
+HYPERBODY_DECODER_VOCAB_SIZE = 129280  # 源侧 :180 VOCAB_SIZE
+HYPERBODY_DECODER_HIDDEN_SIZE = 1280  # 源侧 :65
+HYPERBODY_DECODER_NUM_LAYERS = 12  # 源侧 :64
+HYPERBODY_DECODER_NUM_HEADS = 10  # 源侧 :66
+HYPERBODY_DECODER_FFN_HIDDEN = 6848  # 源侧 :71  只 layer 0 用
+HYPERBODY_DECODER_MOE_FFN_HIDDEN = 896  # 源侧 :97
+HYPERBODY_DECODER_NUM_MOE_EXPERTS = 64  # 源侧 :96
+HYPERBODY_DECODER_MOE_TOPK = 6  # 源侧 :98
+# 源侧 :99 给的是 moe_shared_expert_intermediate_size=1792，Paddle 侧用
+# n_shared_experts × moe_intermediate_size 表达：2 × 896 = 1792
+HYPERBODY_DECODER_NUM_SHARED_EXPERTS = 2
+
+
+def build_moe_layer_freq(num_hidden_layers: int = HYPERBODY_DECODER_NUM_LAYERS) -> list[int]:
+    """逐层的 dense/MoE 0-1 表：``[0] + [1]*(L-1)``（源侧 ``:100``）。
+
+    ⚠️ 必须是 list。传 int 时 Paddle 走 ``i % N``（``gpt_layer_specs.py:803-807``），
+    Megatron 走另一套取模语义，两边必然错位 —— encoder 那份 config 也标了同一个坑。
+    """
+    if num_hidden_layers < 1:
+        raise ValueError(f"num_hidden_layers must be >= 1, got {num_hidden_layers}")
+    return [0] + [1] * (num_hidden_layers - 1)
+
+
+def check_hyperbody_decoder_divisibility(config: "HyperBodyDecoderConfig") -> None:
+    """并行度可除性检查（照 encoder 那份 ``check_hyperencoder_divisibility``）。
+
+    源侧自己不查（Megatron 在 ``TransformerConfig.__post_init__`` 里统一查），
+    这里提前查是为了在建模型**之前**报错，而不是等到某个 GEMM 形状对不上。
+    读 config 上的真实几何而不是模块常量 —— smoke 那份 config.json 是缩小几何。
+    """
+    tp_size = max(getattr(config, "tensor_model_parallel_size", 1) or 1, 1)
+    ep_size = max(getattr(config, "expert_model_parallel_size", 1) or 1, 1)
+    for name in ("hidden_size", "num_attention_heads", "intermediate_size", "moe_intermediate_size"):
+        value = getattr(config, name)
+        if value % tp_size != 0:
+            raise ValueError(f"decoder {name}={value} must be divisible by TP={tp_size}")
+    if config.n_routed_experts % ep_size != 0:
+        raise ValueError(f"decoder n_routed_experts={config.n_routed_experts} must be divisible by EP={ep_size}")
+
+
+class HyperBodyDecoderConfig(PretrainedConfig):
+    r"""HyperBody 的 LLM 主干（DeepSeekV2-Lite MoE，12 层 / 64 experts / top-6）。
+
+    默认值即源侧 ``_make_language_config`` 的取值，所以 ``config.json`` 只需要
+    ``{"model_type": "hyperbody_decoder", "architectures": [...]}`` 加上想改的字段。
+
+    Args:
+        moe_layer_freq: 逐层 dense/MoE 的 0-1 表。``None`` 时按
+            ``build_moe_layer_freq(num_hidden_layers)`` 生成 ``[0] + [1]*(L-1)``。
+            ⚠️ 传 int 会让 Paddle 走 ``i % N``（``gpt_layer_specs.py:803-807``），
+            与 Megatron 的取模语义不同，必然错位。
+        first_k_dense_replace: 只为了显式声明**必须是 ``None``** ——
+            ``TransformerConfig.__post_init__``（``:2275-2297``）在它与非 int 的
+            ``moe_layer_freq`` 同时给出时直接抛异常。
+        use_cpu_initialization: 源侧 ``:67`` 是 ``True``（Megatron 的 TP 不变初始化：
+            整张权重在 CPU 上建好再切），**这里刻意取 ``False``** —— 与 encoder
+            侧同一处取舍（``hyperencoder_fleet/CLAUDE.json`` 的
+            ``intentional_divergence``）。两个原因：
+            1. Paddle 的 cpu-init 路径在 bf16 下本身是坏的：
+               ``tensor_parallel/layers.py:1849`` 调
+               ``_initialize_affine_weight_cpu`` 时**没有转发 ``params_dtype``**，
+               master weight 停在该函数的 ``paddle.float32`` 默认值上，
+               到 ``:269`` 的 ``weight.copy_(cpu_weight)`` 就炸
+               ``dtype 16 != 10``（``VocabParallelEmbedding`` 那条路径转发了，
+               所以只有 Column/RowParallelLinear 触发）。
+            2. 反正对不上 torch 的 RNG，CPU 初始化换来的"TP 不变"对我们没有价值。
+            代价：必须在 fleet RNG tracker 就绪之后建模型 ——
+            分布式启动（``paddleformers-cli``）会做，裸脚本得自己先调
+            ``paddlefleet.tensor_parallel.random.model_parallel_cuda_manual_seed(seed)``，
+            否则报 ``cuda rng state model-parallel-rng is not added``。
+    """
+
+    model_type = "hyperbody_decoder"
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        # === 结构（源侧 :64-93）===
+        vocab_size: int = HYPERBODY_DECODER_VOCAB_SIZE,
+        hidden_size: int = HYPERBODY_DECODER_HIDDEN_SIZE,
+        num_hidden_layers: int = HYPERBODY_DECODER_NUM_LAYERS,
+        num_attention_heads: int = HYPERBODY_DECODER_NUM_HEADS,
+        num_key_value_heads: int | None = None,
+        head_dim: int | None = None,
+        intermediate_size: int = HYPERBODY_DECODER_FFN_HIDDEN,
+        hidden_act: str = "silu",
+        gated_linear_unit: bool = True,
+        multi_latent_attention: bool = False,
+        use_qk_norm: bool = False,
+        normalization: str = "RMSNorm",
+        rms_norm_eps: float = 1e-6,
+        initializer_range: float = 0.02,
+        use_cache: bool = True,
+        # === 位置编码（源侧 :80-86）===
+        position_embedding_type: str = "rope",
+        rope_theta: float = 10000,
+        rotary_percent: float = 1.0,
+        max_position_embeddings: int = 8192,
+        # === dropout / bias（源侧 :89-92）===
+        attention_dropout: float = 0.0,
+        hidden_dropout_prob: float = 0.0,
+        use_bias: bool = False,
+        attention_bias: bool = False,
+        # === MoE（源侧 :96-116）===
+        n_routed_experts: int = HYPERBODY_DECODER_NUM_MOE_EXPERTS,
+        moe_intermediate_size: int = HYPERBODY_DECODER_MOE_FFN_HIDDEN,
+        num_experts_per_tok: int = HYPERBODY_DECODER_MOE_TOPK,
+        n_shared_experts: int = HYPERBODY_DECODER_NUM_SHARED_EXPERTS,
+        moe_layer_freq: list[int] | None = None,
+        first_k_dense_replace: None = None,
+        moe_token_dispatcher_type: str = "alltoall",
+        moe_expert_fusion: bool = True,
+        n_group: int = 1,
+        topk_group: int = 1,
+        router_aux_loss_coef: float = 0.001,
+        scoring_func: str = "softmax",
+        topk_method: str = "greedy",
+        norm_topk_prob: bool = False,
+        moe_router_load_balancing_type: str = "seq_aux_loss",
+        moe_shared_expert_overlap: bool = True,
+        routed_scaling_factor: float = 1.0,
+        routed_scaling_factor_learnable: bool = False,
+        # === dtype / 数值（源侧 :119-125）===
+        bf16: bool = True,
+        attention_softmax_in_fp32: bool = False,
+        fp32_residual_connection: bool = False,
+        variable_seq_lengths: bool = True,
+        calculate_per_token_loss: bool = False,
+        # === 融合开关（源侧 :128-133）===
+        bias_activation_fusion: bool = True,
+        masked_softmax_fusion: bool = True,
+        bias_dropout_fusion: bool = True,
+        apply_rope_fusion: bool = False,
+        cross_entropy_loss_fusion: bool = False,
+        # === 初始化 ===
+        use_cpu_initialization: bool = False,
+        use_accuracy_compatible: bool = False,
+        # === 并行（运行期由 yaml 覆盖）===
+        tensor_model_parallel_size: int = 1,
+        pipeline_model_parallel_size: int = 1,
+        virtual_pipeline_model_parallel_size: int = 1,
+        expert_model_parallel_size: int = 1,
+        context_parallel_size: int = 1,
+        sequence_parallel: bool = False,
+        pp_seg_method: str = "layer:TransformerLayer|EmptyLayer",
+        # === 其它 ===
+        tie_word_embeddings: bool = False,
+        hyperbody_context_token_id: int = CONTEXT_TOKEN,
+        **kwargs,
+    ):
+        # ---- 结构 ----
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        # 源侧 :91 num_query_groups=10 == num_attention_heads ⇒ 纯 MHA，不是 GQA
+        self.num_key_value_heads = num_key_value_heads if num_key_value_heads is not None else num_attention_heads
+        self.head_dim = head_dim if head_dim is not None else hidden_size // num_attention_heads
+        self.intermediate_size = intermediate_size
+        self.hidden_act = hidden_act
+        self.rms_norm_eps = rms_norm_eps
+        self.initializer_range = initializer_range
+        self.use_cache = use_cache
+
+        # ---- 位置编码 ----
+        self.rope_theta = rope_theta
+        self.rotary_percent = rotary_percent
+        # 源侧 :85-86 把 seq_length 与 max_position_embeddings 设成同一个值。
+        # 走 CLI 时这三个都会被 data_args.max_seq_len 覆盖
+        # （cli/train/sft/workflow.py:338-339）。
+        self.max_position_embeddings = max_position_embeddings
+        self.max_sequence_length = max_position_embeddings
+        self.seq_length = max_position_embeddings
+
+        # ---- dropout / bias ----
+        self.attention_dropout = attention_dropout
+        self.hidden_dropout_prob = hidden_dropout_prob
+        self.use_bias = use_bias
+        self.attention_bias = attention_bias
+
+        # ---- MoE ----
+        self.n_routed_experts = n_routed_experts
+        self.moe_intermediate_size = moe_intermediate_size
+        self.num_experts_per_tok = num_experts_per_tok
+        self.n_shared_experts = n_shared_experts
+        self.moe_layer_freq = (
+            build_moe_layer_freq(num_hidden_layers) if moe_layer_freq is None else list(moe_layer_freq)
+        )
+        self.first_k_dense_replace = first_k_dense_replace
+        self.n_group = n_group
+        self.topk_group = topk_group
+        # :112 moe_router_pre_softmax=True 无对应字段 —— 下面三条即等价
+        self.scoring_func = scoring_func
+        self.topk_method = topk_method
+        self.norm_topk_prob = norm_topk_prob
+        self.routed_scaling_factor = routed_scaling_factor
+        self.routed_scaling_factor_learnable = routed_scaling_factor_learnable
+
+        # ---- dtype / 数值 ----
+        self.bf16 = bf16
+        self.attention_softmax_in_fp32 = attention_softmax_in_fp32
+        self.variable_seq_lengths = variable_seq_lengths
+        self.calculate_per_token_loss = calculate_per_token_loss
+
+        # ---- 融合开关（都不属于 llm_meta，本类说了算）----
+        self.bias_activation_fusion = bias_activation_fusion
+        self.masked_softmax_fusion = masked_softmax_fusion
+        self.bias_dropout_fusion = bias_dropout_fusion
+        self.cross_entropy_loss_fusion = cross_entropy_loss_fusion
+
+        # ---- 初始化 ----
+        self.use_cpu_initialization = use_cpu_initialization
+        self.use_accuracy_compatible = use_accuracy_compatible
+
+        self.pp_seg_method = pp_seg_method
+        # HyperBody 专属：LLM 在 <context> 位置把 encoder 输出贴进 embedding 流
+        # （源侧 megatron_mimo_training_hyperbody.py:186-190）。decoder 单独训练时不用。
+        self.hyperbody_context_token_id = hyperbody_context_token_id
+
+        # ⚠️ 下面这些都属于 LlmMetaConfig，必须走 kwargs 才不会被
+        # set_expected_keys 打回默认值（见模块 docstring 第 2 步）。
+        super().__init__(
+            tie_word_embeddings=tie_word_embeddings,
+            multi_latent_attention=multi_latent_attention,
+            use_qk_norm=use_qk_norm,
+            normalization=normalization,
+            gated_linear_unit=gated_linear_unit,
+            position_embedding_type=position_embedding_type,
+            fp32_residual_connection=fp32_residual_connection,
+            apply_rope_fusion=apply_rope_fusion,
+            moe_token_dispatcher_type=moe_token_dispatcher_type,
+            moe_expert_fusion=moe_expert_fusion,
+            moe_router_load_balancing_type=moe_router_load_balancing_type,
+            moe_shared_expert_overlap=moe_shared_expert_overlap,
+            router_aux_loss_coef=router_aux_loss_coef,
+            tensor_model_parallel_size=tensor_model_parallel_size,
+            pipeline_model_parallel_size=pipeline_model_parallel_size,
+            virtual_pipeline_model_parallel_size=virtual_pipeline_model_parallel_size,
+            expert_model_parallel_size=expert_model_parallel_size,
+            context_parallel_size=context_parallel_size,
+            sequence_parallel=sequence_parallel,
+            **kwargs,
+        )

--- a/paddleformers/transformers/hyperbody_decoder/modeling.py
+++ b/paddleformers/transformers/hyperbody_decoder/modeling.py
@@ -1,0 +1,398 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""HyperBody decoder 的「HF-style config → ``GPTConfig``」转换 + 组网装配。
+
+## 职责划分
+
+照参考实现 ``fleet_formers`` 的 hyperencoder 摆：
+
+| 侧 | 内容 |
+|---|---|
+| ``paddlefleet.models.hyperbody_decoder`` | **组件**：``get_hyperbody_decoder_layer_specs`` |
+| ``configuration.py``（本包） | 几何常量 + ``HyperBodyDecoderConfig``（HF-style config 真源） |
+| **本文件** | ① HF-style config → ``GPTConfig``（:class:`HyperBodyDecoderModelProvider`）② 组网装配（:func:`build_hyperbody_decoder_model`） |
+
+参考实现里 ``HyperEncoderBlock(TransformerBlock)`` / ``HyperEncoderModel``
+也都在 formers 侧，fleet 侧只留 ``layer_specs.py`` + ``modality_encoders.py``。
+
+## 为什么组网要自己写一遍，而不是直接用 ``gpt_builder``
+
+``paddlefleet.gpt_builders.gpt_builder`` 在 ``n_routed_experts`` 非空时会自己去调
+``get_gpt_decoder_layers_spec``，**没有任何注入 layer spec 的口子**。要让「fleet 出
+组件、formers 做装配」这条分工成立，就得由本文件直接调
+``get_gpt_spec`` + ``build_spec_layer``，把 fleet 那份 spec 喂进去。
+
+:func:`build_hyperbody_decoder_model` 是 ``gpt_builder`` 的窄化版本：只保留
+HyperBody decoder 真正用到的路径（embedding + N 层 backbone + norm + lm_head +
+LanguageLoss），其余分支（MTP、head/tail EmptyLayer、``separate_mtp_headloss``、
+ringmoe 子组、meta-device 初始化）一律**显式拒绝**而不是静默跳过 —— 源侧
+``_build_model_specs`` 一个都没用，静默跳过只会在将来打开某个开关时错得无声。
+
+## ``__new__`` 而不是 ``__init__``
+
+``AutoModelForCausalLM.from_config`` 走 ``model_utils.py:1349-1368`` 的
+``with dtype_guard(dtype): model = cls(config)``，而我们要返回的是 fleet 的
+``GPTModel``（一个 ``PipelineLayer``），不是本类的实例。仓里所有 fleet 模型都用
+``__new__`` 返回别的对象（``kimi_k2``、``deepseek_v4``、``glm4_moe``），照办。
+
+## ``_gen_aoa_config`` 为什么绕不过去
+
+aoa 表面上只服务 **HF 格式互转**，常规 flex_checkpoint 存档根本不碰它。但
+**CLI 训完必经一次 HF 导出**：``cli/train/sft/workflow.py:793`` 把
+``last_fc_to_hf=True`` 写死了，没有 yaml 开关，缺 aoa 就在训练全部跑完之后抛
+``RuntimeError: ... must implement either the _gen_inv_aoa_config ...``。
+
+只写正向（HF → fleet）一张：``model_utils.py:3286-3289`` 会自己加
+``aoa_config_reverse=True`` 反推导出保存方向。右侧的 fleet 结构化名不是猜的，
+是从真存档 metadata 里读出来的：
+``python scripts/dump_ckpt_keys.py <ckpt>/model_state/0.metadata``。
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from paddle.distributed.fleet.meta_parallel import build_spec_layer
+from paddlefleet.models.common.language_loss.language_loss import LanguageLoss
+from paddlefleet.models.gpt.gpt_layer_specs import get_gpt_spec
+from paddlefleet.models.hyperbody_decoder import get_hyperbody_decoder_layer_specs
+
+from ...nn.pp_model import CriterionLayerPipe, GeneralModelForCausalLMPipe
+from ..gpt_provider import GPTModel, GPTModelProvider
+from ..model_utils import PretrainedModel
+from .configuration import HyperBodyDecoderConfig, check_hyperbody_decoder_divisibility
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "HyperBodyDecoderForCausalLM",
+    "HyperBodyDecoderForCausalLMPipe",
+    "HyperBodyDecoderModelProvider",
+    "build_hyperbody_decoder_model",
+]
+
+
+def build_hyperbody_decoder_model(config, *, num_stages: int, loss_fn=None):
+    """组网：fleet 的 layer spec → ``get_gpt_spec`` → ``build_spec_layer``。
+
+    这是 ``paddlefleet.gpt_builders.gpt_builder`` 的窄化版本。参数 ``config``
+    是已经转好的 ``GPTConfig``（即 :class:`HyperBodyDecoderModelProvider` 自己）。
+
+    Args:
+        num_stages: pipeline 段数，等于 ``pipeline_model_parallel_size``。
+        loss_fn: 为空时用 ``LanguageLoss(config)``（与 ``gpt_builder`` 一致）。
+    """
+    # 源侧 _build_model_specs 用不到这些分支；静默跳过会在将来某天错得无声。
+    if getattr(config, "mtp_num_layers", None):
+        raise NotImplementedError("HyperBody decoder 没有 MTP 层（源侧未启用）。")
+    if getattr(config, "separate_mtp_headloss", False):
+        raise NotImplementedError("HyperBody decoder 不用 separate_mtp_headloss。")
+    if config.num_empty_layers_add_in_head or config.num_empty_layers_add_in_tail:
+        raise NotImplementedError("HyperBody decoder 不插 EmptyLayer（pp 切分靠 seg_method）。")
+    if getattr(config, "moe_token_dispatcher_type", None) == "ringmoe":
+        raise NotImplementedError("ringmoe 需要 world 级子组初始化，本模型未支持。")
+    if getattr(config, "init_model_with_meta_device", False):
+        raise NotImplementedError("HyperBody decoder 不走 meta-device 初始化。")
+
+    gpt_spec = get_gpt_spec(
+        config=config,
+        head_empty_layers_spec=[],
+        # ★ 唯一与 gpt_builder 不同的一行：spec 来自 fleet 的 hyperbody_decoder 组件。
+        transformer_layers_spec=get_hyperbody_decoder_layer_specs(config),
+        tail_empty_layers_spec=[],
+        mtp_layers_spec=None,
+        vocab_size=config.vocab_size,
+        tie_word_embeddings=config.tie_word_embeddings,
+        max_sequence_length=config.max_sequence_length,
+        position_embedding_type=config.position_embedding_type,
+        rotary_percent=config.rotary_percent,
+        rotary_base=config.rope_theta,
+        swa_rotary_base=config.swa_rope_theta,
+        rope_scaling=config.rope_scaling,
+        parallel_output=config.parallel_output,
+    )
+    return build_spec_layer(
+        gpt_spec,
+        loss_fn=LanguageLoss(config) if loss_fn is None else loss_fn,
+        num_stages=num_stages,
+        # 与 GPTModelProvider.provide() 同一个切分口径。
+        seg_method="layer:TransformerLayer|EmptyLayer",
+    )
+
+
+@dataclass
+class HyperBodyDecoderModelProvider(GPTModelProvider):
+    """HF-style config → ``GPTConfig`` 的落点（``GPTModelProvider`` 本身就是 ``GPTConfig``）。
+
+    这里只列**必须钉死**的开关。几何（层数 / hidden / experts / topk …）与其余数值
+    一律由 :class:`HyperBodyDecoderConfig` 通过 ``TransformerConfig.register_attributes``
+    灌进来，不在本类重复声明 —— 重复声明会制造第二个真源，而真源在
+    ``configuration.py``。
+
+    ⚠️ ``from_config`` 走的是 ``object.__new__`` + ``register_attributes``
+    （``transformer_config.py:1942-1948``），**不执行 dataclass 的 ``__init__``**。
+    下面这些默认值之所以仍然生效，是因为无 ``default_factory`` 的 dataclass
+    字段就是类属性，实例属性缺失时属性查找会落到类上。所以别把它们改成
+    ``field(default_factory=...)``。
+    """
+
+    # ---- 注意力：MLA 全关，纯 MHA（源侧没设 ⇒ mcore 默认，Paddle 必须显式关）----
+    multi_latent_attention: bool = False
+    use_qk_norm: bool = False
+
+    # ---- 位置编码：普通 RoPE，无任何 scaling（源侧 :80-86 只给了 rotary_base=10000）----
+    # ⚠️ 必须显式写回 None：``GPTConfig`` 把继承来的 ``rope_scaling: dict = None``
+    # 覆盖成了 ``float = 1.0``（``gpt_config.py:32`` vs ``transformer_config.py:485``），
+    # 而 ``gpt_provider.py:210`` 只判 ``is not None``，于是 ``1.0`` 会掉进
+    # ``:211`` 的 ``"mscale_all_dim" in self.rope_scaling`` 炸成
+    # ``TypeError: argument of type 'float' is not iterable``。
+    # 别的 fleet 模型躲过这一枪，是因为它们的 config.json 本来就带 rope_scaling dict。
+    rope_scaling: dict = None
+
+    # ---- FFN / norm（源侧 :73、:76）----
+    gated_linear_unit: bool = True
+    normalization: str = "RMSNorm"
+
+    # ---- MoE（源侧 :103、:113、:114）----
+    moe_token_dispatcher_type: str = "alltoall"
+    moe_router_load_balancing_type: str = "seq_aux_loss"
+    moe_shared_expert_overlap: bool = True
+
+    # ---- 融合开关（源侧 :128-133）----
+    bias_activation_fusion: bool = True
+    masked_softmax_fusion: bool = True  # ⚠️ 与 encoder 的 False 不同
+    bias_dropout_fusion: bool = True
+    apply_rope_fusion: bool = False
+    cross_entropy_loss_fusion: bool = False
+
+    # ---- 其它 ----
+    # 源侧 :93 untie_embeddings_and_output_weights=True 的语义取反。
+    # GPTModelProvider 的默认是 True，不覆盖会悄悄绑上 embedding 与 lm_head。
+    tie_word_embeddings: bool = False
+    # 源侧 :137-139 把重算三行注释掉了。
+    recompute_granularity: str = None
+
+    # ``dtype`` → ``params_dtype`` 其实已由 ``_process_attribute``
+    # （``transformer_config.py:1981-1982``）处理，这里显式写一条只是
+    # 与仓里其它 fleet provider 保持同一形状，便于对照。
+    transform_rules = {
+        **GPTModelProvider.transform_rules,
+        "dtype": "params_dtype",
+    }
+
+    def provide(self, pre_process=None, post_process=None, vp_stage=None, loss_fn=None) -> GPTModel:
+        """覆写父类的 ``provide()``，把组网换成 :func:`build_hyperbody_decoder_model`。
+
+        父类那份会调 ``gpt_builder``（内部自选 layer spec），本模型要用 fleet
+        ``hyperbody_decoder`` 提供的那份 spec，所以只能自己组。
+
+        父类里另外两段在本模型上是死代码，不搬：``mtp_block_spec`` 算完从没传给
+        ``gpt_builder``；``is_pipeline_asymmetric`` 算完也没人读。
+        """
+        # 父类的 rope 展平：``GPTConfig`` 可能带 ``rope_parameters`` 这层包装。
+        if getattr(self, "rope_parameters", None):
+            if self.rope_parameters.get("rope_type", "default") != "default":
+                self.rope_type = self.rope_parameters["rope_type"]
+            if "rope_theta" in self.rope_parameters:
+                self.rope_theta = self.rope_parameters["rope_theta"]
+        if isinstance(self.rope_scaling, dict) and "mscale_all_dim" in self.rope_scaling:
+            self.mscale_all_dim = self.rope_scaling["mscale_all_dim"]
+
+        fleet_model = build_hyperbody_decoder_model(
+            self,
+            num_stages=self.pipeline_model_parallel_size,
+            loss_fn=loss_fn,
+        )
+        # 把 FleetGPTModel 转成 formers 的 GPTModel，好继承 PretrainedModel 的方法
+        # （逐属性拷贝，与父类 gpt_provider.py:232-240 同一手法）。
+        model = GPTModel.__new__(GPTModel)
+        for attr_name in dir(fleet_model):
+            if not attr_name.startswith("__"):
+                try:
+                    setattr(model, attr_name, getattr(fleet_model, attr_name))
+                except Exception:  # 只读属性 / property，跳过即可
+                    pass
+        return model
+
+
+class HyperBodyDecoderPretrainedModel(PretrainedModel):
+    config_class = HyperBodyDecoderConfig
+    base_model_prefix = "hyperbody_decoder"
+    # gate 在 fleet 侧是 fp32（PaddleFleet 的 router 强制 fp32，前提是
+    # use_accuracy_compatible=False），存档 metadata 里也确实是 float32。
+    _keep_in_fp32_modules = ["mlp.gate.weight"]
+
+    @classmethod
+    def _gen_aoa_config(cls, config: HyperBodyDecoderConfig):
+        """HF 权重名 → fleet 结构化名的正向映射表。
+
+        右侧全部对齐真实存档（见模块 docstring 末尾的 dump 命令）：
+
+        =========================================  ==================
+        fleet 结构化名                              shape（smoke 几何）
+        =========================================  ==================
+        model.embedding.embed_tokens.weight        (V, H)
+        model.layers.i.self_attn.qkv_proj.weight   (H, (nq+2nkv)·hd)
+        model.layers.i.self_attn.o_proj.weight     (H, H)
+        model.layers.i.mlp.up_gate_proj.weight     (H, 2I)   ← dense 层
+        model.layers.i.mlp.down_proj.weight        (I, H)    ← dense 层
+        model.layers.i.mlp.gate.weight             (E, H) fp32
+        model.layers.i.mlp.experts.e.*             (H, 2mI) / (mI, H)
+        model.layers.i.mlp.shared_experts.*        (H, 2·ns·mI) / (ns·mI, H)
+        model.lm_head.weight                       (V, H)
+        model.norm.weight                          (H,)
+        =========================================  ==================
+
+        ``^T`` 是因为 HF 的 nn.Linear 权重是 ``(out, in)``，Paddle 是
+        ``(in, out)``；``embed_tokens`` / ``lm_head`` / ``gate`` / norm
+        两侧同序，不带 ``^T``。
+
+        映射的模板是 ``glm4_moe/modeling.py:829``（同为 MHA + 首层 dense +
+        shared experts 的 MoE），三处刻意的差异：
+
+        * 没有 ``gate.e_score_correction_bias`` —— 那是 noaux_tc 路由的产物，
+          本模型是 ``scoring_func="softmax"`` + ``topk_method="greedy"``。
+        * 没有 ``self_attn.{q,k}_norm`` —— ``use_qk_norm=False``。
+        * dense 层集合从 ``moe_layer_freq`` 这张逐层表反推，**不能**读
+          ``first_k_dense_replace``（本模型它必须是 ``None``）。
+        """
+        # 只有 ForCausalLM 两个类，fleet 侧结构化名统一带 "model." 前缀
+        # （glm4_moe 那份靠 ``cls == cls.base_model_class`` 推，我们没有注册
+        # base model 类，直接钉死更省事，也与 dump 出来的 key 一致）。
+        pd_root = "model"
+        num_experts = config.n_routed_experts
+        moe_layer_freq = config.moe_layer_freq
+
+        statements = [
+            f"model.embed_tokens.weight -> {pd_root}.embedding.embed_tokens.weight",
+            f"model.norm.weight -> {pd_root}.norm.weight",
+        ]
+        # 源侧 :93 untie ⇒ 正常走独立 lm_head 这条；tie 的分支只为完整性保留。
+        if config.tie_word_embeddings:
+            statements.append(f"model.embed_tokens.weight -> {pd_root}.lm_head.weight")
+        else:
+            statements.append(f"lm_head.weight -> {pd_root}.lm_head.weight")
+
+        for layer_idx in range(config.num_hidden_layers):
+            hf = f"model.layers.{layer_idx}"
+            pd = f"{pd_root}.layers.{layer_idx}"
+            statements += [
+                f"{hf}.input_layernorm.weight -> {pd}.input_layernorm.weight",
+                f"{hf}.post_attention_layernorm.weight -> {pd}.post_attention_layernorm.weight",
+                f"{hf}.self_attn.o_proj.weight^T -> {pd}.self_attn.o_proj.weight",
+                f"{hf}.self_attn.q_proj.weight^T, {hf}.self_attn.k_proj.weight^T, "
+                f"{hf}.self_attn.v_proj.weight^T -> {pd}.self_attn.qkv_proj.weight, fused_qkv, "
+                f"num_heads={config.num_attention_heads}, num_key_value_groups={config.num_key_value_heads}",
+            ]
+
+            if not moe_layer_freq[layer_idx]:
+                # dense 层（本模型只有 layer 0）：intermediate_size 那条 FFN。
+                statements += [
+                    f"{hf}.mlp.gate_proj.weight^T, {hf}.mlp.up_proj.weight^T "
+                    f"-> {pd}.mlp.up_gate_proj.weight, fused_ffn",
+                    f"{hf}.mlp.down_proj.weight^T -> {pd}.mlp.down_proj.weight",
+                ]
+                continue
+
+            statements += [
+                # gate 两侧 dtype 不同（HF bf16 / fleet fp32）。必须写成
+                # src_dtype+dst_dtype 这对：单个 dtype=... 在反推方向上会被
+                # aoa_engine.py:736 直接断言拦死。照 kimi_k2/modeling.py:82。
+                f"{hf}.mlp.gate.weight -> {pd}.mlp.gate.weight, src_dtype='bfloat16',dst_dtype='float32'",
+                f"{hf}.mlp.shared_experts.gate_proj.weight^T, {hf}.mlp.shared_experts.up_proj.weight^T "
+                f"-> {pd}.mlp.shared_experts.up_gate_proj.weight, fused_ffn",
+                f"{hf}.mlp.shared_experts.down_proj.weight^T -> {pd}.mlp.shared_experts.down_proj.weight",
+                # 逐专家：$EXPERT_ID 由 aoa 解析器展开成 0..num_experts-1。
+                # 这里是 axis=1 而不是 fused_ffn —— routed expert 的 up/gate
+                # 不参与 TP 切分，直接沿最后一维拼（照 glm4_moe:954 的 fleet 分支）。
+                f"{hf}.mlp.experts.$EXPERT_ID.gate_proj.weight^T, {hf}.mlp.experts.$EXPERT_ID.up_proj.weight^T "
+                f"-> {pd}.mlp.experts.$EXPERT_ID.up_gate_proj.weight, axis=1",
+                f"{hf}.mlp.experts.$EXPERT_ID.down_proj.weight^T -> {pd}.mlp.experts.$EXPERT_ID.down_proj.weight",
+            ]
+
+            if config.moe_expert_fusion:
+                # grouped GEMM：把逐专家的 2-D 权重再沿 axis=0 摞成 3-D
+                # [E, ...]。左边是**已经映射好的 fleet 名**，即二段式。
+                w1 = ",".join(f"{pd}.mlp.experts.{e}.up_gate_proj.weight" for e in range(num_experts))
+                w2 = ",".join(f"{pd}.mlp.experts.{e}.down_proj.weight" for e in range(num_experts))
+                statements += [
+                    f"{w1} -> {pd}.mlp.grouped_gemm_experts.weight1, axis=0",
+                    f"{w2} -> {pd}.mlp.grouped_gemm_experts.weight2, axis=0",
+                ]
+
+        return {"aoa_statements": statements}
+
+
+def _build_hyperbody_decoder(cls, config):
+    """两个 ``__new__`` 的公共体：规整 HF config → 建 provider → 组网。"""
+    # 并行度兜底：yaml 没给时 LlmMetaConfig 可能塞进 0 或 -1，
+    # 组网时拿到非正数会算出空的 pp 切分。
+    for name in (
+        "tensor_model_parallel_size",
+        "context_parallel_size",
+        "pipeline_model_parallel_size",
+        "virtual_pipeline_model_parallel_size",
+        "expert_model_parallel_size",
+    ):
+        setattr(config, name, max(getattr(config, name, 1) or 1, 1))
+
+    # HyperBody decoder 的关键开关：即使 config.json / yaml 写错也强制纠回。
+    # 这三条错了不会报错，只会静默换掉注意力实现或加上 QK norm。
+    config.multi_latent_attention = False
+    config.use_qk_norm = False
+    config.gated_linear_unit = True
+
+    # config 上若带着非 dict 的 rope_scaling（比如 config.json 抄来的 1.0），
+    # register_attributes 会把它盖回 provider 的 None 之上，重新引爆
+    # gpt_provider.py:211。HyperBody 没有 RoPE scaling，一律归 None。
+    if not isinstance(getattr(config, "rope_scaling", None), dict):
+        config.rope_scaling = None
+
+    check_hyperbody_decoder_divisibility(config)
+
+    # ★ HF-style config → GPTConfig 的那一步。
+    provider = HyperBodyDecoderModelProvider.from_config(config)
+
+    loss_fn = None
+    if getattr(config, "dpo_config", None):
+        loss_fn = CriterionLayerPipe(config, use_infohub=True)
+
+    gpt_model = provider.provide(loss_fn=loss_fn)
+    if not hasattr(config, "architectures"):
+        config.architectures = [cls.__name__.replace("Pipe", "")]
+    # provide() 返回的是 fleet 的 GPTModel，不是本类实例，所以 aoa 与 fp32
+    # 白名单都得手动挂上去（save_pretrained 读的是这个对象的属性）。
+    # 只挂正向表：model_utils.py:3286-3289 会自己反推保存方向。
+    gpt_model._gen_aoa_config = cls._gen_aoa_config
+    gpt_model._keep_in_fp32_modules = cls._keep_in_fp32_modules
+    # Trainer 存档时读的是 config_to_save，不是 provider 那份被展平过的 config。
+    gpt_model.config_to_save = config
+    gpt_model.is_fleet = cls.is_fleet
+    return gpt_model
+
+
+class HyperBodyDecoderForCausalLM(HyperBodyDecoderPretrainedModel):
+    is_fleet = True
+
+    def __new__(cls, config):
+        return _build_hyperbody_decoder(cls, config)
+
+
+class HyperBodyDecoderForCausalLMPipe(HyperBodyDecoderPretrainedModel, GeneralModelForCausalLMPipe):
+    is_fleet = True
+
+    def __new__(cls, config):
+        return _build_hyperbody_decoder(cls, config)

--- a/paddleformers/transformers/hyperbody_decoder/modeling.py
+++ b/paddleformers/transformers/hyperbody_decoder/modeling.py
@@ -12,52 +12,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""HyperBody decoder 的「HF-style config → ``GPTConfig``」转换 + 组网装配。
+"""HyperBody decoder: "HF-style config -> ``GPTConfig``" conversion + model assembly.
 
-## 职责划分
+## Split of responsibilities
 
-照参考实现 ``fleet_formers`` 的 hyperencoder 摆：
-
-| 侧 | 内容 |
+| Side | Contents |
 |---|---|
-| ``paddlefleet.models.hyperbody_decoder`` | **组件**：``get_hyperbody_decoder_layer_specs`` |
-| ``configuration.py``（本包） | 几何常量 + ``HyperBodyDecoderConfig``（HF-style config 真源） |
-| **本文件** | ① HF-style config → ``GPTConfig``（:class:`HyperBodyDecoderModelProvider`）② 组网装配（:func:`build_hyperbody_decoder_model`） |
+| ``paddlefleet.models.hyperbody_decoder`` | **Components**: ``get_hyperbody_decoder_layer_specs`` |
+| ``configuration.py`` (this package) | Geometry constants + ``HyperBodyDecoderConfig`` (HF-style config source of truth) |
+| **This file** | (1) HF-style config -> ``GPTConfig`` (:class:`HyperBodyDecoderModelProvider`) (2) model assembly (:func:`build_hyperbody_decoder_model`) |
 
-参考实现里 ``HyperEncoderBlock(TransformerBlock)`` / ``HyperEncoderModel``
-也都在 formers 侧，fleet 侧只留 ``layer_specs.py`` + ``modality_encoders.py``。
+## Why assembly is written out here instead of using ``gpt_builder`` directly
 
-## 为什么组网要自己写一遍，而不是直接用 ``gpt_builder``
+``paddlefleet.gpt_builders.gpt_builder`` calls ``get_gpt_decoder_layers_spec`` itself
+when ``n_routed_experts`` is set, with **no hook to inject a layer spec**. To keep the
+"fleet provides components, formers does assembly" split, this file calls
+``get_gpt_spec`` + ``build_spec_layer`` directly and feeds in the fleet spec.
 
-``paddlefleet.gpt_builders.gpt_builder`` 在 ``n_routed_experts`` 非空时会自己去调
-``get_gpt_decoder_layers_spec``，**没有任何注入 layer spec 的口子**。要让「fleet 出
-组件、formers 做装配」这条分工成立，就得由本文件直接调
-``get_gpt_spec`` + ``build_spec_layer``，把 fleet 那份 spec 喂进去。
+:func:`build_hyperbody_decoder_model` is a narrowed version of ``gpt_builder``: it
+keeps only the path this model actually uses (embedding + N-layer backbone + norm +
+lm_head + LanguageLoss); every other branch (MTP, head/tail EmptyLayer,
+``separate_mtp_headloss``, ringmoe subgroups, meta-device init) is **explicitly
+rejected** rather than silently skipped, so turning on one of those switches later
+fails loudly instead of silently.
 
-:func:`build_hyperbody_decoder_model` 是 ``gpt_builder`` 的窄化版本：只保留
-HyperBody decoder 真正用到的路径（embedding + N 层 backbone + norm + lm_head +
-LanguageLoss），其余分支（MTP、head/tail EmptyLayer、``separate_mtp_headloss``、
-ringmoe 子组、meta-device 初始化）一律**显式拒绝**而不是静默跳过 —— 源侧
-``_build_model_specs`` 一个都没用，静默跳过只会在将来打开某个开关时错得无声。
+## ``__new__`` instead of ``__init__``
 
-## ``__new__`` 而不是 ``__init__``
+``AutoModelForCausalLM.from_config`` runs ``with dtype_guard(dtype): model =
+cls(config)`` (``model_utils.py:1349-1368``), but what we need to return is a fleet
+``GPTModel`` (a ``PipelineLayer``), not an instance of this class. So ``__new__``
+returns that fleet ``GPTModel`` directly instead of leaving ``__init__`` to populate
+an instance of this class.
 
-``AutoModelForCausalLM.from_config`` 走 ``model_utils.py:1349-1368`` 的
-``with dtype_guard(dtype): model = cls(config)``，而我们要返回的是 fleet 的
-``GPTModel``（一个 ``PipelineLayer``），不是本类的实例。仓里所有 fleet 模型都用
-``__new__`` 返回别的对象（``kimi_k2``、``deepseek_v4``、``glm4_moe``），照办。
+## Why ``_gen_aoa_config`` cannot be skipped
 
-## ``_gen_aoa_config`` 为什么绕不过去
+aoa on the surface only serves **HF-format interconversion**, and normal
+flex_checkpoint archives never touch it. But the **CLI does one HF export after
+training**: ``cli/train/sft/workflow.py:793`` hard-codes ``last_fc_to_hf=True`` with
+no yaml switch, so missing aoa raises ``RuntimeError: ... must implement either the
+_gen_inv_aoa_config ...`` only after the whole training run finishes.
 
-aoa 表面上只服务 **HF 格式互转**，常规 flex_checkpoint 存档根本不碰它。但
-**CLI 训完必经一次 HF 导出**：``cli/train/sft/workflow.py:793`` 把
-``last_fc_to_hf=True`` 写死了，没有 yaml 开关，缺 aoa 就在训练全部跑完之后抛
-``RuntimeError: ... must implement either the _gen_inv_aoa_config ...``。
-
-只写正向（HF → fleet）一张：``model_utils.py:3286-3289`` 会自己加
-``aoa_config_reverse=True`` 反推导出保存方向。右侧的 fleet 结构化名不是猜的，
-是从真存档 metadata 里读出来的：
-``python scripts/dump_ckpt_keys.py <ckpt>/model_state/0.metadata``。
+We write only the forward direction (HF -> fleet): ``model_utils.py:3286-3289`` adds
+``aoa_config_reverse=True`` on its own to derive the save direction.
 """
 
 from __future__ import annotations
@@ -86,31 +82,32 @@ __all__ = [
 
 
 def build_hyperbody_decoder_model(config, *, num_stages: int, loss_fn=None):
-    """组网：fleet 的 layer spec → ``get_gpt_spec`` → ``build_spec_layer``。
+    """Assembly: fleet layer spec -> ``get_gpt_spec`` -> ``build_spec_layer``.
 
-    这是 ``paddlefleet.gpt_builders.gpt_builder`` 的窄化版本。参数 ``config``
-    是已经转好的 ``GPTConfig``（即 :class:`HyperBodyDecoderModelProvider` 自己）。
+    This is a narrowed version of ``paddlefleet.gpt_builders.gpt_builder``. The
+    ``config`` argument is an already-converted ``GPTConfig`` (i.e.
+    :class:`HyperBodyDecoderModelProvider` itself).
 
     Args:
-        num_stages: pipeline 段数，等于 ``pipeline_model_parallel_size``。
-        loss_fn: 为空时用 ``LanguageLoss(config)``（与 ``gpt_builder`` 一致）。
+        num_stages: number of pipeline stages, equal to ``pipeline_model_parallel_size``.
+        loss_fn: defaults to ``LanguageLoss(config)`` (matching ``gpt_builder``).
     """
-    # 源侧 _build_model_specs 用不到这些分支；静默跳过会在将来某天错得无声。
+    # These branches are unused by this model; silently skipping would fail silently later.
     if getattr(config, "mtp_num_layers", None):
-        raise NotImplementedError("HyperBody decoder 没有 MTP 层（源侧未启用）。")
+        raise NotImplementedError("HyperBody decoder has no MTP layers.")
     if getattr(config, "separate_mtp_headloss", False):
-        raise NotImplementedError("HyperBody decoder 不用 separate_mtp_headloss。")
+        raise NotImplementedError("HyperBody decoder does not use separate_mtp_headloss.")
     if config.num_empty_layers_add_in_head or config.num_empty_layers_add_in_tail:
-        raise NotImplementedError("HyperBody decoder 不插 EmptyLayer（pp 切分靠 seg_method）。")
+        raise NotImplementedError("HyperBody decoder inserts no EmptyLayer (pp split relies on seg_method).")
     if getattr(config, "moe_token_dispatcher_type", None) == "ringmoe":
-        raise NotImplementedError("ringmoe 需要 world 级子组初始化，本模型未支持。")
+        raise NotImplementedError("ringmoe needs world-level subgroup init, not supported by this model.")
     if getattr(config, "init_model_with_meta_device", False):
-        raise NotImplementedError("HyperBody decoder 不走 meta-device 初始化。")
+        raise NotImplementedError("HyperBody decoder does not use meta-device init.")
 
     gpt_spec = get_gpt_spec(
         config=config,
         head_empty_layers_spec=[],
-        # ★ 唯一与 gpt_builder 不同的一行：spec 来自 fleet 的 hyperbody_decoder 组件。
+        # The only line that differs from gpt_builder: spec comes from the fleet hyperbody_decoder component.
         transformer_layers_spec=get_hyperbody_decoder_layer_specs(config),
         tail_empty_layers_spec=[],
         mtp_layers_spec=None,
@@ -128,81 +125,85 @@ def build_hyperbody_decoder_model(config, *, num_stages: int, loss_fn=None):
         gpt_spec,
         loss_fn=LanguageLoss(config) if loss_fn is None else loss_fn,
         num_stages=num_stages,
-        # 与 GPTModelProvider.provide() 同一个切分口径。
+        # Same split criterion as GPTModelProvider.provide().
         seg_method="layer:TransformerLayer|EmptyLayer",
     )
 
 
 @dataclass
 class HyperBodyDecoderModelProvider(GPTModelProvider):
-    """HF-style config → ``GPTConfig`` 的落点（``GPTModelProvider`` 本身就是 ``GPTConfig``）。
+    """Landing point for HF-style config -> ``GPTConfig`` (``GPTModelProvider`` is itself a ``GPTConfig``).
 
-    这里只列**必须钉死**的开关。几何（层数 / hidden / experts / topk …）与其余数值
-    一律由 :class:`HyperBodyDecoderConfig` 通过 ``TransformerConfig.register_attributes``
-    灌进来，不在本类重复声明 —— 重复声明会制造第二个真源，而真源在
-    ``configuration.py``。
+    Only the switches that **must be pinned** are listed here. Geometry (num layers /
+    hidden / experts / topk ...) and other numerics are all injected by
+    :class:`HyperBodyDecoderConfig` via ``TransformerConfig.register_attributes`` and
+    are not redeclared here -- redeclaring would create a second source of truth,
+    whose real home is ``configuration.py``.
 
-    ⚠️ ``from_config`` 走的是 ``object.__new__`` + ``register_attributes``
-    （``transformer_config.py:1942-1948``），**不执行 dataclass 的 ``__init__``**。
-    下面这些默认值之所以仍然生效，是因为无 ``default_factory`` 的 dataclass
-    字段就是类属性，实例属性缺失时属性查找会落到类上。所以别把它们改成
-    ``field(default_factory=...)``。
+    WARNING: ``from_config`` goes through ``object.__new__`` + ``register_attributes``
+    (``transformer_config.py:1942-1948``) and **does not run the dataclass
+    ``__init__``**. The defaults below still take effect because a dataclass field
+    with no ``default_factory`` is a class attribute, and attribute lookup falls back
+    to the class when the instance attribute is missing. So do not change them to
+    ``field(default_factory=...)``.
     """
 
-    # ---- 注意力：MLA 全关，纯 MHA（源侧没设 ⇒ mcore 默认，Paddle 必须显式关）----
+    # ---- attention: MLA fully off, pure MHA (Paddle must turn it off explicitly) ----
     multi_latent_attention: bool = False
     use_qk_norm: bool = False
 
-    # ---- 位置编码：普通 RoPE，无任何 scaling（源侧 :80-86 只给了 rotary_base=10000）----
-    # ⚠️ 必须显式写回 None：``GPTConfig`` 把继承来的 ``rope_scaling: dict = None``
-    # 覆盖成了 ``float = 1.0``（``gpt_config.py:32`` vs ``transformer_config.py:485``），
-    # 而 ``gpt_provider.py:210`` 只判 ``is not None``，于是 ``1.0`` 会掉进
-    # ``:211`` 的 ``"mscale_all_dim" in self.rope_scaling`` 炸成
-    # ``TypeError: argument of type 'float' is not iterable``。
-    # 别的 fleet 模型躲过这一枪，是因为它们的 config.json 本来就带 rope_scaling dict。
+    # ---- position embedding: plain RoPE, no scaling ----
+    # WARNING: must explicitly write None back: ``GPTConfig`` overrides the inherited
+    # ``rope_scaling: dict = None`` to ``float = 1.0`` (``gpt_config.py:32`` vs
+    # ``transformer_config.py:485``), and ``gpt_provider.py:210`` only checks
+    # ``is not None``, so ``1.0`` falls into the ``"mscale_all_dim" in
+    # self.rope_scaling`` check at ``:211`` and blows up with
+    # ``TypeError: argument of type 'float' is not iterable``.
     rope_scaling: dict = None
 
-    # ---- FFN / norm（源侧 :73、:76）----
+    # ---- FFN / norm ----
     gated_linear_unit: bool = True
     normalization: str = "RMSNorm"
 
-    # ---- MoE（源侧 :103、:113、:114）----
+    # ---- MoE ----
     moe_token_dispatcher_type: str = "alltoall"
     moe_router_load_balancing_type: str = "seq_aux_loss"
     moe_shared_expert_overlap: bool = True
 
-    # ---- 融合开关（源侧 :128-133）----
+    # ---- fusion switches ----
     bias_activation_fusion: bool = True
-    masked_softmax_fusion: bool = True  # ⚠️ 与 encoder 的 False 不同
+    masked_softmax_fusion: bool = True
     bias_dropout_fusion: bool = True
     apply_rope_fusion: bool = False
     cross_entropy_loss_fusion: bool = False
 
-    # ---- 其它 ----
-    # 源侧 :93 untie_embeddings_and_output_weights=True 的语义取反。
-    # GPTModelProvider 的默认是 True，不覆盖会悄悄绑上 embedding 与 lm_head。
+    # ---- misc ----
+    # GPTModelProvider defaults tie_word_embeddings to True; not overriding would
+    # silently tie embedding and lm_head.
     tie_word_embeddings: bool = False
-    # 源侧 :137-139 把重算三行注释掉了。
+    # Recompute disabled.
     recompute_granularity: str = None
 
-    # ``dtype`` → ``params_dtype`` 其实已由 ``_process_attribute``
-    # （``transformer_config.py:1981-1982``）处理，这里显式写一条只是
-    # 与仓里其它 fleet provider 保持同一形状，便于对照。
+    # ``dtype`` -> ``params_dtype`` is already handled by ``_process_attribute``
+    # (``transformer_config.py:1981-1982``); writing it here explicitly only keeps
+    # the same shape as other fleet providers in this repo, for easy comparison.
     transform_rules = {
         **GPTModelProvider.transform_rules,
         "dtype": "params_dtype",
     }
 
     def provide(self, pre_process=None, post_process=None, vp_stage=None, loss_fn=None) -> GPTModel:
-        """覆写父类的 ``provide()``，把组网换成 :func:`build_hyperbody_decoder_model`。
+        """Override the parent's ``provide()``, swapping assembly for :func:`build_hyperbody_decoder_model`.
 
-        父类那份会调 ``gpt_builder``（内部自选 layer spec），本模型要用 fleet
-        ``hyperbody_decoder`` 提供的那份 spec，所以只能自己组。
+        The parent's version calls ``gpt_builder`` (which picks its own layer spec);
+        this model needs the spec provided by fleet ``hyperbody_decoder``, so it
+        assembles by itself.
 
-        父类里另外两段在本模型上是死代码，不搬：``mtp_block_spec`` 算完从没传给
-        ``gpt_builder``；``is_pipeline_asymmetric`` 算完也没人读。
+        Two other parent segments are dead code for this model and are not carried
+        over: ``mtp_block_spec`` is computed but never passed to ``gpt_builder``, and
+        ``is_pipeline_asymmetric`` is computed but never read.
         """
-        # 父类的 rope 展平：``GPTConfig`` 可能带 ``rope_parameters`` 这层包装。
+        # Parent's rope flattening: ``GPTConfig`` may carry a ``rope_parameters`` wrapper.
         if getattr(self, "rope_parameters", None):
             if self.rope_parameters.get("rope_type", "default") != "default":
                 self.rope_type = self.rope_parameters["rope_type"]
@@ -216,14 +217,15 @@ class HyperBodyDecoderModelProvider(GPTModelProvider):
             num_stages=self.pipeline_model_parallel_size,
             loss_fn=loss_fn,
         )
-        # 把 FleetGPTModel 转成 formers 的 GPTModel，好继承 PretrainedModel 的方法
-        # （逐属性拷贝，与父类 gpt_provider.py:232-240 同一手法）。
+        # Convert FleetGPTModel into formers' GPTModel so it inherits PretrainedModel's
+        # methods (attribute-by-attribute copy, same technique as parent
+        # gpt_provider.py:232-240).
         model = GPTModel.__new__(GPTModel)
         for attr_name in dir(fleet_model):
             if not attr_name.startswith("__"):
                 try:
                     setattr(model, attr_name, getattr(fleet_model, attr_name))
-                except Exception:  # 只读属性 / property，跳过即可
+                except Exception:  # read-only attribute / property, just skip
                     pass
         return model
 
@@ -231,47 +233,45 @@ class HyperBodyDecoderModelProvider(GPTModelProvider):
 class HyperBodyDecoderPretrainedModel(PretrainedModel):
     config_class = HyperBodyDecoderConfig
     base_model_prefix = "hyperbody_decoder"
-    # gate 在 fleet 侧是 fp32（PaddleFleet 的 router 强制 fp32，前提是
-    # use_accuracy_compatible=False），存档 metadata 里也确实是 float32。
+    # The gate is fp32 on the fleet side (PaddleFleet's router forces fp32 as long as
+    # use_accuracy_compatible=False), and the archive metadata is indeed float32.
     _keep_in_fp32_modules = ["mlp.gate.weight"]
 
     @classmethod
     def _gen_aoa_config(cls, config: HyperBodyDecoderConfig):
-        """HF 权重名 → fleet 结构化名的正向映射表。
+        """Forward mapping table from HF weight names to fleet structured names.
 
-        右侧全部对齐真实存档（见模块 docstring 末尾的 dump 命令）：
+        The right-hand side matches the real archive:
 
         =========================================  ==================
-        fleet 结构化名                              shape（smoke 几何）
+        fleet structured name                       shape (smoke geometry)
         =========================================  ==================
         model.embedding.embed_tokens.weight        (V, H)
-        model.layers.i.self_attn.qkv_proj.weight   (H, (nq+2nkv)·hd)
+        model.layers.i.self_attn.qkv_proj.weight   (H, (nq+2nkv)*hd)
         model.layers.i.self_attn.o_proj.weight     (H, H)
-        model.layers.i.mlp.up_gate_proj.weight     (H, 2I)   ← dense 层
-        model.layers.i.mlp.down_proj.weight        (I, H)    ← dense 层
+        model.layers.i.mlp.up_gate_proj.weight     (H, 2I)   <- dense layer
+        model.layers.i.mlp.down_proj.weight        (I, H)    <- dense layer
         model.layers.i.mlp.gate.weight             (E, H) fp32
         model.layers.i.mlp.experts.e.*             (H, 2mI) / (mI, H)
-        model.layers.i.mlp.shared_experts.*        (H, 2·ns·mI) / (ns·mI, H)
+        model.layers.i.mlp.shared_experts.*        (H, 2*ns*mI) / (ns*mI, H)
         model.lm_head.weight                       (V, H)
         model.norm.weight                          (H,)
         =========================================  ==================
 
-        ``^T`` 是因为 HF 的 nn.Linear 权重是 ``(out, in)``，Paddle 是
-        ``(in, out)``；``embed_tokens`` / ``lm_head`` / ``gate`` / norm
-        两侧同序，不带 ``^T``。
+        ``^T`` is because HF's nn.Linear weight is ``(out, in)`` while Paddle is
+        ``(in, out)``; ``embed_tokens`` / ``lm_head`` / ``gate`` / norm have the same
+        order on both sides and carry no ``^T``.
 
-        映射的模板是 ``glm4_moe/modeling.py:829``（同为 MHA + 首层 dense +
-        shared experts 的 MoE），三处刻意的差异：
+        Three deliberate specifics of this model:
 
-        * 没有 ``gate.e_score_correction_bias`` —— 那是 noaux_tc 路由的产物，
-          本模型是 ``scoring_func="softmax"`` + ``topk_method="greedy"``。
-        * 没有 ``self_attn.{q,k}_norm`` —— ``use_qk_norm=False``。
-        * dense 层集合从 ``moe_layer_freq`` 这张逐层表反推，**不能**读
-          ``first_k_dense_replace``（本模型它必须是 ``None``）。
+        * No ``gate.e_score_correction_bias`` -- that is a product of noaux_tc
+          routing; this model uses ``scoring_func="softmax"`` + ``topk_method="greedy"``.
+        * No ``self_attn.{q,k}_norm`` -- ``use_qk_norm=False``.
+        * The dense-layer set is derived from the per-layer ``moe_layer_freq`` table,
+          **not** from ``first_k_dense_replace`` (which must be ``None`` here).
         """
-        # 只有 ForCausalLM 两个类，fleet 侧结构化名统一带 "model." 前缀
-        # （glm4_moe 那份靠 ``cls == cls.base_model_class`` 推，我们没有注册
-        # base model 类，直接钉死更省事，也与 dump 出来的 key 一致）。
+        # There are only the two ForCausalLM classes; fleet structured names uniformly
+        # carry the "model." prefix.
         pd_root = "model"
         num_experts = config.n_routed_experts
         moe_layer_freq = config.moe_layer_freq
@@ -280,7 +280,7 @@ class HyperBodyDecoderPretrainedModel(PretrainedModel):
             f"model.embed_tokens.weight -> {pd_root}.embedding.embed_tokens.weight",
             f"model.norm.weight -> {pd_root}.norm.weight",
         ]
-        # 源侧 :93 untie ⇒ 正常走独立 lm_head 这条；tie 的分支只为完整性保留。
+        # untie => the normal independent lm_head path; the tie branch is kept only for completeness.
         if config.tie_word_embeddings:
             statements.append(f"model.embed_tokens.weight -> {pd_root}.lm_head.weight")
         else:
@@ -299,7 +299,7 @@ class HyperBodyDecoderPretrainedModel(PretrainedModel):
             ]
 
             if not moe_layer_freq[layer_idx]:
-                # dense 层（本模型只有 layer 0）：intermediate_size 那条 FFN。
+                # Dense layer (only layer 0 in this model): the intermediate_size FFN.
                 statements += [
                     f"{hf}.mlp.gate_proj.weight^T, {hf}.mlp.up_proj.weight^T "
                     f"-> {pd}.mlp.up_gate_proj.weight, fused_ffn",
@@ -308,24 +308,27 @@ class HyperBodyDecoderPretrainedModel(PretrainedModel):
                 continue
 
             statements += [
-                # gate 两侧 dtype 不同（HF bf16 / fleet fp32）。必须写成
-                # src_dtype+dst_dtype 这对：单个 dtype=... 在反推方向上会被
-                # aoa_engine.py:736 直接断言拦死。照 kimi_k2/modeling.py:82。
+                # The gate has different dtypes on the two sides (bf16 vs fp32). It
+                # must be written as the src_dtype+dst_dtype pair: a single dtype=...
+                # is rejected outright by an assertion in aoa_engine.py:736 on the
+                # reverse direction.
                 f"{hf}.mlp.gate.weight -> {pd}.mlp.gate.weight, src_dtype='bfloat16',dst_dtype='float32'",
                 f"{hf}.mlp.shared_experts.gate_proj.weight^T, {hf}.mlp.shared_experts.up_proj.weight^T "
                 f"-> {pd}.mlp.shared_experts.up_gate_proj.weight, fused_ffn",
                 f"{hf}.mlp.shared_experts.down_proj.weight^T -> {pd}.mlp.shared_experts.down_proj.weight",
-                # 逐专家：$EXPERT_ID 由 aoa 解析器展开成 0..num_experts-1。
-                # 这里是 axis=1 而不是 fused_ffn —— routed expert 的 up/gate
-                # 不参与 TP 切分，直接沿最后一维拼（照 glm4_moe:954 的 fleet 分支）。
+                # Per expert: $EXPERT_ID is expanded by the aoa parser into
+                # 0..num_experts-1. This uses axis=1 rather than fused_ffn -- a routed
+                # expert's up/gate do not participate in TP sharding, so they are
+                # concatenated directly along the last axis.
                 f"{hf}.mlp.experts.$EXPERT_ID.gate_proj.weight^T, {hf}.mlp.experts.$EXPERT_ID.up_proj.weight^T "
                 f"-> {pd}.mlp.experts.$EXPERT_ID.up_gate_proj.weight, axis=1",
                 f"{hf}.mlp.experts.$EXPERT_ID.down_proj.weight^T -> {pd}.mlp.experts.$EXPERT_ID.down_proj.weight",
             ]
 
             if config.moe_expert_fusion:
-                # grouped GEMM：把逐专家的 2-D 权重再沿 axis=0 摞成 3-D
-                # [E, ...]。左边是**已经映射好的 fleet 名**，即二段式。
+                # grouped GEMM: stack the per-expert 2-D weights along axis=0 into a
+                # 3-D [E, ...] tensor. The left-hand side is the already-mapped fleet
+                # name, i.e. a two-stage mapping.
                 w1 = ",".join(f"{pd}.mlp.experts.{e}.up_gate_proj.weight" for e in range(num_experts))
                 w2 = ",".join(f"{pd}.mlp.experts.{e}.down_proj.weight" for e in range(num_experts))
                 statements += [
@@ -337,9 +340,9 @@ class HyperBodyDecoderPretrainedModel(PretrainedModel):
 
 
 def _build_hyperbody_decoder(cls, config):
-    """两个 ``__new__`` 的公共体：规整 HF config → 建 provider → 组网。"""
-    # 并行度兜底：yaml 没给时 LlmMetaConfig 可能塞进 0 或 -1，
-    # 组网时拿到非正数会算出空的 pp 切分。
+    """Shared body of the two ``__new__``: normalize HF config -> build provider -> assemble."""
+    # Parallelism fallback: when yaml omits them, LlmMetaConfig may inject 0 or -1,
+    # and a non-positive value would compute an empty pp split during assembly.
     for name in (
         "tensor_model_parallel_size",
         "context_parallel_size",
@@ -349,21 +352,22 @@ def _build_hyperbody_decoder(cls, config):
     ):
         setattr(config, name, max(getattr(config, name, 1) or 1, 1))
 
-    # HyperBody decoder 的关键开关：即使 config.json / yaml 写错也强制纠回。
-    # 这三条错了不会报错，只会静默换掉注意力实现或加上 QK norm。
+    # Key switches for the HyperBody decoder: force them back even if config.json /
+    # yaml sets them wrong. Getting these three wrong raises no error -- it only
+    # silently swaps the attention implementation or adds a QK norm.
     config.multi_latent_attention = False
     config.use_qk_norm = False
     config.gated_linear_unit = True
 
-    # config 上若带着非 dict 的 rope_scaling（比如 config.json 抄来的 1.0），
-    # register_attributes 会把它盖回 provider 的 None 之上，重新引爆
-    # gpt_provider.py:211。HyperBody 没有 RoPE scaling，一律归 None。
+    # If config carries a non-dict rope_scaling (e.g. a stray 1.0 from config.json),
+    # register_attributes would override the provider's None with it and re-trigger
+    # gpt_provider.py:211. HyperBody has no RoPE scaling, so normalize it to None.
     if not isinstance(getattr(config, "rope_scaling", None), dict):
         config.rope_scaling = None
 
     check_hyperbody_decoder_divisibility(config)
 
-    # ★ HF-style config → GPTConfig 的那一步。
+    # The HF-style config -> GPTConfig step.
     provider = HyperBodyDecoderModelProvider.from_config(config)
 
     loss_fn = None
@@ -373,12 +377,13 @@ def _build_hyperbody_decoder(cls, config):
     gpt_model = provider.provide(loss_fn=loss_fn)
     if not hasattr(config, "architectures"):
         config.architectures = [cls.__name__.replace("Pipe", "")]
-    # provide() 返回的是 fleet 的 GPTModel，不是本类实例，所以 aoa 与 fp32
-    # 白名单都得手动挂上去（save_pretrained 读的是这个对象的属性）。
-    # 只挂正向表：model_utils.py:3286-3289 会自己反推保存方向。
+    # provide() returns a fleet GPTModel, not an instance of this class, so aoa and
+    # the fp32 whitelist must be attached manually (save_pretrained reads them off
+    # this object). Only the forward table is attached: model_utils.py:3286-3289
+    # derives the save direction on its own.
     gpt_model._gen_aoa_config = cls._gen_aoa_config
     gpt_model._keep_in_fp32_modules = cls._keep_in_fp32_modules
-    # Trainer 存档时读的是 config_to_save，不是 provider 那份被展平过的 config。
+    # The Trainer reads config_to_save when archiving, not the provider's flattened config.
     gpt_model.config_to_save = config
     gpt_model.is_fleet = cls.is_fleet
     return gpt_model

--- a/tests/transformers/hyperbody_decoder/__init__.py
+++ b/tests/transformers/hyperbody_decoder/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/transformers/hyperbody_decoder/test_modeling.py
+++ b/tests/transformers/hyperbody_decoder/test_modeling.py
@@ -103,9 +103,7 @@ class HyperBodyDecoderConfigTest(unittest.TestCase):
 
 class HyperBodyDecoderProviderTest(unittest.TestCase):
     def test_provider_pins(self):
-        provider = HyperBodyDecoderModelProvider.from_config(
-            tiny_hyperbody_decoder_config()
-        )
+        provider = HyperBodyDecoderModelProvider.from_config(tiny_hyperbody_decoder_config())
         self.assertFalse(provider.multi_latent_attention)
         self.assertFalse(provider.use_qk_norm)
         self.assertEqual(provider.normalization, "RMSNorm")
@@ -118,9 +116,7 @@ class HyperBodyDecoderProviderTest(unittest.TestCase):
             get_hyperbody_decoder_layer_specs,
         )
 
-        provider = HyperBodyDecoderModelProvider.from_config(
-            tiny_hyperbody_decoder_config()
-        )
+        provider = HyperBodyDecoderModelProvider.from_config(tiny_hyperbody_decoder_config())
         specs = get_hyperbody_decoder_layer_specs(provider)
         mlp_classes = [s.sublayers_spec.mlp.layer.__name__ for s in specs]
         self.assertEqual(mlp_classes[0], "MLP")
@@ -129,9 +125,7 @@ class HyperBodyDecoderProviderTest(unittest.TestCase):
 
 class HyperBodyDecoderAoAConfigTest(unittest.TestCase):
     def test_gen_aoa_config_produces_statements(self):
-        aoa = HyperBodyDecoderForCausalLM._gen_aoa_config(
-            tiny_hyperbody_decoder_config()
-        )
+        aoa = HyperBodyDecoderForCausalLM._gen_aoa_config(tiny_hyperbody_decoder_config())
         self.assertIn("aoa_statements", aoa)
         self.assertGreater(len(aoa["aoa_statements"]), 0)
 

--- a/tests/transformers/hyperbody_decoder/test_modeling.py
+++ b/tests/transformers/hyperbody_decoder/test_modeling.py
@@ -27,6 +27,7 @@ import tempfile
 import unittest
 
 from paddleformers.transformers import AutoConfig
+from paddleformers.transformers.auto.modeling import MODEL_MAPPING, AutoModelForCausalLM
 from paddleformers.transformers.hyperbody_decoder.configuration import (
     HyperBodyDecoderConfig,
 )
@@ -99,6 +100,33 @@ class HyperBodyDecoderConfigTest(unittest.TestCase):
         config = tiny_hyperbody_decoder_config(first_k_dense_replace=1)
         with self.assertRaises(ValueError):
             HyperBodyDecoderModelProvider.from_config(config)
+
+
+class HyperBodyDecoderAutoModelTest(unittest.TestCase):
+    """The model is a CausalLM; ``AutoModelForCausalLM`` is the documented entry
+    point, and the base ``AutoModel`` mapping resolves it as well. These checks
+    only resolve the class (they do not instantiate the network, which needs a
+    distributed launcher) so they run single-process."""
+
+    def test_auto_model_base_mapping(self):
+        # Base ``AutoModel`` route: ``MODEL_MAPPING`` is keyed by the config type
+        # and must resolve to the concrete model class even when ``config.json``
+        # carries no ``architectures`` field.
+        config = tiny_hyperbody_decoder_config()
+        self.assertIn(type(config), MODEL_MAPPING.keys())
+        self.assertEqual(MODEL_MAPPING[type(config)].__name__, "HyperBodyDecoderForCausalLM")
+
+    def test_auto_model_for_causal_lm_mapping(self):
+        # Task route: with ``architectures`` present (as in every saved
+        # checkpoint) ``AutoModelForCausalLM`` resolves to the wrapper class.
+        config = tiny_hyperbody_decoder_config(architectures=["HyperBodyDecoderForCausalLM"])
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.save_pretrained(tmpdir)
+            config_path = os.path.join(tmpdir, "config.json")
+            with open(config_path, "r", encoding="utf-8") as f:
+                config_dict = json.load(f)
+            model_class = AutoModelForCausalLM._get_model_class_from_config(tmpdir, config_path, config=config_dict)
+        self.assertEqual(model_class.__name__, "HyperBodyDecoderForCausalLM")
 
 
 class HyperBodyDecoderProviderTest(unittest.TestCase):

--- a/tests/transformers/hyperbody_decoder/test_modeling.py
+++ b/tests/transformers/hyperbody_decoder/test_modeling.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2026 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the HyperBody decoder PaddleFormers wrapper.
+
+The forward path builds a fleet ``GPTModel`` (a ``PipelineLayer``) which needs
+a distributed launcher and packed pipeline inputs, so end-to-end parity is
+validated separately by the bitwise-alignment scripts. These tests cover the
+wrapper contract that runs single-process: config round-trip, Auto* mapping,
+the provider's pinned fields, the dense/MoE layer split, and ``_gen_aoa_config``.
+"""
+
+import json
+import os
+import tempfile
+import unittest
+
+from paddleformers.transformers import AutoConfig
+from paddleformers.transformers.hyperbody_decoder.configuration import (
+    HyperBodyDecoderConfig,
+)
+from paddleformers.transformers.hyperbody_decoder.modeling import (
+    HyperBodyDecoderForCausalLM,
+    HyperBodyDecoderModelProvider,
+)
+
+
+def tiny_hyperbody_decoder_config(**kwargs):
+    config_kwargs = dict(
+        vocab_size=128,
+        hidden_size=64,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        head_dim=16,
+        intermediate_size=128,
+        n_routed_experts=4,
+        moe_intermediate_size=64,
+        num_experts_per_tok=2,
+        n_shared_experts=1,
+        moe_layer_freq=[0, 1, 1, 1],
+        n_group=1,
+        topk_group=1,
+        max_position_embeddings=64,
+    )
+    config_kwargs.update(kwargs)
+    return HyperBodyDecoderConfig(**config_kwargs)
+
+
+class HyperBodyDecoderConfigTest(unittest.TestCase):
+    def test_config_round_trip(self):
+        config = tiny_hyperbody_decoder_config()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.save_pretrained(tmpdir)
+            loaded = HyperBodyDecoderConfig.from_pretrained(tmpdir)
+
+        for field in [
+            "vocab_size",
+            "hidden_size",
+            "num_hidden_layers",
+            "n_routed_experts",
+            "moe_layer_freq",
+            "num_experts_per_tok",
+        ]:
+            self.assertEqual(getattr(config, field), getattr(loaded, field))
+        self.assertEqual(loaded.model_type, "hyperbody_decoder")
+
+    def test_auto_config_mapping(self):
+        config = tiny_hyperbody_decoder_config()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.save_pretrained(tmpdir)
+            config_path = os.path.join(tmpdir, "config.json")
+            with open(config_path, "r", encoding="utf-8") as f:
+                config_dict = json.load(f)
+            # Drop architectures so AutoConfig has to route via model_type.
+            config_dict.pop("architectures", None)
+            with open(config_path, "w", encoding="utf-8") as f:
+                json.dump(config_dict, f)
+
+            auto_config = AutoConfig.from_pretrained(tmpdir)
+
+        self.assertEqual(type(auto_config).__name__, "HyperBodyDecoderConfig")
+        self.assertEqual(auto_config.model_type, "hyperbody_decoder")
+
+    def test_first_k_dense_and_moe_layer_freq_mutually_exclusive(self):
+        # Both knobs describe the same dense/MoE pattern; supplying both is
+        # ambiguous and must be rejected when the provider is materialized.
+        config = tiny_hyperbody_decoder_config(first_k_dense_replace=1)
+        with self.assertRaises(ValueError):
+            HyperBodyDecoderModelProvider.from_config(config)
+
+
+class HyperBodyDecoderProviderTest(unittest.TestCase):
+    def test_provider_pins(self):
+        provider = HyperBodyDecoderModelProvider.from_config(
+            tiny_hyperbody_decoder_config()
+        )
+        self.assertFalse(provider.multi_latent_attention)
+        self.assertFalse(provider.use_qk_norm)
+        self.assertEqual(provider.normalization, "RMSNorm")
+        self.assertTrue(provider.gated_linear_unit)
+        self.assertEqual(provider.moe_token_dispatcher_type, "alltoall")
+        self.assertFalse(provider.tie_word_embeddings)
+
+    def test_provider_builds_layer_specs(self):
+        from paddlefleet.models.hyperbody_decoder.layer_specs import (
+            get_hyperbody_decoder_layer_specs,
+        )
+
+        provider = HyperBodyDecoderModelProvider.from_config(
+            tiny_hyperbody_decoder_config()
+        )
+        specs = get_hyperbody_decoder_layer_specs(provider)
+        mlp_classes = [s.sublayers_spec.mlp.layer.__name__ for s in specs]
+        self.assertEqual(mlp_classes[0], "MLP")
+        self.assertTrue(all(name == "MoELayer" for name in mlp_classes[1:]))
+
+
+class HyperBodyDecoderAoAConfigTest(unittest.TestCase):
+    def test_gen_aoa_config_produces_statements(self):
+        aoa = HyperBodyDecoderForCausalLM._gen_aoa_config(
+            tiny_hyperbody_decoder_config()
+        )
+        self.assertIn("aoa_statements", aoa)
+        self.assertGreater(len(aoa["aoa_statements"]), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### PR Category
Models

### PR Types
New features

### Description
Adds the HyperBody decoder model wrapper to PaddleFormers. New
`transformers/hyperbody_decoder/` package:

- `configuration.py` — `HyperBodyDecoderConfig` (`model_type="hyperbody_decoder"`),
  HF-style fields incl. `use_cpu_initialization` / `use_accuracy_compatible`
  exposed as config knobs (no env-var switches);
- `modeling.py` — `HyperBodyDecoderModelProvider(GPTModelProvider)` pinning the
  fixed architecture, `_gen_aoa_config` for HF <-> fleet weight name mapping
  (bidirectional via `aoa_config_reverse`, so no separate `_gen_inv_aoa_config`
  is needed), and `HyperBodyDecoderForCausalLM` / `...ForCausalLMPipe`.

Registration is synced across all three entry points so `AutoConfig` /
`AutoModel` and the top-level `paddleformers.transformers` namespace all resolve
the new model: `transformers/__init__.py`, `auto/configuration.py`,
`auto/modeling.py`.

The backbone layer specs live in PaddleFleet (companion PR); this repo only
holds the HF-style config -> GPTConfig conversion and model assembly.

### Tests
`tests/transformers/hyperbody_decoder/test_modeling.py` (6 cases, launcher-free):
config round-trip, `AutoConfig` mapping, provider pinned fields, dense/MoE
layer-spec split via the provider, `first_k_dense_replace` vs `moe_layer_freq`
mutual exclusion, and `_gen_aoa_config` output.
